### PR TITLE
Copy the kernel's definition of msgid64_ds verbatim.

### DIFF
--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -497,9 +497,18 @@ struct BaseArch : public wordsize, public FcntlConstants {
   struct shmid64_ds {
     ipc64_perm shm_perm;
     size_t shm_segsz;
-    uint64_t shm_atime_only_little_endian;
-    uint64_t shm_dtime_only_little_endian;
-    uint64_t shm_ctime_only_little_endian;
+    __kernel_time_t shm_atime;
+#if __BITS_PER_LONG != 64
+    unsigned long unused1;
+#endif
+    __kernel_time_t shm_dtime;
+#if __BITS_PER_LONG != 64
+    unsigned long unused2;
+#endif
+    __kernel_time_t shm_ctime;
+#if __BITS_PER_LONG != 64
+    unsigned long unused3;
+#endif
     __kernel_pid_t shm_cpid;
     __kernel_pid_t shm_lpid;
     __kernel_ulong_t shm_nattch;


### PR DESCRIPTION
The discrepancy doesn't affect x86 (32 or 64 bit) but it does break ARM.