### PR TITLE
Don't clear syscall breakpoint after INCOMPLETE

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -1394,6 +1394,8 @@ void AddressSpace::coalesce_around(MemoryMap::iterator it) {
 }
 
 void AddressSpace::destroy_breakpoint(BreakpointMap::const_iterator it) {
+  if (task_set().empty())
+    return;
   Task* t = *task_set().begin();
   t->write_mem(it->first.to_data_ptr<uint8_t>(), it->second.overwritten_data);
   breakpoints.erase(it);

--- a/src/ReplaySession.h
+++ b/src/ReplaySession.h
@@ -327,6 +327,8 @@ private:
                                       const StepConstraints& constraints,
                                       BreakStatus& break_status);
 
+  void clear_syscall_bp();
+
   std::shared_ptr<EmuFs> emu_fs;
   TraceReader trace_in;
   TraceFrame trace_frame;
@@ -335,6 +337,9 @@ private:
   CPUIDBugDetector cpuid_bug_detector;
   Flags flags;
   bool did_fast_forward;
+
+  std::shared_ptr<AddressSpace> syscall_bp_vm;
+  remote_code_ptr syscall_bp_addr;
 };
 
 } // namespace rr

--- a/src/ReplayTimeline.h
+++ b/src/ReplayTimeline.h
@@ -349,6 +349,9 @@ private:
    */
   void unapply_breakpoints_and_watchpoints();
 
+  void apply_breakpoints_internal();
+  void unapply_breakpoints_internal();
+
   static MarkKey session_mark_key(ReplaySession& session) {
     ReplayTask* t = session.current_task();
     return MarkKey(session.trace_reader().time(), t ? t->tick_count() : 0,


### PR DESCRIPTION
This is a performance microoptimization. In a pathological case
(lots of breakpoints before the syscall is reached), this gave
about a 20% replay performance improvement.

Also cc @carnaval, who has been looking at a very similar benchmark.