### PR TITLE
Fix test that runs simple shell script.

### DIFF
--- a/src/test/simple_script_debug.py
+++ b/src/test/simple_script_debug.py
@@ -1,6 +1,6 @@
 from rrutil import *
 
-send_gdb('b main\n')
+send_gdb('b __libc_start_main\n')
 expect_gdb('Breakpoint 1')
 
 send_gdb('c\n')


### PR DESCRIPTION
The test expected to be able to set a breakpoint for main. Works when the
interpreter is bash, but not when dash is used.

Fix by setting a breakpoint on a function that will always be visible to
the debugger.

Fixes the following test failures on Ubunutu (uses dash as default
interpreter):

    491 - simple_script_debug (Failed)
    492 - simple_script_debug-no-syscallbuf (Failed)
    1001 - simple_script_debug-32 (Failed)
    1002 - simple_script_debug-32-no-syscallbuf (Failed)

Note that I still have unresolved test failures on my Ubuntu 14.10:

    183 - quotactl (Failed)
    184 - quotactl-no-syscallbuf (Failed)
    301 - video_capture (Failed)
    437 - break_time_slice (Failed)
    438 - break_time_slice-no-syscallbuf (Failed)
    449 - cont_signal (Failed)
    450 - cont_signal-no-syscallbuf (Failed)
    693 - quotactl-32 (Failed)
    694 - quotactl-32-no-syscallbuf (Failed)
    896 - step_thread-32-no-syscallbuf (Failed)
    947 - break_time_slice-32 (Failed)
    948 - break_time_slice-32-no-syscallbuf (Failed)
    959 - cont_signal-32 (Failed)
    960 - cont_signal-32-no-syscallbuf (Failed)
    974 - fork_exec_info_thr-32-no-syscallbuf (Failed)
    976 - get_thread_list-32-no-syscallbuf (Failed)

.. Not every test failure can be reproduced every time.