### PR TITLE
Don't clobber registers in sigreturn test.

### DIFF
--- a/src/test/sigreturn.c
+++ b/src/test/sigreturn.c
@@ -141,10 +141,10 @@ int main(void) {
   signal(SIGUSR1, handle_usr1_xmm);
   for (regnum = 0; regnum < 8; ++regnum) {
     int xmm[XMM_SIZE / sizeof(int)] XMM_ALIGNMENT;
+    memcpy(xmm, xmm_bad, sizeof(xmm));
 
     xmm_ops[regnum].set(xmm_good);
     raise(SIGUSR1);
-    memcpy(xmm, xmm_bad, sizeof(xmm));
     xmm_ops[regnum].get(xmm);
 
     test_assert("XMM register should have been preserved" &&
@@ -154,10 +154,10 @@ int main(void) {
   signal(SIGUSR1, handle_usr1_st);
   for (regnum = 0; regnum < 8; ++regnum) {
     char st[ST_SIZE];
+    memcpy(st, &st_bad, sizeof(st));
 
     st_ops[regnum].set(&st_good);
     raise(SIGUSR1);
-    memcpy(st, &st_bad, sizeof(st));
     st_ops[regnum].get(st);
 
     test_assert("ST register should have been preserved" &&


### PR DESCRIPTION
On my machine (with `cc (GCC) 6.1.1 20160602`), the sigreturn-32 tests were failing due to the fact that the memcpy in [sigreturn.c:147](https://github.com/mozilla/rr/blob/05ead1f2d9699d44980e3e6cd8e7b95937306b6a/src/test/sigreturn.c#L147) got compiled to

```asm
movdqa xmm_bad,%xmm0
movaps %xmm0,-0x18(%ebp)
```

which would of course overwrite `%xmm0` before we get a chance to verify its contents were restored correctly. The fix is to simply initialize `xmm` with bad values beforehand.