### PR TITLE
Add support for readlinkat syscall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,6 +421,7 @@ set(BASIC_TESTS
   read_nothing
   readdir
   readlink
+  readlinkat
   readv
   rlimit
   robust_futex

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2036,6 +2036,13 @@ static Switchable rec_prepare_syscall_arch(Task* t,
       return PREVENT_SWITCH;
     }
 
+    case Arch::readlinkat: {
+      syscall_state.reg_parameter(
+          3, ParamSize::from_syscall_result<typename Arch::ssize_t>(
+                 (size_t)t->regs().arg4()));
+      return PREVENT_SWITCH;
+    }
+
     case Arch::getgroups: {
       // We could record a little less data by restricting the recorded data
       // to the syscall result * sizeof(Arch::legacy_gid_t), but that would

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -1420,7 +1420,7 @@ unlinkat = EmulatedSyscall(x86=301, x64=263)
 renameat = UnsupportedSyscall(x86=302, x64=264)
 linkat = UnsupportedSyscall(x86=303, x64=265)
 symlinkat = UnsupportedSyscall(x86=304, x64=266)
-readlinkat = UnsupportedSyscall(x86=305, x64=267)
+readlinkat = IrregularEmulatedSyscall(x86=305, x64=267)
 fchmodat = UnsupportedSyscall(x86=306, x64=268)
 
 #  int faccessat(int dirfd, const char *pathname, int mode, int flags)

--- a/src/test/readlinkat.c
+++ b/src/test/readlinkat.c
@@ -1,0 +1,41 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+#define BUF_SIZE 10
+#define BUF2_SIZE 1000
+
+int main(int argc, char* argv[]) {
+  char path[] = "rr-test-file-XXXXXX";
+  char dpath[] = "rr-test-dir-XXXXXX";
+  const char *dir_path = mkdtemp(dpath);
+  chdir(dir_path);
+  int count;
+  char link[PATH_MAX];
+  char* buf = allocate_guard(BUF_SIZE, 'q');
+  char* buf2 = allocate_guard(BUF2_SIZE, 'r');
+
+  test_assert(0 <= dirfd);
+
+  for (count = 0;; ++count) {
+    sprintf(link, "rr-test-link-%d", count);
+    int ret = symlink(path, link);
+    if (ret == 0) {
+      break;
+    }
+    test_assert(errno == EEXIST);
+  }
+  int ret = readlinkat(AT_FDCWD, link, buf, BUF_SIZE);
+  test_assert(BUF_SIZE == ret);
+  test_assert(0 == memcmp(path, buf, BUF_SIZE));
+  verify_guard(BUF_SIZE, buf);
+
+  test_assert(strlen(path) == readlinkat(AT_FDCWD, link, buf2, BUF2_SIZE));
+  test_assert(0 == memcmp(path, buf2, strlen(path)));
+  verify_guard(BUF2_SIZE, buf2);
+
+  test_assert(0 == unlink(link));
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
I based most of the code on `readlink` syscall already there. The test is by no means exhaustive, but passes.

Can you please comment if there's more testing needed?

This does not solve #1578 completely for me, but at least takes me a bit further and the error looks unrelated:
```
rr: Saving the execution of `./sdl-test' to trace directory `/home/janisozaur/.rr/sdl-test-7'.
[FATAL /home/janisozaur/workspace/rr/src/record_syscall.cc:3057:rec_process_syscall_arch() errno: 0 'Success'] 
 (task 17746 (rec:17746) at time 2636)
 ->  Assertion `t->regs().syscall_result_signed() == -syscall_state.expect_errno' failed to hold. Expected EINVAL for 'ioctl' but got result 0; Unknown ioctl(0x80106463): type:0x64 nr:0x63 dir:0x2 size:16 addr:0xffe9371c
```

```
(gdb) bt
#0  0x70000018 in ?? ()
#1  0xf7786167 in _traced_raw_syscall () at /home/janisozaur/workspace/rr/build/32/traced_syscall_shared.S:38
#2  0xf7783b95 in traced_raw_syscall (call=call@entry=0xffe93688) at /home/janisozaur/workspace/rr/build/32/preload.c:312
#3  0xf7784d97 in syscall_hook_internal (call=0xffe93688) at /home/janisozaur/workspace/rr/build/32/preload.c:2021
#4  syscall_hook (call=0xffe93688) at /home/janisozaur/workspace/rr/build/32/preload.c:2029
#5  0xf77861b2 in _syscall_hook_trampoline () at /home/janisozaur/workspace/rr/build/32/syscall_hook.S:59
#6  0xf734f479 in ioctl () from /usr/lib32/libc.so.6
#7  0xf6dbd67e in drmIoctl () from /usr/lib32/libdrm.so.2
#8  0xf66f3143 in drm_intel_bufmgr_gem_init () from /usr/lib32/libdrm_intel.so.1
#9  0xf6b29805 in ?? () from /usr/lib32/xorg/modules/dri/i965_dri.so
#10 0xf69f959a in ?? () from /usr/lib32/xorg/modules/dri/i965_dri.so
#11 0xf6eb8bf1 in ?? () from /usr/lib32/libGL.so.1
#12 0xf6e8d050 in ?? () from /usr/lib32/libGL.so.1
#13 0xf6e8904e in ?? () from /usr/lib32/libGL.so.1
#14 0xf6e891f2 in glXChooseVisual () from /usr/lib32/libGL.so.1
#15 0xf76e2af5 in X11_GL_GetVisual (_this=0x82d0b90, display=0x82d12b8, screen=0) at /tmp/packerbuild-1000/lib32-sdl2/lib32-sdl2/src/SDL2-2.0.3/src/video/x11/SDL_x11opengl.c:525
#16 0xf76e2d50 in X11_GL_InitExtensions (_this=0x82d0b90) at /tmp/packerbuild-1000/lib32-sdl2/lib32-sdl2/src/SDL2-2.0.3/src/video/x11/SDL_x11opengl.c:323
#17 X11_GL_LoadLibrary (_this=0x82d0b90, path=<optimized out>) at /tmp/packerbuild-1000/lib32-sdl2/lib32-sdl2/src/SDL2-2.0.3/src/video/x11/SDL_x11opengl.c:218
#18 0xf76d5e70 in SDL_GL_LoadLibrary_REAL (path=0x0) at /tmp/packerbuild-1000/lib32-sdl2/lib32-sdl2/src/SDL2-2.0.3/src/video/SDL_video.c:2401
#19 0xf76d7e06 in SDL_CreateWindow_REAL (title=0xf76fb9b2 "OpenGL test", x=-32, y=-32, w=32, h=32, flags=10) at /tmp/packerbuild-1000/lib32-sdl2/lib32-sdl2/src/SDL2-2.0.3/src/video/SDL_video.c:1240
#20 0xf76d7aab in ShouldUseTextureFramebuffer () at /tmp/packerbuild-1000/lib32-sdl2/lib32-sdl2/src/SDL2-2.0.3/src/video/SDL_video.c:192
#21 SDL_VideoInit_REAL (driver_name=<optimized out>) at /tmp/packerbuild-1000/lib32-sdl2/lib32-sdl2/src/SDL2-2.0.3/src/video/SDL_video.c:506
#22 0xf762f6aa in SDL_InitSubSystem_REAL (flags=16416) at /tmp/packerbuild-1000/lib32-sdl2/lib32-sdl2/src/SDL2-2.0.3/src/SDL.c:173
#23 0xf765ea11 in SDL_Init_DEFAULT (a=32) at /tmp/packerbuild-1000/lib32-sdl2/lib32-sdl2/src/SDL2-2.0.3/src/dynapi/SDL_dynapi_procs.h:89
#24 0xf765ed47 in SDL_Init (a=32) at /tmp/packerbuild-1000/lib32-sdl2/lib32-sdl2/src/SDL2-2.0.3/src/dynapi/SDL_dynapi_procs.h:89
#25 0x0804941f in main ()
```