### PR TITLE
Early WIP: rr/sampling profiler hybrid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ set(RR_SOURCES
   src/MagicSaveDataMonitor.cc
   src/MonitoredSharedMemory.cc
   src/Monkeypatcher.cc
+  src/PerfCommand.cc
   src/PerfCounters.cc
   src/ProcMemMonitor.cc
   src/PsCommand.cc

--- a/src/PerfCommand.cc
+++ b/src/PerfCommand.cc
@@ -1,0 +1,65 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include <map>
+
+#include "Command.h"
+#include "TraceStream.h"
+#include "TraceTaskEvent.h"
+#include "main.h"
+#include "util.h"
+#include "Flags.h"
+
+using namespace std;
+
+namespace rr {
+
+class PerfCommand : public Command {
+public:
+  virtual int run(vector<string>& args);
+
+protected:
+  PerfCommand(const char* name, const char* help) : Command(name, help) {}
+
+  static PerfCommand singleton;
+};
+
+PerfCommand PerfCommand::singleton("perf", " rr perf [<trace_dir>]\n");
+
+
+static int perf(const string& trace_dir, FILE* out) {
+  TraceReader trace(trace_dir);
+  
+  if (!probably_not_interactive(STDOUT_FILENO) && !Flags::get().force_things) {
+    fprintf(stderr, "Cowardly refusing to write binary data to a tty. "
+                    "Use -f to overwrite\n");
+    return 1;
+  }
+  
+  // Write perf file header
+
+  // Write perf file data
+  ssize_t total_bytes_left = trace.total_perf_bytes();
+  while (trace.good() && total_bytes_left > 0) {
+    size_t to_read = min((ssize_t)0x1000, total_bytes_left);
+    auto data = trace.read_perf_records(to_read);
+    fwrite(data.data(), 1, data.size(), out);
+    total_bytes_left -= to_read;
+  }
+   
+  return 0;
+};
+
+int PerfCommand::run(vector<string>& args) {
+  while (parse_global_option(args)) {
+  }
+
+  string trace_dir;
+  if (!parse_optional_trace_dir(args, &trace_dir)) {
+    print_help(stderr);
+    return 1;
+  }
+
+  return perf(trace_dir, stdout);
+}
+
+} // namespace rr

--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -317,10 +317,10 @@ static int64_t read_counter(ScopedFd& fd) {
 }
 
 Ticks PerfCounters::read_ticks() {
-  uint64_t period = UINT32_MAX;
+  //uint64_t period = UINT32_MAX;
   uint64_t val = started ? read_counter(fd_ticks) : 0;
-  ioctl(fd_ticks, PERF_EVENT_IOC_RESET);
-  ioctl(fd_ticks, PERF_EVENT_IOC_PERIOD, &period);
+  //ioctl(fd_ticks, PERF_EVENT_IOC_RESET);
+  //ioctl(fd_ticks, PERF_EVENT_IOC_PERIOD, &period);
   return val;
 }
 

--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/syscall.h>
+#include <sys/mman.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -26,6 +27,7 @@ using namespace std;
 namespace rr {
 
 static bool attributes_initialized;
+static struct perf_event_attr samples_attr;
 static struct perf_event_attr ticks_attr;
 static struct perf_event_attr page_faults_attr;
 static struct perf_event_attr hw_interrupts_attr;
@@ -150,6 +152,33 @@ static void init_perf_event_attr(struct perf_event_attr* attr,
   attr->exclude_guest = 1;
 }
 
+static void check_sampling_limit() {
+  static bool checked = false;
+  if (checked)
+    return;
+  // Check perf event sample rate and print a helpful error message
+  {
+    char line[64];
+    int fd = open("/proc/sys/kernel/perf_event_max_sample_rate", O_RDONLY);
+    if (read(fd, line, sizeof(line)) > 0) {
+      assert(atoi(line) >= 4000 &&
+        "Make sure /proc/sys/kernel/perf_event_max_sample_rate is set high enough");
+    }
+    close(fd);
+  }
+}
+
+static void init_samples_event() {
+  memset(&rr::samples_attr, 0, sizeof(rr::samples_attr));
+  rr::samples_attr.type = PERF_TYPE_HARDWARE;
+  rr::samples_attr.size = sizeof(rr::samples_attr);
+  rr::samples_attr.config = PERF_COUNT_HW_CPU_CYCLES;
+  rr::samples_attr.sample_freq = 4000;
+  rr::samples_attr.freq = 1;
+  rr::samples_attr.sample_type = PERF_SAMPLE_IP|PERF_SAMPLE_TIME|PERF_SAMPLE_READ|PERF_SAMPLE_TID;
+  rr::samples_attr.read_format = PERF_FORMAT_GROUP;
+}
+
 static void init_attributes() {
   if (attributes_initialized) {
     return;
@@ -175,6 +204,7 @@ static void init_attributes() {
                        pmu->rinsn_cntr_event);
   init_perf_event_attr(&hw_interrupts_attr, PERF_TYPE_RAW,
                        pmu->hw_intr_cntr_event);
+  init_samples_event();
   // libpfm encodes the event with this bit set, so we'll do the
   // same thing.  Unclear if necessary.
   hw_interrupts_attr.exclude_hv = 1;
@@ -187,7 +217,8 @@ const struct perf_event_attr& PerfCounters::ticks_attr() {
   return rr::ticks_attr;
 }
 
-PerfCounters::PerfCounters(pid_t tid) : tid(tid), started(false) {
+PerfCounters::PerfCounters(pid_t tid) : tid(tid), started(false),
+    sampling_enabled(false) {
   init_attributes();
 }
 
@@ -211,13 +242,33 @@ static ScopedFd start_counter(pid_t tid, int group_fd,
   return fd;
 }
 
+static const int SAMPLE_MMAP_SIZE = (1+(1<<10))*PAGE_SIZE;
+void PerfCounters::samples_unmapper::operator()(void *ptr)
+{
+ munmap(ptr, SAMPLE_MMAP_SIZE);
+}
+
 void PerfCounters::reset(Ticks ticks_period) {
   assert(ticks_period >= 0);
 
   if (!started) {
+    int group_fd = -1;
+    if (enable_sampling() && !samples_mmap) {
+      check_sampling_limit();
+      fd_samples = start_counter(tid, -1, &rr::samples_attr);
+      samples_mmap.reset(mmap(NULL, SAMPLE_MMAP_SIZE, PROT_READ|PROT_WRITE,
+        MAP_SHARED, fd_samples, 0));
+      if (samples_mmap.get() == MAP_FAILED) {
+        FATAL() << "Failed to map samples page";
+      }
+      group_fd = fd_samples;
+    }
+    
     struct perf_event_attr attr = rr::ticks_attr;
     attr.sample_period = ticks_period;
-    fd_ticks = start_counter(tid, -1, &attr);
+    fd_ticks = start_counter(tid, group_fd, &attr);
+    if (group_fd == -1)
+      group_fd = fd_ticks;
 
     struct f_owner_ex own;
     own.type = F_OWNER_TID;
@@ -232,11 +283,10 @@ void PerfCounters::reset(Ticks ticks_period) {
     }
 
     if (extra_perf_counters_enabled()) {
-      int group_leader = fd_ticks;
-      fd_hw_interrupts = start_counter(tid, group_leader, &hw_interrupts_attr);
+      fd_hw_interrupts = start_counter(tid, group_fd, &hw_interrupts_attr);
       fd_instructions_retired =
-          start_counter(tid, group_leader, &instructions_retired_attr);
-      fd_page_faults = start_counter(tid, group_leader, &page_faults_attr);
+          start_counter(tid, group_fd, &instructions_retired_attr);
+      fd_page_faults = start_counter(tid, group_fd, &page_faults_attr);
     }
   } else {
     ioctl(fd_ticks, PERF_EVENT_IOC_RESET);

--- a/src/PerfCounters.h
+++ b/src/PerfCounters.h
@@ -10,6 +10,7 @@
 #include <signal.h>
 #include <stdint.h>
 #include <sys/types.h>
+#include <memory>
 
 #include "ScopedFd.h"
 #include "Ticks.h"
@@ -41,6 +42,11 @@ public:
   // Change this to 'true' to enable perf counters that may be interesting
   // for experimentation, but aren't necessary for core functionality.
   static bool extra_perf_counters_enabled() { return false; }
+
+  // Change this to 'true' to enable sampling
+  bool enable_sampling() { return sampling_enabled; }
+
+  void set_sampling(bool sampling) { sampling_enabled = sampling; }
 
   /**
    * Reset all counter values to 0 and program the counters to send
@@ -81,14 +87,24 @@ public:
   Extra read_extra();
 
   static const struct perf_event_attr& ticks_attr();
+  
+  struct samples_unmapper {
+   public:
+     void operator()(void *ptr);
+  };
+  std::unique_ptr<void,samples_unmapper> samples_mmap;
+
   bool counting;
+
 private:
   pid_t tid;
+  ScopedFd fd_samples;
   ScopedFd fd_ticks;
   ScopedFd fd_page_faults;
   ScopedFd fd_hw_interrupts;
   ScopedFd fd_instructions_retired;
   bool started;
+  bool sampling_enabled;
 };
 
 } // namespace rr

--- a/src/PerfCounters.h
+++ b/src/PerfCounters.h
@@ -81,7 +81,7 @@ public:
   Extra read_extra();
 
   static const struct perf_event_attr& ticks_attr();
-
+  bool counting;
 private:
   pid_t tid;
   ScopedFd fd_ticks;

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1473,7 +1473,8 @@ static string lookup_by_path(const string& name) {
 
 /*static*/ RecordSession::shr_ptr RecordSession::create(
     const vector<string>& argv, const vector<string>& extra_env,
-    SyscallBuffering syscallbuf, BindCPU bind_cpu) {
+    SyscallBuffering syscallbuf, BindCPU bind_cpu,
+    bool do_sampling) {
   // The syscallbuf library interposes some critical
   // external symbols like XShmQueryExtension(), so we
   // preload it whether or not syscallbuf is enabled. Indicate here whether
@@ -1556,15 +1557,17 @@ static string lookup_by_path(const string& name) {
   env.push_back("MOZ_GDB_SLEEP=0");
 
   shr_ptr session(
-      new RecordSession(full_path, argv, env, syscallbuf, bind_cpu));
+      new RecordSession(full_path, argv, env, syscallbuf, bind_cpu, do_sampling));
   return session;
 }
 
 RecordSession::RecordSession(const std::string& exe_path,
                              const std::vector<std::string>& argv,
                              const std::vector<std::string>& envp,
-                             SyscallBuffering syscallbuf, BindCPU bind_cpu)
-    : trace_out(argv[0], choose_cpu(bind_cpu)),
+                             SyscallBuffering syscallbuf, BindCPU bind_cpu,
+                             bool do_sampling)
+    : do_sampling_(do_sampling),
+      trace_out(argv[0], choose_cpu(bind_cpu)),
       scheduler_(*this),
       ignore_sig(0),
       continue_through_sig(0),

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -31,7 +31,8 @@ public:
       const std::vector<std::string>& argv,
       const std::vector<std::string>& extra_env = std::vector<std::string>(),
       SyscallBuffering syscallbuf = ENABLE_SYSCALL_BUF,
-      BindCPU bind_cpu = BIND_CPU);
+      BindCPU bind_cpu = BIND_CPU,
+      bool do_sampling = false);
 
   bool use_syscall_buffer() const { return use_syscall_buffer_; }
   size_t syscall_buffer_size() const { return syscall_buffer_size_; }
@@ -109,18 +110,20 @@ public:
   void set_wait_for_all(bool wait_for_all) {
     this->wait_for_all_ = wait_for_all;
   }
-
+  
   virtual Task* new_task(pid_t tid, pid_t rec_tid, uint32_t serial,
                          SupportedArch a);
 
   RecordTask* find_task(pid_t rec_tid) const;
   RecordTask* find_task(const TaskUid& tuid) const;
-
+  
+  bool do_sampling_;
 private:
   RecordSession(const std::string& exe_path,
                 const std::vector<std::string>& argv,
                 const std::vector<std::string>& envp,
-                SyscallBuffering syscallbuf, BindCPU bind_cpu);
+                SyscallBuffering syscallbuf, BindCPU bind_cpu,
+                bool do_sampling);
 
   virtual void on_create(Task* t);
 

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -184,6 +184,7 @@ RecordTask::RecordTask(RecordSession& session, pid_t _tid, uint32_t serial,
       exit_code(0),
       termination_signal(0),
       tsc_mode(PR_TSC_ENABLE) {
+  hpc.set_sampling(session.do_sampling_);
   push_event(Event(EV_SENTINEL, NO_EXEC_INFO, RR_NATIVE_ARCH));
   if (session.tasks().empty()) {
     // Initial tracee. It inherited its state from this process, so set it up.
@@ -1104,6 +1105,23 @@ uint16_t RecordTask::get_ptrace_eventmsg_seccomp_data() {
   xptrace(PTRACE_GETEVENTMSG, nullptr, &data);
   return data;
 }
+
+#define ACCESS_ONCE(x) (*(volatile decltype(x) *)&(x))
+#define rmb()	asm volatile("lfence":::"memory")
+
+void RecordTask::record_perf_records() {
+  struct perf_event_mmap_page *header =
+    (struct perf_event_mmap_page *)hpc.samples_mmap.get();
+  if (header) {
+    uint64_t head = ACCESS_ONCE(header->data_head);
+    rmb();
+    size_t size = head - header->data_tail;
+    trace_writer().write_perf_records(
+      ((uint8_t*)header) + 0x1000 + header->data_tail,size);
+    header->data_tail = head;
+  }
+}
+
 
 void RecordTask::record_local(remote_ptr<void> addr, ssize_t num_bytes,
                               const void* data) {

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -426,6 +426,9 @@ public:
 
   enum { SYNTHETIC_TIME_SLICE_SI_CODE = -9999 };
 
+protected:
+  void record_perf_records();
+
 private:
   ~RecordTask();
 

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1224,11 +1224,13 @@ void Task::emulate_syscall_entry(const Registers& regs) {
 }
 
 void Task::did_waitpid(WaitStatus status, siginfo_t* override_siginfo) {
+  // If recording and sampling, save the perf records
+  if (hpc.enable_sampling()) {
+    record_perf_records();
+  }
+
   Ticks more_ticks = hpc.counting ? hpc.read_ticks() : 0;
   hpc.counting = false;
-  // Stop PerfCounters ASAP to reduce the possibility that due to bugs or
-  // whatever they pick up something spurious later.
-  //hpc.stop();
   ticks += more_ticks;
   session().accumulate_ticks_processed(more_ticks);
 

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -791,6 +791,12 @@ void Task::resume_execution(ResumeRequest how, WaitRequest wait_how,
     hpc.reset(tick_period == RESUME_UNLIMITED_TICKS
                   ? 0xffffffff
                   : max<Ticks>(1, tick_period));
+  
+    // If recording and sampling, save the perf records
+    if (hpc.enable_sampling()) {
+      record_perf_records();
+    }
+                                
     // Ensure preload_globals.thread_locals_initialized is up to date. Avoid
     // unnecessary writes by caching last written value per-AddressSpace.
     if (preload_globals) {
@@ -1224,11 +1230,6 @@ void Task::emulate_syscall_entry(const Registers& regs) {
 }
 
 void Task::did_waitpid(WaitStatus status, siginfo_t* override_siginfo) {
-  // If recording and sampling, save the perf records
-  if (hpc.enable_sampling()) {
-    record_perf_records();
-  }
-
   Ticks more_ticks = hpc.counting ? hpc.read_ticks() : 0;
   hpc.counting = false;
   ticks += more_ticks;

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1224,10 +1224,11 @@ void Task::emulate_syscall_entry(const Registers& regs) {
 }
 
 void Task::did_waitpid(WaitStatus status, siginfo_t* override_siginfo) {
-  Ticks more_ticks = hpc.read_ticks();
+  Ticks more_ticks = hpc.counting ? hpc.read_ticks() : 0;
+  hpc.counting = false;
   // Stop PerfCounters ASAP to reduce the possibility that due to bugs or
   // whatever they pick up something spurious later.
-  hpc.stop();
+  //hpc.stop();
   ticks += more_ticks;
   session().accumulate_ticks_processed(more_ticks);
 

--- a/src/Task.h
+++ b/src/Task.h
@@ -872,6 +872,8 @@ protected:
                      const std::vector<std::string>& argv,
                      const std::vector<std::string>& envp, pid_t rec_tid = -1);
 
+  virtual void record_perf_records() { }
+
   uint32_t serial;
   // The address space of this task.
   AddressSpace::shr_ptr as;

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -43,6 +43,7 @@ static SubstreamData substreams[TraceStream::SUBSTREAM_COUNT] = {
   { "events", 1024 * 1024, 1 }, { "data_header", 1024 * 1024, 1 },
   { "data", 1024 * 1024, 0 },   { "mmaps", 64 * 1024, 1 },
   { "tasks", 64 * 1024, 1 },    { "generic", 64 * 1024, 1 },
+  { "perf", 64 * 1024, 1}
 };
 
 static const SubstreamData& substream(TraceStream::Substream s) {
@@ -558,6 +559,22 @@ bool TraceReader::read_generic_for_frame(const TraceFrame& frame,
   }
   read_generic(out);
   return true;
+}
+
+void TraceWriter::write_perf_records(const uint8_t* data, size_t len) {
+  auto& perf = writer(PERF_EVENTS);
+  perf.write(data, len);
+}
+
+uint64_t TraceReader::total_perf_bytes() {
+    return reader(PERF_EVENTS).uncompressed_bytes();
+}
+
+std::vector<uint8_t> TraceReader::read_perf_records(size_t nbytes) {
+    std::vector<uint8_t> data;
+    data.resize(nbytes);
+    reader(PERF_EVENTS).read(data.data(), nbytes);
+    return data;
 }
 
 void TraceWriter::close() {

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -54,6 +54,8 @@ public:
     TASKS,
     // Substream that stores arbitrary per-event records
     GENERIC,
+    // Substream that records perf_event records
+    PERF_EVENTS,
     SUBSTREAM_COUNT
   };
 
@@ -145,6 +147,11 @@ public:
    * Write a generic data record to the trace.
    */
   void write_generic(const void* data, size_t len);
+
+  /**
+   * Write a perf records to the trace
+   */
+  void write_perf_records(const uint8_t* data, size_t len);
 
   /**
    * Return true iff all trace files are "good".
@@ -255,6 +262,9 @@ public:
   void read_generic(std::vector<uint8_t>& out);
   bool read_generic_for_frame(const TraceFrame& frame,
                               std::vector<uint8_t>& out);
+
+  uint64_t total_perf_bytes();
+  std::vector<uint8_t> read_perf_records(size_t nbytes);
 
   /**
    * Return true iff all trace files are "good".

--- a/src/VirtualPerfCounterMonitor.cc
+++ b/src/VirtualPerfCounterMonitor.cc
@@ -40,6 +40,20 @@ bool VirtualPerfCounterMonitor::emulate_ioctl(RecordTask* t, uint64_t* result) {
       *result = 0;
       enabled = true;
       break;
+    case PERF_EVENT_IOC_RESET:
+      {
+        *result = 0;
+        RecordTask* target = t->session().find_task(target_tuid);
+        initial_ticks = target->tick_count();
+      }
+      break;
+    case PERF_EVENT_IOC_PERIOD:
+      {
+        *result = 0;
+        // Nominally we'd resent the interrupt here, but since we don't support
+        // that yet, just ignore it.
+      }
+      break;
     default:
       ASSERT(t, false) << "Unsupported perf event ioctl "
                        << HEX((int)t->regs().arg2());


### PR DESCRIPTION
This is an idea I've been kicking around. When doing sampling profiling, you really want to minimize the amount of work you do while sampling in order for it to a) be fast and b) not disrupt the program too much. Unfortunately this is of course in direct conflict with actually collecting anything useful. What I'm proposing here is to use rr to do the actual data collection as a post-processing step. The way this is done is to sample the current ip and the value of the retired branch counter, thus hopefully allowing us to find this position again during replay and do whatever we want to do (backtrace, collect values, more fancy things, etc...).

This is nowhere near done, but I figured people may have early feedback.