### PR TITLE
Support setuid syscall.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,6 +440,7 @@ set(BASIC_TESTS
   setgid
   setgroups
   setsid
+  setuid
   shm
   sigaction_old
   sigaltstack

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -196,7 +196,7 @@ getpid = EmulatedSyscall(x86=20, x64=39)
 
 mount = UnsupportedSyscall(x86=21, x64=165)
 umount = UnsupportedSyscall(x86=22)
-setuid = UnsupportedSyscall(x86=23, x64=105)
+setuid = EmulatedSyscall(x86=23, x64=105)
 getuid = EmulatedSyscall(x86=24, x64=102)
 stime = UnsupportedSyscall(x86=25)
 
@@ -1074,7 +1074,7 @@ setresgid32 = EmulatedSyscall(x86=210)
 getresgid32 = EmulatedSyscall(x86=211, arg1="typename Arch::gid_t", arg2="typename Arch::gid_t", arg3="typename Arch::gid_t")
 
 chown32 = EmulatedSyscall(x86=212)
-setuid32 = UnsupportedSyscall(x86=213)
+setuid32 = EmulatedSyscall(x86=213)
 setgid32 = EmulatedSyscall(x86=214)
 setfsuid32 = UnsupportedSyscall(x86=215)
 setfsgid32 = UnsupportedSyscall(x86=216)

--- a/src/test/setuid.c
+++ b/src/test/setuid.c
@@ -1,0 +1,22 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char* argv[]) {
+
+  uid_t real = getuid();
+
+  test_assert(0 == setuid(real));
+
+  // We can't rely on the presence of any specific user, except for the
+  // current one. But the kernel returns EINVAL for -1, see
+  // include/linux/uidgid.h:uid_valid()
+  // Use that value to increase scope of testing.
+  test_assert(-1 == setuid((uid_t)-1));
+
+  test_assert(0 == setuid(real));
+  test_assert(real == getuid());
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
Needed by the ping command.

A somewhat related sidetrack: With this patch applied, I can use ping, but only as root. Why not as regular user?

    $ strace ping localhost 
    ping: icmp open socket: Operation not permitted

    $ rr ping localhost
    ping: icmp open socket: Operation not permitted

Running rr and strace as root works.

Answer:  /bin/ping has the setuid bit set; it will run with elevated privilegies.  Google says that a process running under ptrace will ignore the setuid bit. Got curios about exactly where in the Linux kernel source that logic is handled but got lost. I guess some variable is set upon `ptrace(...PTRACE_TRACEME)` that execve later checks.

The setuid bits allows a process to run with elevated privs and the setuid() systemcall drops privilegies. Confusing.