### PR TITLE
Replace references to Fedora's YUM with DNF.

### DIFF
--- a/doc/rr.html
+++ b/doc/rr.html
@@ -696,7 +696,7 @@ asm("_untraced_syscall:\n\t"
 <section>
   <h3>Use cases</h3>
   <ul>
-    <li>Run on modern, commodity hardware and software: <code>yum
+    <li>Run on modern, commodity hardware and software: <code>dnf
     install rr; rr record</code>&hellip;
     <li>Aspire to general tool, focus on Firefox initially
     <li>Record nondeterministic test failures at scale (e.g., Firefox

--- a/src/main.cc
+++ b/src/main.cc
@@ -82,7 +82,7 @@ void check_performance_settings() {
             "governor\n"
             "    by running the following commands:\n"
             "\n"
-            "    $ sudo yum install kernel-tools\n"
+            "    $ sudo dnf install kernel-tools\n"
             "    $ sudo cpupower frequency-set -g performance\n"
             "\n",
             governor);


### PR DESCRIPTION
Fedora since 22 has replaced YUM with DNF, which uses largely the same syntax.