### PR TITLE
Support fnctl F_ADD_SEALS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,7 @@ set(BASIC_TESTS
   fault_in_code_page
   fcntl_owner_ex
   fcntl_dupfd
+  fcntl_seals
   fcntl_sig
   fds_clean
   flock

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -132,6 +132,7 @@ struct FcntlConstants {
     GETOWN_EX = 16,
     // Linux-specific operations
     DUPFD_CLOEXEC = 0x400 + 6,
+    ADD_SEALS = 0x400 + 9
   };
 };
 

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1743,6 +1743,7 @@ static Switchable rec_prepare_syscall_arch(Task* t,
         case Arch::SETOWN_EX:
         case Arch::GETSIG:
         case Arch::SETSIG:
+        case Arch::ADD_SEALS:
           break;
 
         case Arch::SETFD:

--- a/src/test/fcntl_seals.c
+++ b/src/test/fcntl_seals.c
@@ -1,0 +1,39 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+#define TEST_MEMFD "foo"
+
+#ifndef MFD_CLOEXEC
+#define MFD_CLOEXEC 0x0001
+#define MFD_ALLOW_SEALING 0x0002
+#endif
+
+#ifndef F_ADD_SEALS
+#define F_ADD_SEALS 0x409
+#endif
+
+#ifndef F_SEAL_SEAL
+#define F_SEAL_SEAL 0x0001
+#define F_SEAL_SHRINK 0x0002
+#define F_SEAL_GROW 0x0004
+#define F_SEAL_WRITE 0x0008
+#endif
+
+int main(int argc, char* argv[]) {
+  int fd;
+
+  /* There's no libc helper for this syscall. */
+  fd = syscall(RR_memfd_create, TEST_MEMFD, MFD_ALLOW_SEALING);
+  if (-1 == fd && ENOSYS == errno) {
+    atomic_puts("SYS_memfd_create not supported on this kernel");
+  } else {
+    test_assert(fd >= 0);
+    test_assert(fcntl(fd, F_ADD_SEALS, F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW) == 0);
+    /* Seal after F_SEAL_SEAL should fail */
+    test_assert(fcntl(fd, F_ADD_SEALS, F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW) == -1);
+  }
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
Hi,

This is needed by Wine Staging 1.7.53

Reference:

        if (fcntl( shm_fd, F_ADD_SEALS, F_SEAL_SEAL | F_SEAL_SHRINK | F_SEAL_GROW ) >= 0)

https://github.com/wine-compholio/wine-patched/blob/81667786de2e23faae28f4f0f1d4a08209b92e1b/server/mapping.c#L209

According to documentation, F_ADD_SEALS does only make sense to memfd_create(). I add the test to fcntl_seals.c, which unfortunately introduce a few duplication code with memfd_create.c. I'm fine to merge them together if you like.

Thanks for review! 