### PR TITLE
make the help command print to stdout and exit 0

### DIFF
--- a/src/Command.cc
+++ b/src/Command.cc
@@ -68,7 +68,7 @@ void Command::print_help(FILE* out) {
   if (help) {
     fputs(help, out);
   } else {
-    print_usage();
+    print_usage(out);
   }
 }
 

--- a/src/HelpCommand.cc
+++ b/src/HelpCommand.cc
@@ -23,13 +23,15 @@ HelpCommand HelpCommand::help3("--help", nullptr);
 
 int HelpCommand::run(std::vector<std::string>& args) {
   if (args.size() == 0) {
-    return print_usage();
+    print_usage(stdout);
+    return 0;
   }
 
   Command* command = Command::command_for_name(args[0]);
   if (!command) {
-    return print_usage();
+    print_usage(stderr);
+    return 1;
   }
-  command->print_help(stderr);
+  command->print_help(stdout);
   return 0;
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -88,9 +88,9 @@ void check_performance_settings() {
   }
 }
 
-int print_usage(void) {
-  fputs("Usage:\n", stderr);
-  Command::print_help_all(stderr);
+void print_usage(FILE* out) {
+  fputs("Usage:\n", out);
+  Command::print_help_all(out);
   fputs(
       "\n"
       "Common options:\n"
@@ -137,8 +137,7 @@ int print_usage(void) {
       "                             critical to the user\n"
       "  -W, --wait-secs=<NUM_SECS> wait NUM_SECS seconds just after startup,\n"
       "                             before initiating recording or replaying\n",
-      stderr);
-  return 1;
+      out);
 }
 
 static void init_random() {
@@ -225,7 +224,8 @@ int main(int argc, char* argv[]) {
   }
 
   if (args.size() == 0) {
-    return print_usage();
+    print_usage(stderr);
+    return 1;
   }
 
   auto command = Command::command_for_name(args[0]);
@@ -233,7 +233,8 @@ int main(int argc, char* argv[]) {
     args.erase(args.begin());
   } else {
     if (!Command::verify_not_option(args)) {
-      return print_usage();
+      print_usage(stderr);
+      return 1;
     }
     command = RecordCommand::get();
   }

--- a/src/main.h
+++ b/src/main.h
@@ -10,7 +10,7 @@ void assert_prerequisites(bool use_syscall_buffer = false);
 
 void check_performance_settings();
 
-int print_usage();
+void print_usage(FILE*);
 
 bool parse_global_option(std::vector<std::string>& args);
 


### PR DESCRIPTION
This changes the help command to print to stdout and to exit with
status 0.  The rationale for stdout that this makes "rr help | more"
work nicely.  The rationale for "exit 0" is that the command worked as
requested.