### PR TITLE
Support prctl PR_GET_KEEPCAPS and PR_SET_KEEPCAPS

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2181,10 +2181,12 @@ static Switchable rec_prepare_syscall_arch(Task* t,
           syscall_state.reg_parameter<int>(2);
           break;
 
+        case PR_GET_KEEPCAPS:
         case PR_GET_NO_NEW_PRIVS:
         case PR_GET_TIMERSLACK:
         case PR_MCE_KILL:
         case PR_MCE_KILL_GET:
+        case PR_SET_KEEPCAPS:
         case PR_SET_PDEATHSIG:
         case PR_SET_TIMERSLACK:
           break;

--- a/src/test/prctl.c
+++ b/src/test/prctl.c
@@ -12,6 +12,12 @@ int main(int argc, char* argv[]) {
   int tsc = 99;
   int dummy;
 
+  test_assert(0 == prctl(PR_SET_KEEPCAPS, 0));
+  test_assert(0 == prctl(PR_GET_KEEPCAPS));
+
+  test_assert(0 == prctl(PR_SET_KEEPCAPS, 1));
+  test_assert(1 == prctl(PR_GET_KEEPCAPS));
+
   test_assert(0 == prctl(PR_SET_NAME, setname));
   test_assert(0 == prctl(PR_GET_NAME, getname));
   atomic_printf("set name `%s'; got name `%s'\n", setname, getname);


### PR DESCRIPTION
DNS server BIND is not going to work without this.