### PR TITLE
make unshare tests succeed if unshare(CLONE_NEWUSER) returns EPERM

### DIFF
--- a/src/test/unshare.c
+++ b/src/test/unshare.c
@@ -58,7 +58,7 @@ static int run_test(void) {
   }
 
   ret = unshare(CLONE_NEWUSER);
-  if (ret == -1 && errno == EINVAL) {
+  if (ret == -1 && (errno == EINVAL || errno == EPERM)) {
     atomic_puts("EXIT-SUCCESS");
     return 77;
   }


### PR DESCRIPTION
Debian has choosen to only allow root to create new user namespaces by
default.  This means on debian systems running the unshare tests fails
if the system hasn't been specifically configured to allow unprivileged
users to create user namespaces.