### PR TITLE
Fixed shared library build with gcc

### DIFF
--- a/src/test/cpuid_loop.S
+++ b/src/test/cpuid_loop.S
@@ -7,6 +7,7 @@
         .globl  cpuid_call
         .type   cpuid_call, @function
 cpuid_call:
+_cpuid_call:
         .cfi_startproc
         pushl   %edi
         .cfi_def_cfa_offset 8
@@ -80,7 +81,7 @@ cpuid_loop:
         movl    %ebx, (%esp)
         movl    %ebp, 8(%esp)
         movl    %edi, 4(%esp)
-        call    cpuid_call
+        call    _cpuid_call
         addl    %eax, %ebx
         mov     $201, %eax
         int     $0x80
@@ -110,6 +111,7 @@ cpuid_loop:
         .globl cpuid_call
         .type  cpuid_call, @function
 cpuid_call:
+_cpuid_call:
         pushq %rbx
         /* Call CPUID twice, once under a conditional.  */
         xorl %eax, %eax
@@ -131,7 +133,7 @@ cpuid_loop:
         mov %rdi, %rbx
         xor %r11d, %r11d
 1:
-        call cpuid_call
+        call _cpuid_call
         addq %rax, %r11
         mov $107, %rax
         syscall


### PR DESCRIPTION
For some reason gcc puts a relocation in the object file, even though
its a local symbol in the same section. Clang works correctly. Fix
gcc as well by introducing a second, local, symbol at the same
location and calling that instead.