### PR TITLE
Support `sync` and `syncfs` syscalls.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,6 +477,7 @@ set(BASIC_TESTS
   stdout_redirect
   strict_priorities
   switch_read
+  sync
   syscallbuf_timeslice
   syscallbuf_timeslice2
   sysconf

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -252,7 +252,7 @@ access = EmulatedSyscall(x86=33, x64=21)
 
 nice = UnsupportedSyscall(x86=34)
 ftime = InvalidSyscall(x86=35)
-sync = UnsupportedSyscall(x86=36, x64=162)
+sync = EmulatedSyscall(x86=36, x64=162)
 
 #  int kill(pid_t pid, int sig)
 #
@@ -1611,7 +1611,7 @@ prlimit64 = EmulatedSyscall(x86=340, x64=302, arg4="typename Arch::rlimit64")
 name_to_handle_at = UnsupportedSyscall(x86=341, x64=303)
 open_by_handle_at = UnsupportedSyscall(x86=342, x64=304)
 clock_adjtime = UnsupportedSyscall(x86=343, x64=305)
-syncfs = UnsupportedSyscall(x86=344, x64=306)
+syncfs = EmulatedSyscall(x86=344, x64=306)
 
 #  int sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
 #               unsigned int flags);

--- a/src/test/sync.c
+++ b/src/test/sync.c
@@ -1,0 +1,20 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+#define FILENAME "foo.txt"
+
+int main(void) {
+  int fd;
+
+  sync();
+
+  fd = open(FILENAME, O_CREAT | O_RDWR, 0600);
+  test_assert(fd >= 0);
+  test_assert(0 == syncfs(fd));
+  unlink(FILENAME);
+
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
Saw that it was suggested that we should implement the remaining syscalls that don't need a scratch buffer https://github.com/mozilla/rr/issues/1053#issuecomment-157201238

Quite a few of the remaining unsupported syscalls are listed as obsolete when I read the glibc man pages, but sync is widely used (and it's needed for a program I've been debugging at work).

I'll take at stab at setreuid, setregid and eventfd next, unless  someone else beats me to it.