### PR TITLE
Add a --version option to print version number and exit.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ set(rr_VERSION_MAJOR 3)
 set(rr_VERSION_MINOR 0)
 set(rr_VERSION_PATCH 0)
 
+add_definitions(-DRR_VERSION="${rr_VERSION_MAJOR}.${rr_VERSION_MINOR}.${rr_VERSION_PATCH}")
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread -O0 -g3 -Wall -Werror -Wstrict-prototypes")
 # Define __STDC_LIMIT_MACROS so |#include <stdint.h>| works as expected.
 # Define __STDC_FORMAT_MACROS so |#include <inttypes.h>| works as expected.

--- a/src/main.cc
+++ b/src/main.cc
@@ -16,6 +16,9 @@
 
 using namespace std;
 
+// Show version and quit.
+static bool show_version = false;
+
 void assert_prerequisites(bool use_syscall_buffer) {
   struct utsname uname_buf;
   memset(&uname_buf, 0, sizeof(uname_buf));
@@ -88,7 +91,12 @@ void check_performance_settings() {
   }
 }
 
+void print_version(FILE* out) {
+  fprintf(out, "rr version %s\n", RR_VERSION);
+}
+
 void print_usage(FILE* out) {
+  print_version(out);
   fputs("Usage:\n", out);
   Command::print_help_all(out);
   fputs(
@@ -129,6 +137,7 @@ void print_usage(FILE* out) {
       "                             where EVENT-NO is the global trace time "
       "at\n"
       "                             which the write occures.\n"
+      "  -N, --version              print the version number and exit\n"
       "  -S, --suppress-environment-warnings\n"
       "                             suppress warnings about issues in the\n"
       "                             environment that rr has no control over\n"
@@ -157,7 +166,8 @@ bool parse_global_option(std::vector<std::string>& args) {
     { 'M', "mark-stdio", NO_PARAMETER },
     { 'S', "suppress-environment-warnings", NO_PARAMETER },
     { 'E', "fatal-errors", NO_PARAMETER },
-    { 'V', "verbose", NO_PARAMETER }
+    { 'V', "verbose", NO_PARAMETER },
+    { 'N', "version", NO_PARAMETER }
   };
 
   ParsedOption opt;
@@ -206,6 +216,9 @@ bool parse_global_option(std::vector<std::string>& args) {
     case 'V':
       flags.verbose = true;
       break;
+    case 'N':
+      show_version = true;
+      break;
     default:
       assert(0 && "Invalid flag");
   }
@@ -221,6 +234,11 @@ int main(int argc, char* argv[]) {
   }
 
   while (parse_global_option(args)) {
+  }
+
+  if (show_version) {
+    print_version(stdout);
+    return 0;
   }
 
   if (args.size() == 0) {


### PR DESCRIPTION
Also prints version number at the top of the usage message. I had an old version of rr installed but I realized I didn't actually know how old it was without poking at the package manager to figure that out. Supporting --version seems to be pretty standard, I don't know if there's an actual standard out there but the GNU coding standards say every command line program should support --version and --help:
https://www.gnu.org/prep/standards/html_node/Command_002dLine-Interfaces.html
