### PR TITLE
Install the gdb packet on travis-ci

### DIFF
--- a/src/script/setup_travis.sh
+++ b/src/script/setup_travis.sh
@@ -7,7 +7,7 @@ echo The slave is `uname -a`
 
 packages=(linux-libc-dev linux-libc-dev:i386
 	  gcc-multilib libc6-dev:i386 rpm
-	  g++ lib32stdc++6
+	  g++ lib32stdc++6 gdb
 	  zlib1g:i386 zlib1g-dev:i386
 	  python-pexpect)
 


### PR DESCRIPTION
This should fix the travis-ci build that regressed with 0e3a9c9.