### PR TITLE
Fix compilation on 32bit linux.

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -175,9 +175,10 @@ inline static T& prepare_log_stream(T&& stream, LogLevel level,
  * Ensure that |_v| is streamed in hex format.
  * We make sure that signed types are *not* sign-extended.
  */
-inline void* HEX(uint64_t v) { return reinterpret_cast<void*>(v); }
-inline void* HEX(int64_t v) { return reinterpret_cast<void*>(v); }
-inline void* HEX(uint32_t v) { return reinterpret_cast<void*>(v); }
-inline void* HEX(int32_t v) { return reinterpret_cast<void*>(uint32_t(v)); }
+template<typename T> inline void *HEX(T v)
+{
+  return reinterpret_cast<void*>(
+    static_cast<typename std::make_unsigned<T>::type>(v));
+}
 
 #endif // RR_LOG_H

--- a/src/task.cc
+++ b/src/task.cc
@@ -1331,7 +1331,7 @@ const ExtraRegisters& Task::extra_regs() {
 
       extra_registers.format_ = ExtraRegisters::XSAVE;
       extra_registers.data_.resize(sizeof(user_fpxregs_struct));
-      xptrace(PTRACE_GETFPXREGS, nullptr, extra_registers.data_.data_());
+      xptrace(PTRACE_GETFPXREGS, nullptr, extra_registers.data_.data());
 #elif defined(__x86_64__)
       // x86-64 that doesn't support XSAVE; apparently Xeon E5620 (Westmere)
       // is in this class.
@@ -1571,7 +1571,7 @@ void Task::set_extra_regs(const ExtraRegisters& regs) {
       } else {
 #if defined(__i386__)
         ptrace_if_alive(PTRACE_SETFPXREGS, nullptr,
-                        extra_registers.data_.data_());
+                        extra_registers.data_.data());
 #elif defined(__x86_64__)
         ptrace_if_alive(PTRACE_SETFPREGS, nullptr,
                         extra_registers.data_.data());


### PR DESCRIPTION
* Typo when accessing `std::vector::data()`
* Implement `HEX()` as template

Ref https://github.com/mozilla/rr/issues/1666#issuecomment-193405431

Close #1666