### PR TITLE
Fix failures when building rr with optimizations

### DIFF
--- a/src/test/cpuid_loop.S
+++ b/src/test/cpuid_loop.S
@@ -127,16 +127,18 @@ cpuid_call:
         .globl cpuid_loop
         .type  cpuid_loop, @function
 cpuid_loop:
+        pushq %rbx
         mov %rdi, %rbx
-        xor %r12d, %r12d
+        xor %r11d, %r11d
 1:
         call cpuid_call
-        addq %rax, %r12
+        addq %rax, %r11
         mov $107, %rax
         syscall
         subq $1, %rbx
         jne 1b
-        movq %r12, %rax
+        movq %r11, %rax
+        popq %rbx
         ret
         .size  cpuid_loop, .-cpuid_loop
 #else

--- a/src/test/ptrace_sysemu.c
+++ b/src/test/ptrace_sysemu.c
@@ -48,7 +48,7 @@ extern char syscall_addr;
 /* Make a syscallbuf-patchable syscall to check that syscallbuf patching
    doesn't happen when we are emulating a ptracer --- which can be
    potentially confused by it. */
-static uid_t my_geteuid(void) {
+static uid_t __attribute__((noinline)) my_geteuid(void) {
   int r;
 #ifdef __i386__
   __asm__ __volatile__("syscall_addr: int $0x80\n\t"


### PR DESCRIPTION
- Inlining of my_geteuid caused a duplicate label
- cpuid_loop clobbered registers that the compiler expected to be preserved.