### PR TITLE
Do not truncate filename pointer in preload sys_creat.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,7 @@ set(BASIC_TESTS
   clone_immediate_exit
   clone_untraced
   constructor
+  creat_address_not_truncated
   desched_blocking_poll
   dup
   epoll_create

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 Copyright (c) 2013 Mozilla Foundation
 Copyright 2015 VMware, Inc
+Copyright 2015 Google Inc.
 
 Contributors: Albert Noll <noll.albert@gmail.com>, Thomas Anderegg <thomas@tanderegg.com>, Nimrod Partush <nimrodpar@gmail.com>
               Andrew Walton <awalton@vmware.com>

--- a/src/preload/preload.c
+++ b/src/preload/preload.c
@@ -1180,7 +1180,7 @@ static long sys_close(const struct syscall_info* call) {
 
 static long sys_open(const struct syscall_info* call);
 static long sys_creat(const struct syscall_info* call) {
-  int fd = call->args[0];
+  const char* pathname = (const char*)call->args[0];
   mode_t mode = call->args[1];
   /* Thus sayeth the man page:
    *
@@ -1188,7 +1188,7 @@ static long sys_creat(const struct syscall_info* call) {
    *   O_CREAT|O_WRONLY|O_TRUNC. */
   struct syscall_info open_call;
   open_call.no = SYS_open;
-  open_call.args[0] = fd;
+  open_call.args[0] = (long)pathname;
   open_call.args[1] = O_CREAT | O_TRUNC | O_WRONLY;
   open_call.args[2] = mode;
   return sys_open(&open_call);

--- a/src/test/creat_address_not_truncated.c
+++ b/src/test/creat_address_not_truncated.c
@@ -1,0 +1,29 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+#include <limits.h>
+
+static const char dummy_filename[] = "dummy.txt";
+
+int main(int argc, char* argv[]) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
+
+  // Request an address where casting to int could corrupt the address on 64-bit
+  // (i.e. not near the top or bottom of memory).
+  uint8_t* map = mmap((void*)(LONG_MAX / 2), page_size, PROT_READ | PROT_WRITE,
+                      MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+
+  // Copy the filename there, and try to use creat. If the address gets
+  // truncated, this can cause a segmentation fault.
+  memcpy(map, dummy_filename, sizeof(dummy_filename));
+
+  int fd = creat((const char*)map, 0600);
+  close(fd);
+
+  test_assert(access(dummy_filename, F_OK) == 0);
+
+  atomic_puts("EXIT-SUCCESS");
+
+  return 0;
+}


### PR DESCRIPTION
The first argument is a const char\*, not an fd, so converting it to int
truncates it on systems where sizeof(int) < sizeof(const char\*), such as
Linux x86_64.

Includes a test that passes a pointer address which should be outside
the range where this happens to work.