### PR TITLE
Add missing <math.h> header

### DIFF
--- a/src/Scheduler.cc
+++ b/src/Scheduler.cc
@@ -5,6 +5,7 @@
 #include "Scheduler.h"
 
 #include <assert.h>
+#include <math.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Since Scheduler.cc uses maths functions (floor() etc.) it needs to
include math.h.

Signed-off-by: Stephen Kitt <steve@sk2.org>