### PR TITLE
Copy signal handlers on clone(2).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,7 @@ set(BASIC_TESTS
   sigaction_old
   sigaltstack
   sigchld_interrupt_signal
+  sighandler_fork
   sigill
   signalfd
   sigprocmask

--- a/src/task.cc
+++ b/src/task.cc
@@ -2107,7 +2107,7 @@ Task* Task::clone(int flags, remote_ptr<void> stack, remote_ptr<void> tls,
   if (CLONE_SHARE_SIGHANDLERS & flags) {
     t->sighandlers = sighandlers;
   } else {
-    auto sh = Sighandlers::create();
+    auto sh = sighandlers->clone();
     t->sighandlers.swap(sh);
   }
   if (CLONE_SHARE_TASK_GROUP & flags) {

--- a/src/test/sighandler_fork.c
+++ b/src/test/sighandler_fork.c
@@ -1,0 +1,36 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+static void sighandler(int sig) {
+  atomic_printf("caught signal %d, exiting\n", sig);
+}
+
+int main(int argc, char* argv[]) {
+  pid_t c;
+
+  signal(SIGCHLD, sighandler);
+
+  atomic_puts("forking child");
+
+  if (0 == (c = fork())) {
+    // Child
+     usleep(10000);
+    atomic_puts("forking grandchild");
+    if (0 == (c = fork())) {
+      // Grandchild
+       usleep(10000);
+      exit(0);
+    }
+    waitpid(c, NULL, 0);
+    return 0;
+  }
+
+  // Because why not.
+  signal(SIGCHLD, NULL);
+
+  waitpid(c, NULL, 0);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
Currently we create a completely new set of signal handlers, but that's bogus.  cloned processes inherit the signal handler set of their parent (until they are exec()ed anyways, which we have code to handle already).

This fixed #1424 and presumably #1434 too.