### PR TITLE
Pass through --fullname to gdb

### DIFF
--- a/src/GdbConnection.h
+++ b/src/GdbConnection.h
@@ -294,7 +294,7 @@ public:
     bool reverse_execution;
   };
   static std::unique_ptr<GdbConnection> await_client_connection(
-      unsigned short desired_port, ProbePort probe, pid_t tgid,
+      unsigned short desired_port, bool show_fullnames, ProbePort probe, pid_t tgid,
       const std::string& exe_image, const Features& features,
       ScopedFd* client_params_fd = nullptr);
 

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1219,7 +1219,7 @@ void GdbServer::emergency_debug(Task* t) {
   // mode (and we don't want to require users to do that)
   features.reverse_execution = false;
   unique_ptr<GdbConnection> dbg = GdbConnection::await_client_connection(
-      0, false, GdbConnection::PROBE_PORT, t->tgid(), t->vm()->exe_image(),
+      t->tid, false, GdbConnection::PROBE_PORT, t->tgid(), t->vm()->exe_image(),
       features);
 
   GdbServer(dbg, t).process_debugger_requests();

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1172,7 +1172,7 @@ void GdbServer::serve_replay(const ConnectionFlags& flags) {
                                   : GdbConnection::PROBE_PORT;
   Task* t = timeline.current_session().current_task();
   dbg = GdbConnection::await_client_connection(
-      port, probe, t->tgid(), t->vm()->exe_image(), GdbConnection::Features(),
+      port, flags.show_fullnames, probe, t->tgid(), t->vm()->exe_image(), GdbConnection::Features(),
       flags.debugger_params_write_pipe);
   if (flags.debugger_params_write_pipe) {
     flags.debugger_params_write_pipe->close();
@@ -1219,7 +1219,7 @@ void GdbServer::emergency_debug(Task* t) {
   // mode (and we don't want to require users to do that)
   features.reverse_execution = false;
   unique_ptr<GdbConnection> dbg = GdbConnection::await_client_connection(
-      t->tid, GdbConnection::PROBE_PORT, t->tgid(), t->vm()->exe_image(),
+      0, false, GdbConnection::PROBE_PORT, t->tgid(), t->vm()->exe_image(),
       features);
 
   GdbServer(dbg, t).process_debugger_requests();

--- a/src/GdbServer.h
+++ b/src/GdbServer.h
@@ -40,12 +40,13 @@ public:
     // -1 to let GdbServer choose the port, a positive integer to select a
     // specific port to listen on.
     int dbg_port;
+    bool show_fullnames;
     // If non-null, then when the gdbserver is set up, we write its connection
     // parameters through this pipe. GdbServer::launch_gdb is passed the
     // other end of this pipe to exec gdb with the parameters.
     ScopedFd* debugger_params_write_pipe;
 
-    ConnectionFlags() : dbg_port(-1), debugger_params_write_pipe(nullptr) {}
+    ConnectionFlags() : dbg_port(-1), show_fullnames(false), debugger_params_write_pipe(nullptr) {}
   };
 
   /**


### PR DESCRIPTION
When I run gdb under emacs, I pass -fullname to make it output filenames in a format automatically detected by emacs so it will pop up a buffer with the source code. I'd like to be able to do that with rr replay, though in rr's standard double-dash format.
