### PR TITLE
Fix warning on glibc 2.20

### DIFF
--- a/src/Command.cc
+++ b/src/Command.cc
@@ -1,5 +1,6 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
 
+#define _DEFAULT_SOURCE
 #define _BSD_SOURCE
 
 #include "Command.h"


### PR DESCRIPTION
`_BSD_SOURCE` is deprecated in glibc 2.20, causing a compilation warning. According to the [feature_test_macros man page](http://man7.org/linux/man-pages/man7/feature_test_macros.7.html), the warning can be silenced while still allowing compatibility with older versions of glibc by defining *both* `_BSD_SOURCE` and `_DEFAULT_SOURCE`.