### PR TITLE
Check that SRCDIR/TESTDIR are found when running tests. Warn that tests ...

### DIFF
--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -137,6 +137,14 @@ if [[ "$?" != "0" ]]; then
     fatal FAILED: rr not found in PATH "($PATH)"
 fi
 
+if [[ ! -d $SRCDIR ]]; then
+    fatal FAILED: SRCDIR "($SRCDIR)" not found. objdir and srcdir must share the same parent.
+fi
+
+if [[ ! -d $TESTDIR ]]; then
+    fatal FAILED: TESTDIR "($TESTDIR)" not found.
+fi
+
 # NB: must set up the trap handler *before* mktemp
 trap onexit EXIT
 workdir=`mktemp -dt rr-test-$TESTNAME-XXXXXXXXX`


### PR DESCRIPTION
...script assume objdir/srcdir share a parent

I was getting 100s of test failure. Turns out I had my objdir within my srcdir. It works except for util.sh.

I tried to create a symblink for objdir/tests -> srcdir/tests but I don't understand CMake. Feel free to reject this pull request if you have a better fix. At least for now this will give a nicer error.