### PR TITLE
Provide an API to create tracee-shared memory mappings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,7 +484,6 @@ set(BASIC_TESTS
   mmap_short_file
   mmap_tmpfs
   mprotect
-  mprotect_growsdown
   mprotect_heterogenous
   mprotect_none
   mprotect_stack
@@ -700,6 +699,7 @@ set(TESTS_WITH_PROGRAM
   main_thread_exit
   mmap_shared_prot
   mmap_write
+  mprotect_growsdown
   mprotect_syscallbuf_overflow
   mutex_pi_stress
   priority

--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -563,6 +563,11 @@ const AddressSpace::Mapping& AddressSpace::mapping_of(
   assert(it->second.map.contains(range));
   return it->second;
 }
+uint32_t& AddressSpace::mapping_flags_of(remote_ptr<void> addr) {
+  return const_cast<AddressSpace::Mapping&>(
+             static_cast<const AddressSpace*>(this)->mapping_of(addr))
+      .flags;
+}
 
 bool AddressSpace::has_mapping(remote_ptr<void> addr) const {
   if (addr + page_size() < addr) {
@@ -688,7 +693,7 @@ void AddressSpace::remap(remote_ptr<void> old_addr, size_t old_num_bytes,
   remote_ptr<void> new_end = new_addr + new_num_bytes;
   map_and_coalesce(m.set_range(new_addr, new_end),
                    mr.recorded_map.set_range(new_addr, new_end), mr.emu_file,
-                   mr.local_addr);
+                   nullptr);
 }
 
 void AddressSpace::remove_breakpoint(remote_code_ptr addr,
@@ -896,15 +901,6 @@ void AddressSpace::unmap_internal(remote_ptr<void> addr, ssize_t num_bytes) {
 
     Mapping m = move(mm);
     mem.erase(m.map);
-
-    // Also unmap any corresponding mapping from the local address space
-    if (m.local_addr) {
-      uint8_t* start_addr =
-          m.local_addr + (max(m.map.start(), rem.start()) - m.map.start());
-      uint8_t* stop_addr =
-          m.local_addr + (min(m.map.end(), rem.end()) - m.map.end());
-      munmap(start_addr, stop_addr - start_addr);
-    }
 
     LOG(debug) << "  erased (" << m.map << ") ...";
 
@@ -1381,6 +1377,7 @@ bool AddressSpace::allocate_watchpoints() {
 static inline void assert_coalesceable(const AddressSpace::Mapping& lower,
                                        const AddressSpace::Mapping& higher) {
   assert(lower.emu_file == higher.emu_file);
+  assert(lower.flags == higher.flags);
   assert((lower.local_addr == 0 && higher.local_addr == 0) ||
          lower.local_addr + lower.map.size() == higher.local_addr);
 }
@@ -1418,6 +1415,7 @@ void AddressSpace::coalesce_around(MemoryMap::iterator it) {
   Mapping new_m(first_kv->second.map.extend(last_kv->first.end()),
                 first_kv->second.recorded_map.extend(last_kv->first.end()),
                 first_kv->second.emu_file, first_kv->second.local_addr);
+  new_m.flags = first_kv->second.flags;
   LOG(debug) << "  coalescing " << new_m.map;
 
   mem.erase(first_kv, ++last_kv);
@@ -1608,6 +1606,27 @@ remote_ptr<void> AddressSpace::chaos_mode_find_free_memory(Task* t,
       addr = range.end();
     }
   }
+}
+
+remote_ptr<void> AddressSpace::find_free_memory(size_t required_space,
+                                                remote_ptr<void> after) {
+  auto maps = maps_starting_at(after);
+  auto current = maps.begin();
+  while (current != maps.end()) {
+    auto next = current;
+    ++next;
+    if (next == maps.end()) {
+      if (current->map.end() + required_space >= current->map.end()) {
+        break;
+      }
+    } else {
+      if (current->map.end() + required_space <= next->map.start()) {
+        break;
+      }
+    }
+    current = next;
+  }
+  return current->map.end();
 }
 
 } // namespace rr

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -233,7 +233,8 @@ public:
         : map(map),
           recorded_map(recorded_map),
           emu_file(emu_file),
-          local_addr(static_cast<uint8_t*>(local_addr)) {}
+          local_addr(static_cast<uint8_t*>(local_addr)),
+          flags(FLAG_NONE) {}
     Mapping(const Mapping&) = default;
     Mapping() = default;
     const Mapping& operator=(const Mapping& other) {
@@ -254,6 +255,16 @@ public:
     // responsibility to keep this alive at least as long as this mapping is
     // present in the address space.
     uint8_t* local_addr;
+    // Flags indicate mappings that require special handling. Adjacent mappings
+    // may only be merged if their `flags` value agree.
+    enum : uint32_t {
+      FLAG_NONE = 0x0,
+      // This mapping represents a syscallbuf. It needs to handled specially
+      // during checksumming since its contents are not fully restored by the
+      // replay.
+      IS_SYSCALLBUF = 0x1
+    };
+    uint32_t flags;
   };
 
   typedef std::map<MemoryRange, Mapping, MappingComparator> MemoryMap;
@@ -379,6 +390,12 @@ public:
    * There must be such a mapping.
    */
   const Mapping& mapping_of(remote_ptr<void> addr) const;
+
+  /**
+   * Return a reference to the flags of the mapping at this address, allowing
+   * manipulation. There must exist a mapping at `addr`.
+   */
+  uint32_t& mapping_flags_of(remote_ptr<void> addr);
 
   /**
    * Return true if there is some mapping for the byte at 'addr'.
@@ -664,6 +681,8 @@ public:
   static uint32_t chaos_mode_min_stack_size() { return 8 * 1024 * 1024; }
 
   remote_ptr<void> chaos_mode_find_free_memory(Task* t, size_t len);
+  remote_ptr<void> find_free_memory(
+      size_t len, remote_ptr<void> after = remote_ptr<void>());
 
   PropertyTable& properties() { return properties_; }
 

--- a/src/DiversionSession.cc
+++ b/src/DiversionSession.cc
@@ -115,9 +115,9 @@ DiversionSession::DiversionResult DiversionSession::diversion_step(
     return result;
   }
 
-  if (t->syscallbuf_hdr) {
+  if (t->syscallbuf_child) {
     // Disable syscall buffering during diversions
-    t->syscallbuf_hdr->locked = 1;
+    t->write_mem(REMOTE_PTR_FIELD(t->syscallbuf_child, locked), (uint8_t)1);
   }
 
   switch (command) {

--- a/src/Event.h
+++ b/src/Event.h
@@ -142,14 +142,15 @@ struct BaseEvent {
  */
 struct DeschedEvent : public BaseEvent {
   /** Desched of |rec|. */
-  DeschedEvent(const struct syscallbuf_record* rec, SupportedArch arch)
+  DeschedEvent(remote_ptr<const struct syscallbuf_record> rec,
+               SupportedArch arch)
       : BaseEvent(NO_EXEC_INFO, arch), rec(rec) {}
   // Record of the syscall that was interrupted by a desched
   // notification.  It's legal to reference this memory /while
   // the desched is being processed only/, because |t| is in the
   // middle of a desched, which means it's successfully
   // allocated (but not yet committed) this syscall record.
-  const struct syscallbuf_record* rec;
+  remote_ptr<const struct syscallbuf_record> rec;
 };
 
 /**
@@ -270,7 +271,7 @@ struct SyscallEvent : public BaseEvent {
   Registers regs;
   // If this is a descheduled buffered syscall, points at the
   // record for that syscall.
-  const struct syscallbuf_record* desched_rec;
+  remote_ptr<const struct syscallbuf_record> desched_rec;
 
   SyscallState state;
   // Syscall number.

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1071,7 +1071,7 @@ bool RecordTask::maybe_in_spinlock() {
          regs().matches(registers_at_start_of_last_timeslice);
 }
 
-const struct syscallbuf_record* RecordTask::desched_rec() const {
+remote_ptr<const struct syscallbuf_record> RecordTask::desched_rec() const {
   return (ev().is_syscall_event()
               ? ev().Syscall().desched_rec
               : (EV_DESCHED == ev().type()) ? ev().Desched().rec : nullptr);
@@ -1196,7 +1196,7 @@ void RecordTask::maybe_flush_syscallbuf() {
     // Already flushing.
     return;
   }
-  if (!syscallbuf_hdr) {
+  if (!syscallbuf_child) {
     return;
   }
 
@@ -1205,7 +1205,7 @@ void RecordTask::maybe_flush_syscallbuf() {
   // modifying the header. We'll take a snapshot of the header now.
   // The syscallbuf code ensures that writes to syscallbuf records
   // complete before num_rec_bytes is incremented.
-  struct syscallbuf_hdr hdr = *syscallbuf_hdr;
+  struct syscallbuf_hdr hdr = read_mem(syscallbuf_child);
 
   ASSERT(this,
          !flushed_syscallbuf || flushed_num_rec_bytes == hdr.num_rec_bytes);
@@ -1232,10 +1232,11 @@ void RecordTask::maybe_flush_syscallbuf() {
     vector<uint8_t> buf;
     buf.resize(sizeof(hdr) + hdr.num_rec_bytes);
     memcpy(buf.data(), &hdr, sizeof(hdr));
-    memcpy(buf.data() + sizeof(hdr), syscallbuf_hdr + 1, hdr.num_rec_bytes);
+    read_bytes_helper(syscallbuf_child + 1, hdr.num_rec_bytes,
+                      buf.data() + sizeof(hdr));
     record_local(syscallbuf_child, buf.size(), buf.data());
   } else {
-    record_local(syscallbuf_child, syscallbuf_data_size(), syscallbuf_hdr);
+    record_remote(syscallbuf_child, syscallbuf_data_size());
   }
   record_current_event();
   pop_event(EV_SYSCALLBUF_FLUSH);

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -286,7 +286,7 @@ public:
    * Exists just so that clients don't need to dig around in the
    * event stack to find this record.
    */
-  const struct syscallbuf_record* desched_rec() const;
+  remote_ptr<const struct syscallbuf_record> desched_rec() const;
   /**
    * Returns true when the task is in a signal handler in an interrupted
    * system call being handled by syscall buffering.

--- a/src/ReplaySession.h
+++ b/src/ReplaySession.h
@@ -270,11 +270,13 @@ public:
   static bool is_ignored_signal(int sig);
 
   struct Flags {
-    Flags() : redirect_stdio(false) {}
+    Flags() : redirect_stdio(false), share_private_mappings(false) {}
     Flags(const Flags& other) = default;
     bool redirect_stdio;
+    bool share_private_mappings;
   };
   bool redirect_stdio() { return flags.redirect_stdio; }
+  bool share_private_mappings() { return flags.share_private_mappings; }
 
   void set_flags(const Flags& flags) { this->flags = flags; }
 

--- a/src/Session.h
+++ b/src/Session.h
@@ -24,6 +24,7 @@ class ReplaySession;
 class ReplayTask;
 class Task;
 class TaskGroup;
+class AutoRemoteSyscalls;
 
 // The following types are used by step() APIs in Session subclasses.
 
@@ -226,6 +227,14 @@ public:
 
   std::string read_spawned_task_error() const;
 
+  static KernelMapping create_shared_mmap(
+      AutoRemoteSyscalls& remote, size_t size, remote_ptr<void> map_hint,
+      const char* name, int tracee_prot = PROT_READ | PROT_WRITE,
+      int trace_flags = 0);
+
+  static bool make_private_shared(AutoRemoteSyscalls& remote,
+                                  const AddressSpace::Mapping m);
+
 protected:
   Session();
   virtual ~Session();
@@ -247,6 +256,9 @@ protected:
   // of tasks (i.e., almost anything!). Not really const!
   void finish_initializing() const;
   void assert_fully_initialized() const;
+
+  void recreate_shared_mmap(AutoRemoteSyscalls& remote,
+                            const AddressSpace::Mapping& m);
 
   AddressSpaceMap vm_map;
   TaskMap task_map;

--- a/src/Session.h
+++ b/src/Session.h
@@ -234,6 +234,8 @@ public:
 
   static bool make_private_shared(AutoRemoteSyscalls& remote,
                                   const AddressSpace::Mapping m);
+  static const AddressSpace::Mapping& recreate_shared_mmap(
+      AutoRemoteSyscalls& remote, const AddressSpace::Mapping& m);
 
 protected:
   Session();
@@ -256,9 +258,6 @@ protected:
   // of tasks (i.e., almost anything!). Not really const!
   void finish_initializing() const;
   void assert_fully_initialized() const;
-
-  void recreate_shared_mmap(AutoRemoteSyscalls& remote,
-                            const AddressSpace::Mapping& m);
 
   AddressSpaceMap vm_map;
   TaskMap task_map;

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -70,7 +70,6 @@ Task::Task(Session& session, pid_t _tid, pid_t _rec_tid, uint32_t serial,
       hpc(_tid),
       tid(_tid),
       rec_tid(_rec_tid > 0 ? _rec_tid : _tid),
-      syscallbuf_hdr(),
       syscallbuf_size(0),
       num_syscallbuf_bytes(0),
       stopping_breakpoint_table_entry_size(0),
@@ -117,8 +116,6 @@ Task::~Task() {
       }
     }
   }
-
-  destroy_local_buffers();
 
   session().on_destroy(this);
   tg->erase_task(this);
@@ -227,9 +224,12 @@ void Task::destroy_buffers() {
                             scratch_size);
   vm()->unmap(scratch_ptr, scratch_size);
   if (!syscallbuf_child.is_null()) {
+    uint8_t *local_mapping = vm()->mapping_of(syscallbuf_child).local_addr;
     remote.infallible_syscall(syscall_number_for_munmap(arch()),
                               syscallbuf_child, num_syscallbuf_bytes);
     vm()->unmap(syscallbuf_child, num_syscallbuf_bytes);
+    munmap(local_mapping, num_syscallbuf_bytes);
+    syscallbuf_child = nullptr;
     if (desched_fd_child >= 0) {
       if (session().is_recording()) {
         remote.infallible_syscall(syscall_number_for_close(arch()),
@@ -1575,18 +1575,6 @@ Task::CapturedState Task::capture_state() {
           : 0;
   state.syscallbuf_child = syscallbuf_child;
   state.syscallbuf_size = syscallbuf_size;
-  if (syscallbuf_hdr) {
-    size_t data_size = syscallbuf_data_size();
-    if (syscallbuf_hdr->locked) {
-      // There may be an incomplete syscall record after num_rec_bytes that
-      // we need to capture here. We don't know how big that record is,
-      // so just record the entire buffer. This should not be common.
-      data_size = num_syscallbuf_bytes;
-    }
-    state.syscallbuf_hdr.resize(data_size);
-    memcpy(state.syscallbuf_hdr.data(), syscallbuf_hdr,
-           state.syscallbuf_hdr.size());
-  }
   state.preload_globals = preload_globals;
   state.scratch_ptr = scratch_ptr;
   state.scratch_size = scratch_size;
@@ -1628,17 +1616,7 @@ void Task::copy_state(const CapturedState& state) {
         remote.infallible_lseek_syscall(
             cloned_file_data_fd_child, state.cloned_file_data_offset, SEEK_SET);
       }
-
-      // The syscallbuf is mapped as a shared
-      // segment between rr and the tracee.  So we
-      // have to unmap it, create a copy, and then
-      // re-map the copy in rr and the tracee.
-      init_syscall_buffer(remote, state.syscallbuf_child);
-      ASSERT(this, state.syscallbuf_child == syscallbuf_child);
-      // Ensure the copied syscallbuf has the same contents
-      // as the old one, for consistency checking.
-      memcpy(syscallbuf_hdr, state.syscallbuf_hdr.data(),
-             state.syscallbuf_hdr.size());
+      syscallbuf_child = state.syscallbuf_child;
     }
   }
   preload_globals = state.preload_globals;
@@ -1658,8 +1636,15 @@ void Task::copy_state(const CapturedState& state) {
   thread_locals_initialized = state.thread_locals_initialized;
 }
 
-void Task::destroy_local_buffers() {
-  munmap(syscallbuf_hdr, num_syscallbuf_bytes);
+remote_ptr<const struct syscallbuf_record> Task::next_syscallbuf_record() {
+  return ((syscallbuf_child + 1).cast<uint8_t>() +
+          read_mem(REMOTE_PTR_FIELD(syscallbuf_child, num_rec_bytes)))
+      .cast<const struct syscallbuf_record>();
+}
+
+long Task::stored_record_size(
+    remote_ptr<const struct syscallbuf_record> record) {
+  return ::stored_record_size(read_mem(REMOTE_PTR_FIELD(record, size)));
 }
 
 long Task::fallible_ptrace(int request, remote_ptr<void> addr, void* data) {
@@ -1709,72 +1694,39 @@ void Task::open_mem_fd_if_needed() {
 
 KernelMapping Task::init_syscall_buffer(AutoRemoteSyscalls& remote,
                                         remote_ptr<void> map_hint) {
-  static int nonce = 0;
-  // Create the segment we'll share with the tracee.
-  char path[PATH_MAX];
-  snprintf(path, sizeof(path) - 1, SYSCALLBUF_SHMEM_PATH_PREFIX "%d-%d", tid,
-           nonce++);
-
-  // Let the child create the shmem block and then send the fd back to us.
-  // This lets us avoid having to make the file world-writeable so that
-  // the child can read it when it's in a different user namespace (which
-  // would be a security hole, letting other users abuse rr users).
-  int child_shmem_fd;
-  {
-    AutoRestoreMem child_path(remote, path);
-    // skip leading '/' since we want the path to be relative to the root fd
-    child_shmem_fd = remote.infallible_syscall(
-        syscall_number_for_openat(arch()), RR_RESERVED_ROOT_DIR_FD,
-        child_path.get() + 1, O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0600);
-  }
-
-  /* Remove the fs name so that we don't have to worry about
-   * cleaning up this segment in error conditions. */
-  unlink(path);
-
-  ScopedFd shmem_fd = remote.retrieve_fd(child_shmem_fd);
-  resize_shmem_segment(shmem_fd, syscallbuf_size);
-  LOG(debug) << "created shmem segment " << path;
-
-  // Map the segment in ours and the tracee's address spaces.
-  void* map_addr;
-  num_syscallbuf_bytes = syscallbuf_size;
-  int prot = PROT_READ | PROT_WRITE;
-  int flags = MAP_SHARED;
-  if ((void*)-1 == (map_addr = mmap(nullptr, num_syscallbuf_bytes, prot, flags,
-                                    shmem_fd, 0))) {
-    FATAL() << "Failed to mmap shmem region";
-  }
-  if (!map_hint.is_null()) {
-    flags |= MAP_FIXED;
-  }
-  remote_ptr<void> child_map_addr = remote.infallible_mmap_syscall(
-      map_hint, num_syscallbuf_bytes, prot, flags, child_shmem_fd, 0);
+  KernelMapping km = Session::create_shared_mmap(remote, syscallbuf_size,
+                                                 map_hint, "syscallbuf");
+  auto& m = remote.task()->vm()->mapping_of(km.start());
+  remote.task()->vm()->mapping_flags_of(km.start()) |=
+      AddressSpace::Mapping::IS_SYSCALLBUF;
 
   ASSERT(this, !syscallbuf_child)
       << "Should not already have syscallbuf initialized!";
-  syscallbuf_child = child_map_addr.cast<struct syscallbuf_hdr>();
-  syscallbuf_hdr = (struct syscallbuf_hdr*)map_addr;
-  // No entries to begin with.
-  memset(syscallbuf_hdr, 0, sizeof(*syscallbuf_hdr));
 
-  struct stat st;
-  ASSERT(this, 0 == ::fstat(shmem_fd, &st));
-  KernelMapping km =
-      vm()->map(child_map_addr, num_syscallbuf_bytes, prot, flags, 0, path,
-                st.st_dev, st.st_ino, nullptr, nullptr, map_addr);
-  shmem_fd.close();
-  remote.infallible_syscall(syscall_number_for_close(arch()), child_shmem_fd);
+  num_syscallbuf_bytes = syscallbuf_size;
+  syscallbuf_child = km.start().cast<struct syscallbuf_hdr>();
+
+  // No entries to begin with.
+  memset(m.local_addr, 0, sizeof(struct syscallbuf_hdr));
 
   return km;
 }
 
 void Task::reset_syscallbuf() {
-  uint8_t* ptr = (uint8_t*)(syscallbuf_hdr + 1);
-  memset(ptr, 0, syscallbuf_hdr->num_rec_bytes);
-  syscallbuf_hdr->num_rec_bytes = 0;
-  syscallbuf_hdr->mprotect_record_count = 0;
-  syscallbuf_hdr->mprotect_record_count_completed = 0;
+  if (!syscallbuf_child)
+    return;
+  // Memset is easiest to do by using the local mapping which should always
+  // exist for the syscallbuf
+  uint32_t num_rec =
+      read_mem(REMOTE_PTR_FIELD(syscallbuf_child, num_rec_bytes));
+  uint8_t* ptr = local_mapping(syscallbuf_child + 1, num_rec);
+  assert(ptr != nullptr);
+  memset(ptr, 0, num_rec);
+  write_mem(REMOTE_PTR_FIELD(syscallbuf_child, num_rec_bytes), (uint32_t)0);
+  write_mem(REMOTE_PTR_FIELD(syscallbuf_child, mprotect_record_count),
+            (uint32_t)0);
+  write_mem(REMOTE_PTR_FIELD(syscallbuf_child, mprotect_record_count_completed),
+            (uint32_t)0);
 }
 
 ssize_t Task::read_bytes_ptrace(remote_ptr<void> addr, ssize_t buf_size,
@@ -1853,7 +1805,7 @@ uint8_t* Task::local_mapping(remote_ptr<void> addr, size_t size) {
 
 ssize_t Task::read_bytes_fallible(remote_ptr<void> addr, ssize_t buf_size,
                                   void* buf) {
-  ASSERT(this, buf_size >= 0) << "Invalid buf_size " << buf_size;
+  ASSERT_ACTIONS(this, buf_size >= 0, << "Invalid buf_size " << buf_size);
   if (0 == buf_size) {
     return 0;
   }

--- a/src/Task.h
+++ b/src/Task.h
@@ -144,8 +144,9 @@ public:
    */
   void finish_emulated_syscall();
 
-  size_t syscallbuf_data_size() const {
-    return syscallbuf_hdr->num_rec_bytes + sizeof(*syscallbuf_hdr);
+  size_t syscallbuf_data_size() {
+    return read_mem(REMOTE_PTR_FIELD(syscallbuf_child, num_rec_bytes)) +
+           sizeof(struct syscallbuf_hdr);
   }
 
   /**
@@ -226,6 +227,9 @@ public:
    * executed; if it's not, results are undefined.
    */
   void destroy_buffers();
+
+  remote_ptr<const struct syscallbuf_record> next_syscallbuf_record();
+  long stored_record_size(remote_ptr<const struct syscallbuf_record> record);
 
   /** Return the current $ip of this. */
   remote_code_ptr ip() { return regs().ip(); }
@@ -374,7 +378,7 @@ public:
    */
   template <typename T>
   T read_mem(remote_ptr<T> child_addr, bool* ok = nullptr) {
-    T val;
+    typename std::remove_cv<T>::type val;
     read_bytes_helper(child_addr, sizeof(val), &val, ok);
     return val;
   }
@@ -684,8 +688,6 @@ public:
    * it's the tid that was recorded. */
   pid_t rec_tid;
 
-  /* Points at rr's mapping of the (shared) syscall buffer. */
-  struct syscallbuf_hdr* syscallbuf_hdr;
   size_t syscallbuf_size;
   size_t num_syscallbuf_bytes;
   /* Points at the tracee's mapping of the buffer. */
@@ -704,7 +706,6 @@ public:
     std::string prname;
     std::vector<struct user_desc> thread_areas;
     remote_ptr<struct syscallbuf_hdr> syscallbuf_child;
-    std::vector<uint8_t> syscallbuf_hdr;
     size_t syscallbuf_size;
     size_t num_syscallbuf_bytes;
     remote_ptr<struct preload_globals> preload_globals;
@@ -765,12 +766,6 @@ protected:
    * that can simply be copied over in local memory.
    */
   void copy_state(const CapturedState& state);
-
-  /**
-   * Destroy tracer-side state of this (as opposed to remote,
-   * tracee-side state).
-   */
-  void destroy_local_buffers();
 
   /**
    * Make the ptrace |request| with |addr| and |data|, return

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -728,6 +728,18 @@ static void process_mmap(ReplayTask* t, const TraceFrame& trace_frame,
         }
       }
     }
+
+    // This code is used to test the sharing functionality. It is in
+    // general a bad idea to indiscriminately share mappings between the
+    // tracer and the tracee. Instead, only mappings that have
+    // sufficiently many memory access from the tracer to require
+    // acceleration should be shared.
+    if ((MAP_PRIVATE & flags) && t->session().share_private_mappings() &&
+        !trace_frame.regs().syscall_failed()) {
+      Session::make_private_shared(
+          remote, t->vm()->mapping_of(trace_frame.regs().syscall_result()));
+    }
+
     // Finally, we finish by emulating the return value.
     remote.regs().set_syscall_result(trace_frame.regs().syscall_result());
   }
@@ -873,8 +885,10 @@ void rep_prepare_run_to_syscall(ReplayTask* t, ReplayTraceStep* step) {
    * exist in this architecture.
    */
   if (is_rrcall_notify_syscall_hook_exit_syscall(sys, t->arch())) {
-    ASSERT(t, t->syscallbuf_hdr);
-    t->syscallbuf_hdr->notify_on_syscall_hook_exit = true;
+    ASSERT(t, t->syscallbuf_child != nullptr);
+    t->write_mem(
+        REMOTE_PTR_FIELD(t->syscallbuf_child, notify_on_syscall_hook_exit),
+        (uint8_t)1);
   }
 }
 

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -243,13 +243,23 @@ template <typename Arch> static void prepare_clone(ReplayTask* t) {
   new_r.set_arg1(trace_frame.regs().arg1());
   new_task->emulate_syscall_entry(new_r);
 
-  if (!(CLONE_VM & r.arg1())) {
+  if (Arch::clone != sys || !(CLONE_VM & r.arg1())) {
     // It's hard to imagine a scenario in which it would
     // be useful to inherit breakpoints (along with their
     // refcounts) across a non-VM-sharing clone, but for
     // now we never want to do this.
     new_task->vm()->remove_all_breakpoints();
     new_task->vm()->remove_all_watchpoints();
+
+    AutoRemoteSyscalls remote(new_task);
+    for (auto m : new_task->vm()->maps()) {
+      // Recreate any tracee-shared mappings
+      if (m.local_addr != 0 &&
+          !(m.flags & AddressSpace::Mapping::IS_SYSCALLBUF)) {
+        memcpy(Session::recreate_shared_mmap(remote, m).local_addr,
+               m.local_addr, m.map.size());
+      }
+    }
   }
 
   TraceReader::MappedData data;

--- a/src/test/break_mmap_private.run
+++ b/src/test/break_mmap_private.run
@@ -1,3 +1,4 @@
 source `dirname $0`/util.sh
 record mmap_private$bitness
 debug break_mmap_private
+debug break_mmap_private --share-private-mappings

--- a/src/test/mprotect_growsdown.run
+++ b/src/test/mprotect_growsdown.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+compare_test EXIT-SUCCESS
+compare_test EXIT-SUCCESS --share-private-mappings

--- a/src/util.cc
+++ b/src/util.cc
@@ -340,7 +340,7 @@ static void iterate_checksums(Task* t, ChecksumMode mode,
     ASSERT(t, valid_mem_len >= 0);
     mem.resize(valid_mem_len);
 
-    if (m.map.fsname().find(SYSCALLBUF_SHMEM_PATH_PREFIX) == 0) {
+    if (m.flags & AddressSpace::Mapping::IS_SYSCALLBUF) {
       /* The syscallbuf consists of a region that's written
       * deterministically wrt the trace events, and a
       * region that's written nondeterministically in the

--- a/src/util.h
+++ b/src/util.h
@@ -60,11 +60,6 @@ template <typename T> bool type_has_no_holes() {
 
 #define SHMEM_FS "/dev/shm"
 
-/* The syscallbuf shared with tracees is created with this prefix
- * followed by the tracee tid, then immediately unlinked and shared
- * anonymously. */
-#define SYSCALLBUF_SHMEM_PATH_PREFIX "/tmp/rr-syscallbuf-"
-
 #define PREFIX_FOR_EMPTY_MMAPED_REGIONS "/tmp/rr-emptyfile-"
 
 enum Completion { COMPLETE, INCOMPLETE };


### PR DESCRIPTION
@rocallahan as discussed on IRC, this generalizes the syscallbuf code to work for other mappings that are shared with the tracee as well and provides an API to replace an existing private mapping with one that is shared with the tracer. The intention of this change is to be able to speed up memory operations on a given segment. This is not quite done yet, but I wanted to put the code up to get some early feedback (or feel free to wait until it's done - that would be fine as well).

cc @carnaval