### PR TITLE
Support pselect6 syscall.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,7 @@ set(BASIC_TESTS
   int3
   intr_futex_wait_restart
   intr_poll
+  intr_pselect
   intr_read_no_restart
   intr_read_restart
   intr_sleep

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1743,6 +1743,13 @@ static Switchable rec_prepare_syscall_arch(Task* t,
       }
       return ALLOW_SWITCH;
 
+    case Arch::pselect6:
+      syscall_state.reg_parameter<typename Arch::fd_set>(2, IN_OUT);
+      syscall_state.reg_parameter<typename Arch::fd_set>(3, IN_OUT);
+      syscall_state.reg_parameter<typename Arch::fd_set>(4, IN_OUT);
+      syscall_state.reg_parameter<typename Arch::timespec>(5, IN_OUT);
+      return ALLOW_SWITCH;
+
     case Arch::recvfrom: {
       syscall_state.reg_parameter(
           2, ParamSize::from_syscall_result<typename Arch::size_t>(

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -1468,7 +1468,7 @@ fchmodat = UnsupportedSyscall(x86=306, x64=268)
 # page....
 faccessat = EmulatedSyscall(x86=307, x64=269)
 
-pselect6 = UnsupportedSyscall(x86=308, x64=270)
+pselect6 = IrregularEmulatedSyscall(x86=308, x64=270)
 
 ppoll = IrregularEmulatedSyscall(x86=309, x64=271)
 

--- a/src/test/intr_pselect.c
+++ b/src/test/intr_pselect.c
@@ -1,0 +1,42 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+static int pipefds[2];
+static int pselect_pipe(int timeout) {
+  fd_set set;
+
+  FD_ZERO(&set);
+  FD_SET(pipefds[0], &set);
+  struct timespec t;
+  t.tv_sec = timeout;
+  t.tv_nsec = 0;
+  sigset_t sigmask;
+  sigemptyset(&sigmask);
+
+  errno = 0;
+  return pselect(pipefds[0] + 1, &set, NULL, NULL, timeout ? &t : NULL,
+                 &sigmask);
+}
+
+static int caught_signal;
+static void handle_signal(int sig) { ++caught_signal; }
+
+int main(int argc, char* argv[]) {
+
+  pipe(pipefds);
+
+  signal(SIGALRM, SIG_IGN);
+  alarm(1);
+  atomic_puts("ignoring SIGALRM, going into pselect ...");
+  test_assert(0 == pselect_pipe(2) && 0 == errno);
+
+  signal(SIGALRM, handle_signal);
+  alarm(1);
+  atomic_puts("handling SIGALRM, going into pselect ...");
+  test_assert(-1 == pselect_pipe(0) && EINTR == errno);
+  test_assert(1 == caught_signal);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 1;
+}


### PR DESCRIPTION
The Qt framework uses pselect6 in its eventloop and when creating subprocesses.

[pselect6](http://lxr.free-electrons.com/source/fs/select.c?v=3.18#L700) has a sigmask param, but I'm not storing it in src/record_syscall.cc. Following the example of ppoll. I assume that only the parameters that must be stored for replay are passed to syscall_state.reg_parameter(). We record the signals that the process receives, so the sigmask serves no purpose for replay.

Was uncertain about using IN_OUT for the timeout param. The man page for pselect states that it does not update its timeout argument, but [the syscall does](http://lxr.free-electrons.com/source/fs/select.c?v=3.18#L310). The glibc wrapper hides that:

    int
    __pselect (int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
               const struct timespec *timeout, const sigset_t *sigmask)
    {
      /* The Linux kernel can in some situations update the timeout value.
         We do not want that so use a local variable.  */
      struct timespec tval;
      if (timeout != NULL)
        {
          tval = *timeout;
          timeout = &tval;
        }
    // ... snip..


The test is copy-paste-modify of intr_ppoll.c. It tests running pselect until timeout and until a signal is received.

`make check` passed.
