### PR TITLE
Add support for TIOCGPGRP ioctl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,6 +506,7 @@ set(BASIC_TESTS
   timerfd
   times
   tiocgwinsz
+  tiocgpgrp
   truncate
   tty_ioctls
   uname

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1182,6 +1182,10 @@ static Switchable prepare_ioctl(Task* t, TaskSyscallState& syscall_state) {
       syscall_state.reg_parameter<typename Arch::winsize>(3);
       return PREVENT_SWITCH;
 
+    case TIOCGPGRP:
+      syscall_state.reg_parameter<typename Arch::pid_t>(3);
+      return PREVENT_SWITCH;
+
     case SNDRV_CTL_IOCTL_PVERSION:
       syscall_state.reg_parameter<int>(3);
       return PREVENT_SWITCH;

--- a/src/test/tiocgpgrp.c
+++ b/src/test/tiocgpgrp.c
@@ -1,0 +1,14 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+int main(int argc, char* argv[]) {
+  int ret;
+  pid_t pgrp = 0;
+
+  ret = ioctl(STDIN_FILENO, TIOCGPGRP, &pgrp);
+  atomic_printf("TIOCGPGRP returned process group %d (ret:%d)\n", pgrp, ret);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
Fixes replay for mpv, which uses tcgetpgrp(0) to check if the terminal is in foreground.

----

Finally found something that I can reasonably do for this project :D

Hopefully I did everything right.

Fun fact: the mpv bug i'm dealing with is related to xv shared memory, but there's another conditional branch in the same function for when shared memory isn't supported, and I didn't know any better way to test that branch than using rr, taking advantage of the fact that it disables shm. And that's how this rr patch happened. Now I know that the non-shm code is just as broken as the shm code. Yay.

Also there's a typo in src/test/tiocgwinsz.c (which i obviously used for inspiration), it says "TIOCWINSZ" in the printf instead of "TIOC**G**WINSZ". I didn't touch that because I don't like to introduce unrelated changes that way.