### PR TITLE
Fix the getrandom test.

### DIFF
--- a/src/test/getrandom.c
+++ b/src/test/getrandom.c
@@ -2,6 +2,14 @@
 
 #include "rrutil.h"
 
+/* If this development environment isn't aware of getrandom, assume
+ * there's no way the kernel supports it and so qthe user doesn't care
+ * about running this test.  The alternative is per-platform
+ * #define's, which is quite unappealing. */
+#ifndef __NR_getrandom
+# define __NR_getrandom 500
+#endif
+
 #ifndef GRND_NONBLOCK
 # define GRND_NONBLOCK	0x0001
 # define GRND_RANDOM	0x0002
@@ -15,7 +23,7 @@ int main(int argc, char* argv[]) {
   
   /* There's no libc helper for this syscall. */
   ret = syscall(__NR_getrandom, buf, sizeof(buf), GRND_NONBLOCK);
-  if (-ENOSYS == ret) {
+  if (-1 == ret && ENOSYS == errno) {
     atomic_puts("SYS_getrandom not supported on this kernel");
   } else {
     uint i;


### PR DESCRIPTION
__NR_getrandom may not be defined on the build system, and I forgot that the libc `syscall` helper sets errno for you.  Followup to #1379.