### PR TITLE
implementing CLONE_VFORK and adding a test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,7 @@ set(TESTS_WITH_PROGRAM
   checkpoint_dying_threads
   checkpoint_mixed_mode
   clone_interruption
+  clone_vfork
   conditional_breakpoint_calls
   conditional_breakpoint_offload
   condvar_stress

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1692,6 +1692,11 @@ static Switchable rec_prepare_syscall_arch(Task* t,
       syscall_state.syscall_entry_registers =
           unique_ptr<Registers>(new Registers(t->regs()));
       unsigned long flags = t->regs().arg1();
+      if (flags & CLONE_VFORK) {
+        Registers r = t->regs();
+        r.set_arg1(flags & ~CLONE_VFORK);
+        t->set_regs(r);
+      }
       if (flags & CLONE_UNTRACED) {
         Registers r = t->regs();
         // We can't let tracees clone untraced tasks,

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -200,7 +200,8 @@ static void process_clone(Task* t, const TraceFrame& trace_frame,
     // If we allow CLONE_UNTRACED then the child would escape from rr control
     // and we can't allow that.
     // Block CLONE_CHILD_CLEARTID because we'll emulate that ourselves.
-    r.set_arg1(flags & ~(CLONE_UNTRACED | CLONE_CHILD_CLEARTID));
+    // Filter CLONE_VFORK too
+    r.set_arg1(flags & ~(CLONE_UNTRACED | CLONE_CHILD_CLEARTID | CLONE_VFORK));
     t->set_regs(r);
   }
 

--- a/src/test/clone_vfork.c
+++ b/src/test/clone_vfork.c
@@ -1,0 +1,27 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+int clonefunc(void *exe) {
+  execl(exe, exe, NULL);
+  test_assert("Not reached" && 0);
+  return 0;
+}
+
+int main(int argc, char *argv[]) {
+  char *child_stack[16384];
+  const char* exe;
+  pid_t child;
+  int status;
+
+  test_assert(2 == argc);
+  exe = argv[1];
+
+  child = clone(clonefunc, child_stack, CLONE_VFORK|SIGCHLD, (void *)exe);
+
+  test_assert(child == waitpid(child, &status, 0));
+  test_assert(WIFEXITED(status) && 0 == WEXITSTATUS(status));
+
+  atomic_puts("clone-vfork-EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/clone_vfork.run
+++ b/src/test/clone_vfork.run
@@ -1,0 +1,6 @@
+source `dirname $0`/util.sh
+
+save_exe simple$bitness
+record $TESTNAME simple$bitness-$nonce
+replay
+check clone-vfork-EXIT-SUCCESS


### PR DESCRIPTION
It should fix the first part of https://github.com/mozilla/rr/issues/1594 . The semantics of CLONE_VFORK are not respected as the parent is scheduled before the child calls exec/exit.