### PR TITLE
Add higher level commands to RR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,8 @@ add_executable(rr
   src/fast_forward.cc
   src/FdTable.cc
   src/Flags.cc
+  src/GdbCommand.cc
+  src/GdbCommandHandler.cc
   src/GdbConnection.cc
   src/GdbExpression.cc
   src/GdbInitCommand.cc

--- a/src/GdbCommand.cc
+++ b/src/GdbCommand.cc
@@ -1,0 +1,18 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+//#define DEBUGTAG "GdbCommand"
+
+#include "GdbCommand.h"
+
+RR_CMD(when) {
+  return std::string() + "Current event: " + std::to_string(t->current_trace_frame().time()) + "\n";
+}
+
+RR_CMD(when-ticks) {
+  return std::string() + "Current tick: " + std::to_string(t->tick_count()) + "\n";
+}
+
+RR_CMD(when-tid) {
+  return std::string() + "Current tid: " + std::to_string(t->tid) + "\n";
+}
+

--- a/src/GdbCommand.h
+++ b/src/GdbCommand.h
@@ -1,0 +1,53 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#ifndef RR_GDB_COMMAND_H_
+#define RR_GDB_COMMAND_H_
+
+#include "GdbServer.h"
+#include "GdbCommandHandler.h"
+
+#include <string>
+#include <vector>
+
+class GdbCommand {
+protected:
+  GdbCommand(const std::string& cmd_name)
+    : cmd_name(cmd_name) {
+    GdbCommandHandler::register_command(*this);
+  }
+
+public:
+
+  const std::string& name() const { return cmd_name; }
+
+  /**
+   * Handle the RR Cmd and return a string response to be echo'd
+   * to the user.
+   *
+   * NOTE: args[0] is the command name
+   */
+  virtual std::string invoke(GdbServer& gdb_server, Task* t, const std::vector<std::string>& args) = 0;
+
+private:
+  const std::string cmd_name;
+};
+
+#define RR_LINE_CONCAT(str, line) str ## line
+#define RR_LINE_EXPAND(str, line) RR_LINE_CONCAT(str, line)
+#define RR_CMD_CLASSNAME(name) RR_LINE_EXPAND(RRCmd, __LINE__)
+#define RR_CMD_OBJ(name) RR_LINE_EXPAND(sRRCmdObj, __LINE__)
+
+#define RR_CMD(name) \
+class RR_CMD_CLASSNAME(name) : public GdbCommand {\
+public:\
+  RR_CMD_CLASSNAME(name)()\
+    : GdbCommand(#name) {}\
+private:\
+  virtual std::string invoke(GdbServer& gdb_server, Task* t, const std::vector<std::string>& args);\
+};\
+\
+static RR_CMD_CLASSNAME(name) RR_CMD_OBJ(name);\
+\
+std::string RR_CMD_CLASSNAME(name)::invoke(GdbServer& gdb_server, Task* t, const std::vector<std::string>& args)
+
+#endif

--- a/src/GdbCommandHandler.cc
+++ b/src/GdbCommandHandler.cc
@@ -1,0 +1,139 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+//#define DEBUGTAG "GdbCommandHandler"
+
+#include "GdbCommand.h"
+#include "GdbCommandHandler.h"
+#include "log.h"
+
+#include <sstream>
+#include <vector>
+
+// HashMap would be better here but the unordered_map API is annoying
+// and linear search is fine.
+static std::vector<GdbCommand*>* gdb_command_list;
+
+static std::string gdb_macro_binding(const GdbCommand& cmd) {
+  return "python RRCmd('" + cmd.name() + "')\n";
+}
+
+/* static */ std::string
+GdbCommandHandler::gdb_macros() {
+  std::stringstream ss;
+  ss << std::string(R"Delimiter(
+
+set python print-stack full
+python
+
+import re
+
+def gdb_unescape(string):
+    result = ""
+    pos = 0
+    while pos < len(string):
+        result += chr(int(string[pos:pos+2], 16))
+        pos += 2
+    return result
+
+def gdb_escape(string):
+    result = ""
+    pos = 0
+    for curr_char in string:
+        result += format(ord(curr_char), 'x')
+    return result
+
+class RRCmd(gdb.Command):
+    def __init__(self, name):
+        gdb.Command.__init__(self, name,
+                             gdb.COMMAND_USER, gdb.COMPLETE_NONE, True)
+        self.cmd_name = name
+
+    def invoke(self, arg, from_tty):
+        args = gdb.string_to_argv(arg)
+        self.rr_cmd(args)
+
+    def rr_cmd(self, args):
+        rv = gdb.execute("maint packet qRRCmd:" + gdb_escape(self.cmd_name), to_string=True);
+        rv_match = re.search('received: "(.*)"', rv, re.MULTILINE);
+        if not rv_match:
+            gdb.write("Response error: " + rv)
+            return
+        response = gdb_unescape(rv_match.group(1))
+        gdb.write(response)
+
+end
+
+)Delimiter");
+
+  if (gdb_command_list) {
+    for (auto& it : *gdb_command_list) {
+      ss << gdb_macro_binding(*it);
+    }
+  }
+  return ss.str();
+}
+
+static GdbCommand* command_for_name(const std::string& name) {
+  if (!gdb_command_list) {
+    return nullptr;
+  }
+  for (auto& it : *gdb_command_list) {
+    if (it->name() == name) {
+      return it;
+    }
+  }
+  return nullptr;
+}
+
+void GdbCommandHandler::register_command(GdbCommand& cmd) {
+  LOG(debug) << "registering command: " << cmd.name();
+  if (!gdb_command_list) {
+    gdb_command_list = new std::vector<GdbCommand*>();
+  }
+  gdb_command_list->push_back(&cmd);
+}
+
+// Use the simplest two hex character by byte encoding
+static std::string gdb_escape(const std::string& str) {
+  std::stringstream ss;
+  ss << std::hex;
+  for (size_t i = 0; i < str.size(); i++) {
+    auto chr = str.at(i);
+    ss << (int)chr;
+  }
+
+  return ss.str();
+}
+static std::string gdb_unescape(const std::string& str) {
+  std::stringstream ss;
+  for (size_t i = 0; i < str.size(); i+=2) {
+    ss << (char)std::stoul(str.substr(i, 2), nullptr, 16);
+  }
+
+  return ss.str();
+}
+static std::vector<std::string> parse_cmd(std::string& str) {
+  std::vector<std::string> args;
+  size_t pos = 0;
+  std::string delimiter = ":";
+  while ((pos = str.find(delimiter)) != std::string::npos) {
+    args.push_back(gdb_unescape(str.substr(0, pos)));
+    str.erase(0, pos + delimiter.length());
+  }
+  args.push_back(gdb_unescape(str));
+  return args;
+}
+
+/* static */ std::string
+GdbCommandHandler::process_command(GdbServer& gdb_server, Task* t, std::string payload) {
+  const std::vector<std::string> args = parse_cmd(payload);
+  GdbCommand* cmd = command_for_name(args[0]);
+  if (!cmd) {
+    return gdb_escape(std::string() + "Command '" + args[0] + "' not found.\n");
+  }
+  LOG(debug) << "invoking command: " << cmd->name();
+  std::string resp = cmd->invoke(gdb_server, t, args);
+  LOG(debug) << "cmd response: " << resp;
+  return gdb_escape(resp);
+}
+

--- a/src/GdbCommandHandler.h
+++ b/src/GdbCommandHandler.h
@@ -1,0 +1,31 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#ifndef RR_GDB_COMMAND_HANDLER_H_
+#define RR_GDB_COMMAND_HANDLER_H_
+
+#include <string>
+
+class GdbCommand;
+class GdbServer;
+class Task;
+
+class GdbCommandHandler {
+public:
+  // Declare any registered command with supporting
+  // wrapper code.
+  static std::string gdb_macros();
+
+  static void register_command(GdbCommand& cmd);
+
+  /**
+   * Process an incoming GDB payload of the following form:
+   *   <command name>:<arg1>:<arg2>:...
+   *
+   * NOTE: RR Command are typically sent with the qRRCmd: prefix which
+   * should of been striped already.
+   */
+  static std::string process_command(GdbServer& gdb_server, Task* t, std::string payload);
+private:
+};
+
+#endif

--- a/src/GdbConnection.h
+++ b/src/GdbConnection.h
@@ -134,6 +134,9 @@ enum GdbRequestType {
 
   /* Uses params.restart. */
   DREQ_RESTART,
+
+  /* Uses params.text. */
+  DREQ_RR_CMD,
 };
 
 enum GdbRestartType {
@@ -169,7 +172,8 @@ struct GdbRequest {
         watch_(other.watch_),
         reg_(other.reg_),
         restart_(other.restart_),
-        cont_(other.cont_) {}
+        cont_(other.cont_),
+        text_(other.text_) {}
   GdbRequest& operator=(const GdbRequest& other) {
     this->~GdbRequest();
     new (this) GdbRequest(other);
@@ -202,6 +206,7 @@ struct GdbRequest {
     RunDirection run_direction;
     std::vector<GdbContAction> actions;
   } cont_;
+  std::string text_;
 
   Mem& mem() {
     assert(type >= DREQ_MEM_FIRST && type <= DREQ_MEM_LAST);
@@ -242,6 +247,10 @@ struct GdbRequest {
   const Cont& cont() const {
     assert(type == DREQ_CONT);
     return cont_;
+  }
+  const std::string& text() const {
+    assert(type == DREQ_RR_CMD);
+    return text_;
   }
 
   /**
@@ -447,6 +456,11 @@ public:
    * anyway.
    */
   void reply_write_siginfo(/* TODO*/);
+
+  /**
+   * Send a manual text response to a rr cmd (maintenance) packet.
+   */
+  void reply_rr_cmd(const std::string& text);
 
   /**
    * Create a checkpoint of the given Session with the given id. Delete the

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "BreakpointCondition.h"
+#include "GdbCommandHandler.h"
 #include "GdbExpression.h"
 #include "kernel_metadata.h"
 #include "log.h"
@@ -53,20 +54,6 @@ static const int DBG_COMMAND_MSG_DELETE_CHECKPOINT = 0x02000000;
 
 static const uint32_t DBG_COMMAND_PARAMETER_MASK = 0x00FFFFFF;
 
-/**
- * 64-bit reads from DBG_WHEN_MAGIC_ADDRESS return the current trace frame's
- * event number (the event we're working towards).
- */
-static const int DBG_WHEN_MAGIC_ADDRESS = DBG_COMMAND_MAGIC_ADDRESS + 4;
-
-/**
- * 64-bit reads from DBG_WHEN_TICKS_MAGIC_ADDRESS return the current trace's
- * tick count.
- */
-static const int DBG_WHEN_TICKS_MAGIC_ADDRESS = DBG_WHEN_MAGIC_ADDRESS + 8;
-
-static const int DBG_REAL_TID_MAGIC_ADDRESS = DBG_WHEN_TICKS_MAGIC_ADDRESS + 8;
-
 // Special-sauce macros defined by rr when launching the gdb client,
 // which implement functionality outside of the gdb remote protocol.
 // (Don't stare at them too long or you'll go blind ;).)
@@ -92,15 +79,6 @@ static const string& gdb_rr_macros() {
         << "end\n"
         << "define restart\n"
         << "  run c$arg0\n"
-        << "end\n"
-        << "define when\n"
-        << "  p *(long long int*)" << DBG_WHEN_MAGIC_ADDRESS << "\n"
-        << "end\n"
-        << "define when-ticks\n"
-        << "  p *(long long int*)" << DBG_WHEN_TICKS_MAGIC_ADDRESS << "\n"
-        << "end\n"
-        << "define real-tid\n"
-        << "  p *(long long int*)" << DBG_REAL_TID_MAGIC_ADDRESS << "\n"
         << "end\n"
         // In gdb version "Fedora 7.8.1-30.fc21", a raw "run" command
         // issued before any user-generated resume-execution command
@@ -155,7 +133,8 @@ static const string& gdb_rr_macros() {
         // Try both "set target-async" and "maint set target-async" since
         // that changed recently.
         << "set target-async 0\n"
-        << "maint set target-async 0\n";
+        << "maint set target-async 0\n"
+        << GdbCommandHandler::gdb_macros();
     s = ss.str();
   }
   return s;
@@ -275,33 +254,6 @@ bool GdbServer::maybe_process_magic_command(const GdbRequest& req) {
       return false;
   }
   dbg->reply_set_mem(true);
-  return true;
-}
-
-bool GdbServer::maybe_process_magic_read(Task* t, const GdbRequest& req) {
-  int64_t value;
-  switch (req.mem().addr) {
-    case DBG_WHEN_MAGIC_ADDRESS:
-      value = t->current_trace_frame().time();
-      break;
-    case DBG_WHEN_TICKS_MAGIC_ADDRESS:
-      value = t->tick_count();
-      break;
-    case DBG_REAL_TID_MAGIC_ADDRESS:
-      value = t->tid;
-      break;
-    default:
-      return false;
-  }
-
-  if (req.mem().len != 8) {
-    return false;
-  }
-
-  vector<uint8_t> mem;
-  mem.resize(req.mem().len);
-  memcpy(mem.data(), &value, mem.size());
-  dbg->reply_get_mem(mem);
   return true;
 }
 
@@ -466,9 +418,6 @@ void GdbServer::dispatch_debugger_request(Session& session,
       return;
     }
     case DREQ_GET_MEM: {
-      if (maybe_process_magic_read(target, req)) {
-        return;
-      }
       vector<uint8_t> mem;
       mem.resize(req.mem().len);
       ssize_t nread = target->read_bytes_fallible(req.mem().addr, req.mem().len,
@@ -616,6 +565,9 @@ void GdbServer::dispatch_debugger_request(Session& session,
     case DREQ_WRITE_SIGINFO:
       LOG(warn) << "WRITE_SIGINFO request outside of diversion session";
       dbg->reply_write_siginfo();
+      return;
+    case DREQ_RR_CMD:
+      dbg->reply_rr_cmd(GdbCommandHandler::process_command(*this, target, req.text()));
       return;
     default:
       FATAL() << "Unknown debugger request " << req.type;

--- a/src/GdbServer.h
+++ b/src/GdbServer.h
@@ -15,6 +15,7 @@
 #include "TraceFrame.h"
 
 class GdbServer {
+  friend class GdbCommand;
 public:
   struct Target {
     Target() : pid(0), require_exec(false), event(0) {}
@@ -116,11 +117,6 @@ private:
    * Otherwise, do nothing and return false.
    */
   bool maybe_process_magic_command(const GdbRequest& req);
-  /**
-   * If |req| is a magic-read command, interpret it and return true.
-   * Otherwise, do nothing and return false.
-   */
-  bool maybe_process_magic_read(Task* t, const GdbRequest& req);
   void dispatch_regs_request(const Registers& regs,
                              const ExtraRegisters& extra_regs);
   enum ReportState { REPORT_NORMAL, REPORT_THREADS_DEAD };

--- a/src/test/when.py
+++ b/src/test/when.py
@@ -2,13 +2,13 @@ from rrutil import *
 import re
 
 send_gdb('when')
-expect_gdb(re.compile(r'= (\d+)'))
+expect_gdb(re.compile(r'Current event: (\d+)'))
 t = eval(last_match().group(1));
 if t < 1 or t > 10000:
     failed('ERROR in first "when"')
 
 send_gdb('when-ticks')
-expect_gdb(re.compile(r'= (\d+)'))
+expect_gdb(re.compile(r'Current tick: (\d+)'))
 ticks = eval(last_match().group(1));
 if ticks != 0:
     failed('ERROR in first "when-ticks"')
@@ -18,7 +18,9 @@ expect_gdb('Breakpoint 1')
 send_gdb('c')
 
 send_gdb('when')
-expect_gdb(re.compile(r'= (\d+)'))
+expect_gdb(re.compile(r'Current event: (\d+)'))
+with open("/tmp/out", "w") as text_file:
+    text_file.write(last_match().group(1))
 t2 = eval(last_match().group(1));
 if t2 < 1 or t2 > 10000:
     failed('ERROR in second "when"')
@@ -26,7 +28,7 @@ if t2 <= t:
     failed('ERROR ... "when" failed to advance')
 
 send_gdb('when-ticks')
-expect_gdb(re.compile(r'= (\d+)'))
+expect_gdb(re.compile(r'Current tick: (\d+)'))
 ticks2 = eval(last_match().group(1));
 if ticks2 < 0 or ticks2 > 100000:
     failed('ERROR in second "when-ticks"')


### PR DESCRIPTION
This pull request is adding more powerful commands to GDB to build more useful command.

Here's a starting proof of concept:
![Imgur](http://i.imgur.com/XMh1mO4.png)

This uses forks gdb-dashboard, which already shows a lot of relevant info (source, stack, threads, disassembly).

I've added RR Events which shows the RR event in the past and in the future. It also shows the previous and upcoming thread switch.

I'm not sure if exposing the low level RR Events is useful to users of RR but it's a step towards being able to expose better data when debugging.