### PR TITLE
Only consider files when looking up executables in $PATH

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1456,7 +1456,9 @@ static string lookup_by_path(const string& name) {
       *next = 0;
     }
     string file = string(s) + "/" + name;
-    if (!access(file.c_str(), X_OK)) {
+    struct stat st;
+    if (!stat(file.c_str(), &st) && S_ISREG(st.st_mode) &&
+        !access(file.c_str(), X_OK)) {
       free(p);
       return file;
     }


### PR DESCRIPTION
dc23125f make `rr record` do $PATH lookup on its own to check the
executable, but only checks if a matching file has the executable bit,
which is true of directories. In some corner case, where a directory of
the same name as a program is in one of the directories in $PATH, this
makes `rr record` fail with:
    execve of '...' failed (EACCES)

So first check if a matching file is a regular file.