### PR TITLE
Tasks may not have an address space if in an inconsistent state.

### DIFF
--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -870,7 +870,9 @@ void GdbServer::emergency_debug(Task* t) {
   // this.  Unlike in that context though, we don't know if |t|
   // overshot an internal breakpoint.  If it did, cover that
   // breakpoint up.
-  t->vm()->destroy_all_breakpoints();
+  if (t->vm()) {
+    t->vm()->destroy_all_breakpoints();
+  }
 
   // Don't launch a debugger on fatal errors; the user is most
   // likely already in a debugger, and wouldn't be able to


### PR DESCRIPTION
For example, if we do an `emergency_debug()` while the Task is being initialized.  This fix was useful in me tracking down the new issue in #16, so I'm going to go ahead it even though there are probably lots of other sites that assume a vm exists.  Found by valgrind.