### PR TITLE
Invoke python more precisely

### DIFF
--- a/src/generate_syscalls.py
+++ b/src/generate_syscalls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import assembly_templates
 import StringIO

--- a/src/test/cpuid.run
+++ b/src/test/cpuid.run
@@ -14,7 +14,7 @@ if [[ $@ == -n ]]; then
 	    ;;
     esac
     rr --suppress-environment-warnings dump $workdir/latest-trace | \
-        python $TESTDIR/check_syscall_perf_interval.py $syscall rbc 2
+        python2 $TESTDIR/check_syscall_perf_interval.py $syscall rbc 2
     if [[ $? != 0 ]]; then
         failed "expected 2 rbcs between each geteuid32 syscall"
     fi

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -220,7 +220,7 @@ function replay { replayflags=$1
 # Load the "expect" script to drive replay of the recording of |exe|.
 function debug { expectscript=$1; replayargs=$2
     _RR_TRACE_DIR="$workdir" \
-        python $TESTDIR/$expectscript.py \
+        python2 $TESTDIR/$expectscript.py \
         rr $GLOBAL_OPTIONS replay -x $TESTDIR/test_setup.gdb $replayargs
     if [[ $? == 0 ]]; then
         passed


### PR DESCRIPTION
Specifying the exact version makes python invocation less ambiguous and
eases its usage on systems which don't link python to python2.
Hopefully nowadays the python2 symlink is installed on all modern
distributions.