### PR TITLE
Improve contrast by dropping background

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
     }
     body {
       font-family: 'Open Sans', sans;
-      background: linear-gradient(#d1cec4, white);
       color: #484848;
     }
     body > * {


### PR DESCRIPTION
Drop linear-gradient global background. This background reduces contrast a lot, at least at the document's beginning, and makes the style of titles inconsistent across the document.

I understand this is a bikeshed-prone matter and I'm not an expert designer (my training is basically [this](https://www.goodreads.com/book/show/10875750-the-non-designer-s-design-book)), so apologies for sending a PR, but when I visited your website intending to hear more on your project, this was seriously my first reaction (I don't usually do this). I was in relatively low-light conditions, but still.