### PR TITLE
Enforce a floor on the desched_fd to prevent it from being too low

### DIFF
--- a/include/rr/rr.h
+++ b/include/rr/rr.h
@@ -28,4 +28,13 @@
  */
 #define RR_RESERVED_ROOT_DIR_FD 1000
 
+/**
+ * The preferred fd that rr uses to control tracee desched. Some software
+ * (e.g. the chromium IPC code) wants to have the first few fds all to itself,
+ * so we need to stay above some floor. Tracee close()es of the fd that is
+ * actually assigned will be silently ignored, and tracee dup()s to that fd will
+ * fail with EBADF.
+ */
+#define RR_DESCHED_EVENT_FLOOR_FD 100
+
 #endif /* RR_H_ */


### PR DESCRIPTION
for the chromium IPC code in Firefox.

F_DUPFD(_CLOEXEC) picks the first free fd at or above the provided one, so this effectively gives us dup() with a custom floor value.  Chromium only wants the first few fds to itself, so 100 is mor than enough.