### PR TITLE
Log sent GdbConnection packets again.

### DIFF
--- a/src/GdbConnection.cc
+++ b/src/GdbConnection.cc
@@ -275,11 +275,10 @@ void GdbConnection::read_data_once() {
 void GdbConnection::write_flush() {
   size_t write_index = 0;
 
-#ifdef DEBUGTAG
   outbuf.push_back(0);
   LOG(debug) << "write_flush: '" << outbuf.data() << "'";
   outbuf.pop_back();
-#endif
+
   while (write_index < outbuf.size()) {
     ssize_t nwritten;
 


### PR DESCRIPTION
Adding and removing an element at the end of the array should be cheap the vast majority of the time, so we may as well do this.