### PR TITLE
Remove -W from help

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -147,8 +147,6 @@ void print_usage(FILE* out) {
       "  -T, --dump-at=TIME         dump memory at global timepoint TIME\n"
       "  -V, --verbose              log messages that may not be urgently \n"
       "                             critical to the user\n"
-      "  -W, --wait-secs=<NUM_SECS> wait NUM_SECS seconds just after startup,\n"
-      "                             before initiating recording or replaying\n"
       "\n"
       "Use RR_LOG to control logging; e.g. RR_LOG=all:warn,Task:debug\n",
       out);


### PR DESCRIPTION
a9fb580 removed the -W (aka --wait-secs) option, but left one
reference to it in the --help output.  This patch removes the
straggler.