### PR TITLE
Use "(rr)" for the gdb command prompt rather than "(gdb)"

### DIFF
--- a/doc/rr.html
+++ b/doc/rr.html
@@ -607,7 +607,7 @@ asm("_untraced_syscall:\n\t"
 </section>
 
 <section>
-  <p><code>(gdb) call foo()</code> can cause replay divergence.
+  <p><code>(rr) call foo()</code> can cause replay divergence.
   <p>So you're not allowed to do it &hellip; for now. Support coming.
 </section>
 

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -143,7 +143,8 @@ static const char gdb_rr_macros[] =
     // that changed recently.
     "set target-async 0\n"
     "maint set target-async 0\n"
-    "handle SIGURG stop\n";
+    "handle SIGURG stop\n"
+    "set prompt (rr) \n";
 
 /**
  * Attempt to find the value of |regname| (a DebuggerRegister

--- a/src/test/breakpoint_overlap.py
+++ b/src/test/breakpoint_overlap.py
@@ -40,7 +40,7 @@ expect_gdb('Breakpoint 1')
 
 send_gdb('c')
 expect_gdb('Breakpoint 1')
-expect_gdb('(gdb)')
+expect_gdb('(rr)')
 
 send_gdb('p/x *(char*)$pc')
 expect_gdb('0x([a-f0-9]+)')

--- a/src/test/read_big_struct.py
+++ b/src/test/read_big_struct.py
@@ -7,7 +7,7 @@ send_gdb('c')
 expect_gdb('Breakpoint 1, breakpoint')
 
 send_gdb('f 1')
-expect_gdb('(gdb)')
+expect_gdb('(rr)')
 
 send_gdb('p big')
 expect_gdb("bytes = 'Z'")

--- a/src/test/rrutil.py
+++ b/src/test/rrutil.py
@@ -100,7 +100,7 @@ def set_up():
     global gdb_rr
     try:
         gdb_rr = pexpect.spawn(*get_rr_cmd(), timeout=TIMEOUT_SEC, logfile=open('gdb_rr.log', 'w'))
-        expect_gdb(r'\(gdb\)')
+        expect_gdb(r'\(rr\)')
     except Exception, e:
         failed('initializing rr and gdb', e)
 

--- a/src/test/step_thread.py
+++ b/src/test/step_thread.py
@@ -15,14 +15,14 @@ for bp in bps:
     send_gdb('b '+ bp +'')
     expect_gdb('Breakpoint \d')
 
-expect_gdb(r'\(gdb\)')
+expect_gdb(r'\(rr\)')
 
 hit_bps = { 'A': 0, 'B': 0, 'C': 0 }
 
 events = [ re.compile(r'Breakpoint 1, hit_barrier'),
            re.compile(r'Breakpoint \d, ([ABC])'),
            re.compile(r'Remote connection closed'),
-           re.compile(r'\(gdb\)') ]
+           re.compile(r'\(rr\)') ]
 while 1:
     send_gdb('s')
     i = expect_list(events)
@@ -36,7 +36,7 @@ while 1:
     bp = last_match().group(1)
     assert not hit_bps[bp]
     hit_bps[bp] = 1
-    expect_gdb(r'\(gdb\)')
+    expect_gdb(r'\(rr\)')
 
 for bp in hit_bps.iterkeys():
     assert hit_bps[bp]


### PR DESCRIPTION
Fixes #1574.