### PR TITLE
syscalls: add support for mknod

### DIFF
--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -221,7 +221,7 @@ chdir = EmulatedSyscall(x86=12, x64=80)
 # also stored in the memory pointed to by t.
 time = EmulatedSyscall(x86=13, x64=201, arg1="typename Arch::time_t")
 
-mknod = UnsupportedSyscall(x86=14, x64=133)
+mknod = EmulatedSyscall(x86=14, x64=133)
 
 #  int chmod(const char *path, mode_t mode)
 #

--- a/src/test/mknod.c
+++ b/src/test/mknod.c
@@ -1,0 +1,31 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+#define FILENAME "foo"
+#define MODE (S_IFIFO)
+
+int main(int argc, char* argv[]) {
+
+  int result;
+  struct stat* st;
+
+  result = mknod(FILENAME, MODE, 0);
+  test_assert(result == 0);
+
+  ALLOCATE_GUARD(st, 'x');
+  test_assert(stat(FILENAME, st) == 0);
+
+  test_assert(st->st_mode == MODE);
+  FREE_GUARD(st);
+
+  result = mknod(FILENAME, MODE, 0);
+
+  test_assert(result < 0);
+  test_assert(errno == EEXIST);
+
+  unlink(FILENAME);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
Signed-off-by: David Turner <dturner@twitter.com>