### PR TITLE
Implement support for the two trivial cases of the personality syscall.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,7 @@ set(BASIC_TESTS
   orphan_process
   pause
   perf_event
+  personality
   pthread_rwlocks
   poll_sig_race
   prctl

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -16,6 +16,7 @@
 #include <linux/ipc.h>
 #include <linux/msg.h>
 #include <linux/net.h>
+#include <linux/personality.h>
 #include <linux/prctl.h>
 #include <linux/seccomp.h>
 #include <linux/sem.h>
@@ -2456,6 +2457,19 @@ static Switchable rec_prepare_syscall_arch(Task* t,
         case MADV_NOHUGEPAGE:
         case MADV_DONTDUMP:
         case MADV_DODUMP:
+          break;
+        default:
+          syscall_state.expect_errno = EINVAL;
+      }
+      return PREVENT_SWITCH;
+
+    case Arch::personality:
+      switch ((int)t->regs().arg1()) {
+        case PER_LINUX:
+          // The default personality requires no handling.
+          break;
+        case 0xffffffff:
+          // A special argument that only returns the existing personality.
           break;
         default:
           syscall_state.expect_errno = EINVAL;

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -745,7 +745,7 @@ fchdir = EmulatedSyscall(x86=133, x64=81)
 
 bdflush = UnsupportedSyscall(x86=134)
 sysfs = UnsupportedSyscall(x86=135, x64=139)
-personality = UnsupportedSyscall(x86=136, x64=135)
+personality = IrregularEmulatedSyscall(x86=136, x64=135)
 afs_syscall = InvalidSyscall(x86=137, x64=183)
 setfsuid = UnsupportedSyscall(x86=138, x64=122)
 setfsgid = UnsupportedSyscall(x86=139, x64=123)

--- a/src/test/personality.c
+++ b/src/test/personality.c
@@ -1,0 +1,13 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+#include <sys/personality.h>
+
+int main(int argc, char* argv[]) {
+  personality(PER_LINUX);
+  test_assert(personality(0xffffffff) == PER_LINUX);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
This is needed for pulseaudio, which Firefox seems to launch in some circumstances.