### PR TITLE
Fix quotactl test failure on Ubuntu 14.10

### DIFF
--- a/src/test/quotactl.c
+++ b/src/test/quotactl.c
@@ -20,8 +20,13 @@ static void find_home_device(void) {
   test_assert(f);
   while (fgets(mount_line, sizeof(mount_line), f)) {
     int maj, min;
-    sscanf(mount_line, "%*d %*d %d:%d %*s %*s %*s %*s - %*s %1000s %*s", &maj,
-           &min, home_device);
+    int ret;
+    ret = sscanf(mount_line, "%*d %*d %d:%d %*s %*s %*s %*s - %*s %1000s %*s",
+            &maj, &min, home_device);
+    // optional field (7) missing?
+    if (ret != 3)
+      sscanf(mount_line, "%*d %*d %d:%d %*s %*s %*s - %*s %1000s %*s", &maj,
+        &min, home_device);
     if (maj == major(home_stat.st_dev) && min == minor(home_stat.st_dev)) {
       atomic_printf("%s (%d:%d) is on device special file %s\n", home, maj, min,
                     home_device);


### PR DESCRIPTION
The 7'th field of /proc/[pid]/mountinfo is optional.

The following tests pass now:

    183 - quotactl
    184 - quotactl-no-syscallbuf
    693 - quotactl-32
    694 - quotactl-32-no-syscallbuf