### PR TITLE
Add support for Skylake Y/U processor line

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -127,6 +127,7 @@ static CpuMicroarch get_cpu_microarch() {
     case 0x406F0:
     case 0x50660:
       return IntelBroadwell;
+    case 0x406e0:
     case 0x506e0:
       return IntelSkylake;
     default:


### PR DESCRIPTION
Support the CPUID processor signature for the Skylake Y/U processors,
which is the same as the Skylake H/S processor signature except for
bit 16 which is 1 for the H/S line and 0 for the Y/U line.

Relevant info is on page 13 of [6th gen specification update](http://www.intel.com/content/dam/www/public/us/en/documents/specification-updates/desktop-6th-gen-core-family-spec-update.pdf) or page 183 (row 2 of the table) of [the Intel dev manual](http://www.intel.com/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developers-manual.pdf).

Before this addition, rr would throw the fatal unknown cpu error on my Intel i5-6200u, now it works fine.