### PR TITLE
Make exe_directory work when rr is used as a library

### DIFF
--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -645,6 +645,11 @@ public:
    */
   KernelMapping read_kernel_mapping(Task* t, remote_ptr<void> addr);
 
+  /**
+   * Same as read_kernel_mapping, but reads rr's own memory map.
+   */
+  static KernelMapping read_local_kernel_mapping(uint8_t* addr);
+
   static uint32_t chaos_mode_min_stack_size() { return 8 * 1024 * 1024; }
 
   remote_ptr<void> chaos_mode_find_free_memory(Task* t, size_t len);

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -260,7 +260,7 @@ template <typename Arch> static void prepare_clone(ReplayTask* t) {
 }
 
 static string find_exec_stub(SupportedArch arch) {
-  string exe_path = exe_directory();
+  string exe_path = exe_directory() + "../bin/";
   if (arch == x86 && NativeArch::arch() == x86_64) {
     exe_path += "exec_stub_32";
   } else {

--- a/src/util.cc
+++ b/src/util.cc
@@ -724,14 +724,21 @@ string real_path(const string& path) {
   return path;
 }
 
-string exe_directory() {
-  string exe_path = real_path("/proc/self/exe");
+static string read_exe_dir() {
+  KernelMapping km =
+      AddressSpace::read_local_kernel_mapping((uint8_t*)&read_exe_dir);
+  string exe_path = km.fsname();
   int end = exe_path.length();
   // Chop off the filename
   while (end > 0 && exe_path[end - 1] != '/') {
     --end;
   }
   exe_path.erase(end);
+  return exe_path;
+}
+
+string exe_directory() {
+  static string exe_path = read_exe_dir();
   return exe_path;
 }
 


### PR DESCRIPTION
This is done by looking through the mappings in the current address space
and finding the one that contains rr code, under the assumption that
that would be either the rr executable or the rr library.

This is done by reuising the code from AddressSpace to iterate over kernel
mappings.