### PR TITLE
capget v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,6 +279,7 @@ set(BASIC_TESTS
   block
   blocked_sigsegv
   brk
+  capget
   chew_cpu
   chown
   clock

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -12,6 +12,7 @@
 #include <asm/ldt.h>
 #include <elf.h>
 #include <fcntl.h>
+#include <linux/capability.h>
 #include <linux/ethtool.h>
 #include <linux/ipc.h>
 #include <linux/msg.h>
@@ -242,6 +243,8 @@ struct BaseArch : public wordsize, public FcntlConstants {
   typedef __kernel_long_t __kernel_suseconds_t;
   typedef signed_int __kernel_pid_t;
   typedef int64_t __kernel_loff_t;
+
+  typedef unsigned_int __u32;
 
   template <typename T> struct ptr {
     typedef T Referent;
@@ -591,6 +594,19 @@ struct BaseArch : public wordsize, public FcntlConstants {
     unsigned_int lm : 1;
   };
   RR_VERIFY_TYPE(user_desc);
+
+  struct __user_cap_header_struct {
+    __u32 version;
+    int pid;
+  };
+  RR_VERIFY_TYPE(__user_cap_header_struct);
+
+  struct __user_cap_data_struct {
+    __u32 effective;
+    __u32 permitted;
+    __u32 inheritable;
+  };
+  RR_VERIFY_TYPE(__user_cap_data_struct);
 
   // This structure uses fixed-size fields, but the padding rules
   // for 32-bit vs. 64-bit architectures dictate that it be

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1512,6 +1512,12 @@ static Switchable rec_prepare_syscall_arch(Task* t,
       return ALLOW_SWITCH;
     }
 
+    case Arch::capget: {
+      syscall_state.reg_parameter<typename Arch::__user_cap_header_struct>(1, IN_OUT);
+      syscall_state.reg_parameter<typename Arch::__user_cap_data_struct>(2, OUT);
+      return ALLOW_SWITCH;
+    }
+
     case Arch::clone: {
       syscall_state.syscall_entry_registers =
           unique_ptr<Registers>(new Registers(t->regs()));

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -983,7 +983,7 @@ chown = EmulatedSyscall(x86=182, x64=92)
 # and via the argument buf, if present.
 getcwd = IrregularEmulatedSyscall(x86=183, x64=79)
 
-capget = UnsupportedSyscall(x86=184, x64=125)
+capget = IrregularEmulatedSyscall(x86=184, x64=125)
 capset = UnsupportedSyscall(x86=185, x64=126)
 
 #  int sigaltstack(const stack_t *ss, stack_t *oss)

--- a/src/test/capget.c
+++ b/src/test/capget.c
@@ -1,0 +1,21 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+extern int capget(cap_user_header_t header, const cap_user_data_t data);
+
+int main(int argc, char* argv[]) {
+  struct __user_cap_header_struct hdr;
+  struct __user_cap_data_struct data[2];
+
+  memset(&hdr, 0, sizeof(hdr));
+  hdr.version = _LINUX_CAPABILITY_VERSION_3;
+
+  test_assert(0 == capget(&hdr, &data[0]));
+  test_assert(0 == data[0].effective);
+  test_assert(0 == data[0].permitted);
+  test_assert(0 == data[0].inheritable);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/rrutil.h
+++ b/src/test/rrutil.h
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <linux/capability.h>
 #include <linux/ethtool.h>
 #include <linux/filter.h>
 #include <linux/futex.h>


### PR DESCRIPTION

Add support for capget(2). It is used in ping(8) which is called from a properiatary application I wish to record.
 
*v2*
Changes since yesterday (had to undo a merge, rebase and force push so the history of this PR is a bit wedged. Sorry about that. Still learning.).
* I've dropped the sys/capability.h; declaring `capget(...)`  in src/test/capget.c instead.
* Added typedef for __u32
* src/kernel_abi.h: Used the struct definitions instead of the `cap_user_{header,data}_t` typedefs for "pointer to structs"i.

`make check` passes.

*v3*
~~Just realized that `typedef uint32_t __u32` is not the proper thing to do. In the kernel, they are not mapped to fixed integer sizes, but to the regular int types. So, should be `typedef unsigned_int __u32` (using the wordsize typedefs from src/kernel_abi.h).~~

Fixed.

[int-l64.h](http://lxr.free-electrons.com/source/include/uapi/asm-generic/int-l64.h#L26)
[int-ll64.h](http://lxr.free-electrons.com/source/include/uapi/asm-generic/int-ll64.h#L26)
