### PR TITLE
Refactor syscall hooking

### DIFF
--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -334,7 +334,9 @@ static bool patch_syscall_with_hook_x86ish(Monkeypatcher& patcher,
                        sizeof(nops));
 
   // Now write out the stub
-  substitute<StubPatch>(stub_patch, jump_patch_end.as_int(),
+  substitute<StubPatch>(stub_patch, jump_patch_start.as_int() +
+                        syscall_instruction_length(x86_64) +
+                        hook.next_instruction_length,
                         trampoline_call_offset32);
   write_and_record_bytes(t, stub_patch_start, stub_patch);
 

--- a/src/Monkeypatcher.h
+++ b/src/Monkeypatcher.h
@@ -36,7 +36,7 @@ class Task;
  */
 class Monkeypatcher {
 public:
-  Monkeypatcher() : stub_buffer_allocated(0) {}
+  Monkeypatcher() {}
   Monkeypatcher(const Monkeypatcher&) = default;
 
   /**
@@ -66,8 +66,8 @@ public:
   void init_dynamic_syscall_patching(
       RecordTask* t, int syscall_patch_hook_count,
       remote_ptr<syscall_patch_hook> syscall_patch_hooks,
-      remote_ptr<void> stub_buffer, remote_ptr<void> stub_buffer_end,
-      remote_ptr<void> syscall_hook_trampoline);
+      remote_ptr<void> syscall_hook_trampoline,
+      remote_ptr<void> syscall_hook_end);
 
   /**
    * Try to allocate a stub from the sycall patching stub buffer. Returns null
@@ -99,7 +99,7 @@ public:
    * without affecting the syscall buffering logic. If not sure, return false.
    */
   bool is_syscallbuf_excluded_instruction(remote_ptr<void> p) {
-    return p >= syscall_hook_trampoline && p < stub_buffer_end;
+    return p >= syscall_hook_trampoline && p < syscall_hook_end;
   }
 
 private:
@@ -114,13 +114,10 @@ private:
    * (or are currently trying) to patch.
    */
   std::unordered_set<remote_code_ptr> tried_to_patch_syscall_addresses;
-  /**
-   * Writable executable memory where we can generate stubs.
-   */
-  remote_ptr<void> stub_buffer;
-  remote_ptr<void> stub_buffer_end;
+
+  // The addresses that contain our syscall hooks
   remote_ptr<void> syscall_hook_trampoline;
-  size_t stub_buffer_allocated;
+  remote_ptr<void> syscall_hook_end;
 };
 
 } // namespace rr

--- a/src/assembly_templates.py
+++ b/src/assembly_templates.py
@@ -94,10 +94,6 @@ templates = {
         RawBytes(0xc3),         # ret
     ),
     'X86SyscallStubExtendedJump': AssemblyTemplate(
-        RawBytes(0xe9), # jmp
-        Field('relative_jump_target', 4),
-    ),
-    'X86SyscallStubMonkeypatch': AssemblyTemplate(
         # This code must match the stubs in syscall_hook.S.
         # We must adjust the stack pointer without modifying flags,
         # at least on the return path.
@@ -106,7 +102,7 @@ templates = {
         Field('fake_return_addr', 4),
         RawBytes(0x89, 0x64, 0x24, 0x04),                   # mov %esp,4(%esp)
         RawBytes(0x81, 0x44, 0x24, 0x04, 0x00, 0x01, 0x00, 0x00), # addl $256,4(%esp)
-        RawBytes(0xe8),                                     # call $trampoline_relative_addr
+        RawBytes(0xe9),                                     # call $trampoline_relative_addr
         Field('trampoline_relative_addr', 4),
         RawBytes(0xc2, 0xfc, 0x00),                         # ret $252
     ),
@@ -128,10 +124,6 @@ templates = {
         RawBytes(0xc3),         # ret
     ),
     'X64SyscallStubExtendedJump': AssemblyTemplate(
-        RawBytes(0xff, 0x25, 0x00, 0x00, 0x00, 0x00), # jmp *0(%rip)
-        Field('jump_target', 8),
-    ),
-    'X64SyscallStubMonkeypatch': AssemblyTemplate(
         # This code must match the stubs in syscall_hook.S.
         RawBytes(0x48, 0x81, 0xec, 0x00, 0x01, 0x00, 0x00), # sub $256,%rsp
         RawBytes(0xc7, 0x04, 0x24),                         # movl $return_addr_lo,(%rsp)
@@ -140,9 +132,8 @@ templates = {
         Field('return_addr_hi', 4),
         RawBytes(0x48, 0x89, 0x64, 0x24, 0x08),             # mov %rsp,8(%rsp)
         RawBytes(0x48, 0x81, 0x44, 0x24, 0x08, 0x00, 0x01, 0x00, 0x00), # addq $256,8(%rsp)
-        RawBytes(0xe8),                                     # call $trampoline_relative_addr
-        Field('trampoline_relative_addr', 4),
-        RawBytes(0xc2, 0xf8, 0x00),                         # ret $248
+        RawBytes(0xff, 0x25, 0x00, 0x00, 0x00, 0x00), # jmp *0(%rip)
+        Field('jump_target', 8),
     ),
 }
 

--- a/src/preload/preload.c
+++ b/src/preload/preload.c
@@ -610,8 +610,7 @@ extern char _breakpoint_table_entry_end;
 static void __attribute__((constructor)) init_process(void) {
   struct rrcall_init_preload_params params;
   extern RR_HIDDEN void _syscall_hook_trampoline(void);
-  extern RR_HIDDEN void _stub_buffer(void);
-  extern RR_HIDDEN void _stub_buffer_end(void);
+  extern RR_HIDDEN void _syscall_hook_end(void);
 
 #if defined(__i386__)
   extern RR_HIDDEN void _syscall_hook_trampoline_3d_01_f0_ff_ff(void);
@@ -681,8 +680,7 @@ static void __attribute__((constructor)) init_process(void) {
   params.syscallbuf_fds_disabled =
       buffer_enabled ? syscallbuf_fds_disabled : NULL;
   params.syscall_hook_trampoline = (void*)_syscall_hook_trampoline;
-  params.syscall_hook_stub_buffer = (void*)_stub_buffer;
-  params.syscall_hook_stub_buffer_end = (void*)_stub_buffer_end;
+  params.syscall_hook_end = (void*)_syscall_hook_end;
   params.syscall_patch_hook_count =
       sizeof(syscall_patch_hooks) / sizeof(syscall_patch_hooks[0]);
   params.syscall_patch_hooks = syscall_patch_hooks;

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -159,8 +159,7 @@ struct rrcall_init_preload_params {
   int syscall_patch_hook_count;
   PTR(struct syscall_patch_hook) syscall_patch_hooks;
   PTR(void) syscall_hook_trampoline;
-  PTR(void) syscall_hook_stub_buffer;
-  PTR(void) syscall_hook_stub_buffer_end;
+  PTR(void) syscall_hook_end;
   /* Array of size SYSCALLBUF_FDS_DISABLED_SIZE */
   PTR(volatile char) syscallbuf_fds_disabled;
   PTR(struct mprotect_record) mprotect_records;

--- a/src/preload/syscall_hook.S
+++ b/src/preload/syscall_hook.S
@@ -244,63 +244,42 @@ _syscall_hook_trampoline:
         .cfi_endproc
         .size _syscall_hook_trampoline, . - _syscall_hook_trampoline
 
+#define SYSCALLHOOK_START(name) \
+        .global name;           \
+        .hidden name;           \
+        .type name, @function;  \
+name:                           \
+        .cfi_startproc;         \
+        .cfi_offset %rip, 0;    \
+        .cfi_offset %rsp, 8;
+
+#define SYSCALLHOOK_END(name)   \
+        ret;                    \
+        .cfi_endproc;           \
+        .size name, .-name
 
 
-        .global _syscall_hook_trampoline_48_3d_01_f0_ff_ff
-        .hidden _syscall_hook_trampoline_48_3d_01_f0_ff_ff
-        .type _syscall_hook_trampoline_48_3d_01_f0_ff_ff, @function
-_syscall_hook_trampoline_48_3d_01_f0_ff_ff:
-        .cfi_startproc
-
+SYSCALLHOOK_START(_syscall_hook_trampoline_48_3d_01_f0_ff_ff)
         callq _syscall_hook_trampoline
         cmpq $0xfffffffffffff001,%rax
-        ret
+SYSCALLHOOK_END(_syscall_hook_trampoline_48_3d_01_f0_ff_ff)
 
-        .cfi_endproc
-        .size _syscall_hook_trampoline_48_3d_01_f0_ff_ff, .-_syscall_hook_trampoline_48_3d_01_f0_ff_ff
-
-
-
-        .global _syscall_hook_trampoline_48_3d_00_f0_ff_ff
-        .hidden _syscall_hook_trampoline_48_3d_00_f0_ff_ff
-        .type _syscall_hook_trampoline_48_3d_00_f0_ff_ff, @function
-_syscall_hook_trampoline_48_3d_00_f0_ff_ff:
-        .cfi_startproc
-
+SYSCALLHOOK_START(_syscall_hook_trampoline_48_3d_00_f0_ff_ff)
         callq _syscall_hook_trampoline
         cmpq $0xfffffffffffff000,%rax
-        ret
+SYSCALLHOOK_END(_syscall_hook_trampoline_48_3d_00_f0_ff_ff)
 
-        .cfi_endproc
-        .size _syscall_hook_trampoline_48_3d_00_f0_ff_ff, .-_syscall_hook_trampoline_48_3d_00_f0_ff_ff
-
-
-
-        .global _syscall_hook_trampoline_48_8b_3c_24
-        .hidden _syscall_hook_trampoline_48_8b_3c_24
-        .type _syscall_hook_trampoline_48_8b_3c_24, @function
-_syscall_hook_trampoline_48_8b_3c_24:
-        .cfi_startproc
-
-        callq _syscall_hook_trampoline
-        /* The original instruction after the syscall is movq (%rsp),%rdi.
-           Because we pushed a return address and shifted RSP down
-           before reaching this point, to get the equivalent behavior we
-           need to use this offset. */
-        movq (8 + _syscall_stack_adjust)(%rsp),%rdi
-        ret
-
-        .cfi_endproc
-        .size _syscall_hook_trampoline_48_8b_3c_24, .-_syscall_hook_trampoline_48_8b_3c_24
+SYSCALLHOOK_START(_syscall_hook_trampoline_48_8b_3c_24)
+         callq _syscall_hook_trampoline
+         /* The original instruction after the syscall is movq (%rsp),%rdi.
+            Because we pushed a return address and shifted RSP down
+            before reaching this point, to get the equivalent behavior we
+            need to use this offset. */
+         movq (8 + _syscall_stack_adjust)(%rsp),%rdi
+SYSCALLHOOK_END(_syscall_hook_trampoline_48_8b_3c_24)
 
 
-
-        .global _syscall_hook_trampoline_5a_5e_c3
-        .hidden _syscall_hook_trampoline_5a_5e_c3
-        .type _syscall_hook_trampoline_5a_5e_c3, @function
-_syscall_hook_trampoline_5a_5e_c3:
-        .cfi_startproc
-
+SYSCALLHOOK_START(_syscall_hook_trampoline_5a_5e_c3)
         callq _syscall_hook_trampoline
         /* The original instructions after the syscall are
            pop %rdx; pop %rsi; retq. */
@@ -316,34 +295,15 @@ _syscall_hook_trampoline_5a_5e_c3:
         .size _syscall_hook_trampoline_5a_5e_c3, .-_syscall_hook_trampoline_5a_5e_c3
 
 
-
-        .global _syscall_hook_trampoline_89_c2_f7_da
-        .hidden _syscall_hook_trampoline_89_c2_f7_da
-        .type _syscall_hook_trampoline_89_c2_f7_da, @function
-_syscall_hook_trampoline_89_c2_f7_da:
-        .cfi_startproc
-
+SYSCALLHOOK_START(_syscall_hook_trampoline_89_c2_f7_da)
         call _syscall_hook_trampoline
         mov %eax,%edx
         neg %edx
-        ret
+SYSCALLHOOK_END(_syscall_hook_trampoline_89_c2_f7_da)
 
-        .cfi_endproc
-        .size _syscall_hook_trampoline_89_c2_f7_da, .-_syscall_hook_trampoline_89_c2_f7_da
-
-
-
-        .global _syscall_hook_trampoline_90_90_90
-        .hidden _syscall_hook_trampoline_90_90_90
-        .type _syscall_hook_trampoline_90_90_90, @function
-_syscall_hook_trampoline_90_90_90:
-        .cfi_startproc
-
-        jmp _syscall_hook_trampoline
-
-        .cfi_endproc
-        .size _syscall_hook_trampoline_90_90_90, .-_syscall_hook_trampoline_90_90_90
-
+SYSCALLHOOK_START(_syscall_hook_trampoline_90_90_90)
+        call _syscall_hook_trampoline
+SYSCALLHOOK_END(_syscall_hook_trampoline_90_90_90)
 
 _stub_buffer:
         .rept 1000

--- a/src/preload/syscall_hook.S
+++ b/src/preload/syscall_hook.S
@@ -6,17 +6,15 @@
         .set _stack_pad_size,2048
 
         /* _syscall_hook_trampoline must be the first instruction defined
-           in this file, and _stub_buffer_end must be at the end of the last
+           in this file, and _syscall_hook_end must be at the end of the last
            instruction. */
 
         .global _syscall_hook_trampoline
         .hidden _syscall_hook_trampoline
         .type _syscall_hook_trampoline, @function
 
-        .global _stub_buffer
-        .hidden _stub_buffer
-        .global _stub_buffer_end
-        .hidden _stub_buffer_end
+        .global _syscall_hook_end
+        .hidden _syscall_hook_end
 
 #if defined(__i386__)
 /**
@@ -104,72 +102,31 @@ _syscall_hook_trampoline:
         .cfi_endproc
         .size _syscall_hook_trampoline, .-_syscall_hook_trampoline
 
+#define SYSCALLHOOK_START(name) \
+       .global name;           \
+       .hidden name;           \
+       .type name, @function;  \
+name:                           \
+       .cfi_startproc;         \
+       .cfi_def_cfa_offset 0   \
+       .cfi_offset %eip, 0;    \
+       .cfi_offset %esp, 4;
 
+#define SYSCALLHOOK_END(name)         \
+       ret $_syscall_stack_adjust-4;  \
+       .cfi_endproc;                  \
+       .size name, .-name
 
-        .global _syscall_hook_trampoline_3d_01_f0_ff_ff
-        .hidden _syscall_hook_trampoline_3d_01_f0_ff_ff
-        .type _syscall_hook_trampoline_3d_01_f0_ff_ff, @function
-_syscall_hook_trampoline_3d_01_f0_ff_ff:
-        .cfi_startproc
-
+SYSCALLHOOK_START(_syscall_hook_trampoline_3d_01_f0_ff_ff)
         call _syscall_hook_trampoline
         cmpl $0xfffff001,%eax
-        ret
+SYSCALLHOOK_END(_syscall_hook_trampoline_3d_01_f0_ff_ff)
 
-        .cfi_endproc
-        .size _syscall_hook_trampoline_3d_01_f0_ff_ff, .-_syscall_hook_trampoline_3d_01_f0_ff_ff
+SYSCALLHOOK_START(_syscall_hook_trampoline_90_90_90)
+        call _syscall_hook_trampoline
+SYSCALLHOOK_END(_syscall_hook_trampoline_90_90_90)
 
-
-
-        .global _syscall_hook_trampoline_90_90_90
-        .hidden _syscall_hook_trampoline_90_90_90
-        .type _syscall_hook_trampoline_90_90_90, @function
-_syscall_hook_trampoline_90_90_90:
-        .cfi_startproc
-
-        jmp _syscall_hook_trampoline
-
-        .cfi_endproc
-        .size _syscall_hook_trampoline_90_90_90, .-_syscall_hook_trampoline_90_90_90
-
-
-
-_stub_buffer:
-        .rept 1000
-        /* Must match X86SyscallStubMonkeypatch. We reproduce it here so we
-           can build the correct CFI unwinding info, so gdb gives good stack
-           traces from inside the syscall hook code. */
-        .cfi_startproc
-        /* Adjust %rsp first to ensure that x86-64 redzone is respected. If
-           we store directly to -_syscall_stack_adjust(%rsp) values can be
-           overwritten if a signal arrives and the kernel allocates a user
-           handler signal frame there. */
-        sub    $_syscall_stack_adjust,%esp
-        /* Backtrace here will be invalid! */
-        movl   $0x12345678,(%esp)
-        /* Backtrace here will be invalid! */
-        mov    %esp,4(%esp)
-        /* Backtrace here will be invalid! */
-        addl   $_syscall_stack_adjust,4(%esp)
-        .cfi_rel_offset %esp,4
-        /* We won't be able to get complete stack traces inside the above
-           sequence, but that's not important. What's important is that at this
-           point:
-           * (%esp) contains a "return address" for this stub that points
-             back to the patch site.
-           * (%esp+4) contains the value of %esp that will hold at the
-             patch site, and we've emitted CFI data to indicate that.
-           This makes gdb treat the patch site as the caller of this stub,
-           even though no call actually happened. */
-        call  _stub_buffer /* FAKE, filled in by rr */
-        /* Avoid modifying flags on the return path, though it's unclear
-           whether this is really necessary. */
-        /* A backtrace here will be valid since for unwinding purposes we're
-           basically in the same state as before the call. */
-        ret    $_syscall_stack_adjust-4
-        .cfi_endproc
-        .endr
-_stub_buffer_end:
+_syscall_hook_end:
 
 #elif defined(__x86_64__)
         .text
@@ -250,12 +207,13 @@ _syscall_hook_trampoline:
         .type name, @function;  \
 name:                           \
         .cfi_startproc;         \
+        .cfi_def_cfa_offset 0   \
         .cfi_offset %rip, 0;    \
         .cfi_offset %rsp, 8;
 
-#define SYSCALLHOOK_END(name)   \
-        ret;                    \
-        .cfi_endproc;           \
+#define SYSCALLHOOK_END(name)          \
+        ret $_syscall_stack_adjust-8;  \
+        .cfi_endproc;                  \
         .size name, .-name
 
 
@@ -275,7 +233,7 @@ SYSCALLHOOK_START(_syscall_hook_trampoline_48_8b_3c_24)
             Because we pushed a return address and shifted RSP down
             before reaching this point, to get the equivalent behavior we
             need to use this offset. */
-         movq (8 + _syscall_stack_adjust)(%rsp),%rdi
+         movq _syscall_stack_adjust(%rsp),%rdi
 SYSCALLHOOK_END(_syscall_hook_trampoline_48_8b_3c_24)
 
 
@@ -283,7 +241,6 @@ SYSCALLHOOK_START(_syscall_hook_trampoline_5a_5e_c3)
         callq _syscall_hook_trampoline
         /* The original instructions after the syscall are
            pop %rdx; pop %rsi; retq. */
-        pop %rdx /* Return address, ignored */
         /* We're not returning to the dynamically generated stub, so
            we need to fix the stack pointer ourselves. */
         add $_syscall_stack_adjust,%rsp
@@ -305,50 +262,7 @@ SYSCALLHOOK_START(_syscall_hook_trampoline_90_90_90)
         call _syscall_hook_trampoline
 SYSCALLHOOK_END(_syscall_hook_trampoline_90_90_90)
 
-_stub_buffer:
-        .rept 1000
-        /* Must match X64SyscallStubMonkeypatch. We reproduce it here so we
-           can build the correct CFI unwinding info, so gdb gives good stack
-           traces from inside the syscall hook code. */
-        .cfi_startproc
-        /* Save fake return address and old sp to the stack, for gdb to use
-           during stack unwinding. Addresses will be filled in by rr.
-           _syscall_stack_adjust is greater than the x86-64 redzone,
-           avoiding overwriting below-RSP locals of leaf functions that call
-           syscalls. */
-        /* Adjust %rsp first to ensure that x86-64 redzone is respected. If
-           we store directly to -_syscall_stack_adjust(%rsp) values can be
-           overwritten if a signal arrives and the kernel allocates a user
-           handler signal frame there. */
-        sub    $_syscall_stack_adjust,%rsp
-        /* Backtrace here will be invalid! */
-        movl   $0x12345678,(%rsp)
-        /* Backtrace here will be invalid! */
-        movl   $0x12345678,4(%rsp)
-        /* Backtrace here will be invalid! */
-        mov    %rsp,8(%rsp)
-        /* Backtrace here will be invalid! */
-        addq   $_syscall_stack_adjust,8(%rsp)
-        /* Backtrace here will be invalid! */
-        .cfi_rel_offset %rsp,8
-        /* We won't be able to get complete stack traces inside the above
-           sequence, but that's not important. What's important is that at this
-           point:
-           * (%rsp) contains a "return address" for this stub that points
-             back to the patch site.
-           * (%rsp+8) contains the value of %rsp that will hold at the
-             patch site, and we've emitted CFI data to indicate that.
-           This makes gdb treat the patch site as the caller of this stub,
-           even though no call actually happened. */
-        call   _stub_buffer /* FAKE, filled in by rr */
-        /* Avoid modifying flags on the return path, though it's unclear
-           whether this is really necessary. */
-        /* A backtrace here will be valid since for unwinding purposes we're
-           basically in the same state as before the call. */
-        ret    $_syscall_stack_adjust-8
-        .cfi_endproc
-        .endr
-_stub_buffer_end:
+_syscall_hook_end:
 
 #endif /* __x86_64__ */
 


### PR DESCRIPTION
Without this, the preload library had a collection of pre-layed-out stubs
to which it added CFI, which would then be overwritten by rr once it knew
the actual addresses it needed. However, in addition to this, we also needed
"extender pages" which are within 2GB of the patches callsite in order to
make use of a relative jmp. This commit removes one layer of indirection
by merging the stubcode into the extender page and using CFI in the actual
syscall hook to ensure that backtraces are still correct.

I feel a little bad for proposing to remove the stub_buffer code since it's incredibly
clever, but I do feel the resulting simplification is worth it.

Tested on x86_64 by running an application, verifying that replay works correctly and
that gdb still has backtraces when stopped in. I also started running the test suite, but
for some reason the server I'm using for rr development has absolutely abysmal single-core
performance, so running the test suite takes forever.