### PR TITLE
Handle fcntl F_DUPFD correctly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ set(BASIC_TESTS
   fadvise
   fault_in_code_page
   fcntl_owner_ex
+  fcntl_dupfd
   flock
   flock2
   fork_child_crash

--- a/src/task.cc
+++ b/src/task.cc
@@ -944,6 +944,14 @@ void Task::on_syscall_exit_arch(int syscallno, const Registers& regs) {
     case Arch::dup3:
       fd_table()->did_dup(regs.arg1(), regs.syscall_result());
       return;
+    case Arch::fcntl64:
+    case Arch::fcntl:
+      if (regs.arg2() == Arch::DUPFD ||
+          regs.arg2() == Arch::DUPFD_CLOEXEC) {
+        LOG(debug) << "Recording fcntl dup of " << regs.arg1() << " to " << regs.syscall_result();
+        fd_table()->did_dup(regs.arg1(), regs.syscall_result());
+      }
+      return;
     case Arch::close:
       fd_table()->did_close(regs.arg1());
       return;

--- a/src/task.cc
+++ b/src/task.cc
@@ -948,7 +948,6 @@ void Task::on_syscall_exit_arch(int syscallno, const Registers& regs) {
     case Arch::fcntl:
       if (regs.arg2() == Arch::DUPFD ||
           regs.arg2() == Arch::DUPFD_CLOEXEC) {
-        LOG(debug) << "Recording fcntl dup of " << regs.arg1() << " to " << regs.syscall_result();
         fd_table()->did_dup(regs.arg1(), regs.syscall_result());
       }
       return;

--- a/src/test/fcntl_dupfd.c
+++ b/src/test/fcntl_dupfd.c
@@ -1,0 +1,17 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char* argv[]) {
+  int fd;
+
+  fd = fcntl(1, F_DUPFD, 3);
+  test_assert(fd >= 3);
+  close(1);
+
+  fd = dup2(fd, 1);
+  test_assert(fd == 1);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
This is needed to get the correct terminal output when replaying mach running in /bin/dash.