### PR TITLE
Add rr_page_{32,64}_replay as install targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,10 @@ set_source_files_properties(src/exec_stub.c
                             COMPILE_FLAGS "-fno-stack-protector")
 
 install(PROGRAMS scripts/signal-rr-recording.sh
-                  ${CMAKE_CURRENT_BINARY_DIR}/bin/rr_page_64 ${CMAKE_CURRENT_BINARY_DIR}/bin/rr_page_32
+                  ${CMAKE_CURRENT_BINARY_DIR}/bin/rr_page_64
+                  ${CMAKE_CURRENT_BINARY_DIR}/bin/rr_page_64_replay
+                  ${CMAKE_CURRENT_BINARY_DIR}/bin/rr_page_32
+                  ${CMAKE_CURRENT_BINARY_DIR}/bin/rr_page_32_replay
   DESTINATION bin)
 
 install(TARGETS rr rrpreload exec_stub


### PR DESCRIPTION
Fixes the following assertion that happens when i run 
    
    $ rr echo
    $ rr replay

[FATAL /home/dannas/code/external/rr/src/AutoRemoteSyscalls.cc:451:check_syscall_result() errno: 0 'Success'] 
 (task 11774 (rec:26039) at time 14)
 ->  Assertion `false' failed to hold. Syscall openat failed with errno ENOENT opening usr/local/bin/rr_page_64_replay
