### PR TITLE
Support qGetTLSAddr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ set_source_files_properties(src/preload/preload.c
                             PROPERTIES COMPILE_FLAGS ${CMAKE_C_FLAGS_RELEASE})
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
+include_directories("${PROJECT_SOURCE_DIR}/third-party/proc-service")
 # We need to know where our generated files are.
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -269,6 +270,7 @@ set(RR_SOURCES
   src/StdioMonitor.cc
   src/Task.cc
   src/TaskGroup.cc
+  src/ThreadDb.cc
   src/TraceFrame.cc
   src/TraceStream.cc
   src/VirtualPerfCounterMonitor.cc
@@ -772,6 +774,7 @@ set(TESTS_WITH_PROGRAM
   thread_exit_signal
   threaded_syscall_spam
   threads
+  tls
   ttyname
   unexpected_stack_growth
   user_ignore_sig

--- a/src/GdbServer.h
+++ b/src/GdbServer.h
@@ -234,6 +234,11 @@ private:
 
   // gdb checkpoints, indexed by ID
   std::map<int, Checkpoint> checkpoints;
+
+  // Set of symbols to look up, for qSymbol.
+  std::set<std::string> symbols;
+  // Iterator into |symbols|.
+  std::set<std::string>::iterator symbols_iter;
 };
 
 } // namespace rr

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -292,6 +292,15 @@ public:
   void clear_singlestep_flag() { set_flags(flags() & ~X86_TF_FLAG); }
   bool df_flag() const { return flags() & X86_DF_FLAG; }
 
+  uintptr_t fs_base() const {
+    assert(arch() == x86_64);
+    return u.x64regs.fs_base;
+  }
+  uintptr_t gs_base() const {
+    assert(arch() == x86_64);
+    return u.x64regs.gs_base;
+  }
+
   // End of X86-specific stuff
 
   void print_register_file(FILE* f) const;

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -41,6 +41,7 @@
 #include "ScopedFd.h"
 #include "StdioMonitor.h"
 #include "StringVectorToCharArray.h"
+#include "ThreadDb.h"
 #include "kernel_abi.h"
 #include "kernel_metadata.h"
 #include "kernel_supplement.h"
@@ -2336,4 +2337,17 @@ static void run_initial_child(Session& session, const ScopedFd& error_fd,
 string Task::syscall_name(int syscall) const {
   return rr::syscall_name(syscall, arch());
 } // namespace rr
+
+bool Task::get_tls_address(size_t offset, remote_ptr<void> load_module,
+                           remote_ptr<void>* result) {
+  return tg->thread_db()->get_tls_address(rec_tid, offset, load_module, result);
+}
+
+void Task::register_symbol(const std::string& name, remote_ptr<void> address) {
+  tg->thread_db()->register_symbol(name, address);
+}
+
+const std::set<std::string> Task::get_symbols_and_clear_map() {
+  return tg->thread_db()->get_symbols_and_clear_map();
+}
 }

--- a/src/Task.h
+++ b/src/Task.h
@@ -622,6 +622,27 @@ public:
    */
   std::string syscall_name(int syscallno) const;
 
+  /**
+   * Look up a TLS address for this thread.  |offset| and
+   * |load_module| are as specified in the qGetTLSAddr packet.  If the
+   * address is found, set |*result| and return true.  Otherwise,
+   * return false.
+   */
+  bool get_tls_address(size_t offset, remote_ptr<void> load_module,
+                       remote_ptr<void>* result);
+
+  /**
+   * Indicate that the symbol |name| has the given address.
+   */
+  void register_symbol(const std::string& name, remote_ptr<void> address);
+
+  /**
+   * Return a set of the names of all the symbols that might be needed
+   * by libthread_db.  Also clears the current mapping of symbol names
+   * to addresses.
+   */
+  const std::set<std::string> get_symbols_and_clear_map();
+
   /* True when any assumptions made about the status of this
    * process have been invalidated, and must be re-established
    * with a waitpid() call. Only applies to tasks which are dying, usually

--- a/src/TaskGroup.cc
+++ b/src/TaskGroup.cc
@@ -4,6 +4,7 @@
 
 #include "Session.h"
 #include "Task.h"
+#include "ThreadDb.h"
 #include "log.h"
 
 namespace rr {
@@ -44,6 +45,13 @@ void TaskGroup::destabilize() {
     t->unstable = true;
     LOG(debug) << "  destabilized task " << t->tid;
   }
+}
+
+ThreadDb* TaskGroup::thread_db() {
+  if (!thread_db_) {
+    thread_db_ = std::unique_ptr<ThreadDb>(new ThreadDb(this));
+  }
+  return thread_db_.get();
 }
 
 } // namespace rr

--- a/src/TaskGroup.h
+++ b/src/TaskGroup.h
@@ -16,6 +16,7 @@
 namespace rr {
 
 class Session;
+class ThreadDb;
 
 /**
  * Tracks a group of tasks with an associated ID, set from the
@@ -117,6 +118,8 @@ public:
   // Whether this task group has execed
   bool execed;
 
+  ThreadDb* thread_db();
+
 private:
   TaskGroup(const TaskGroup&) = delete;
   TaskGroup operator=(const TaskGroup&) = delete;
@@ -128,6 +131,8 @@ private:
   std::set<TaskGroup*> children_;
 
   uint32_t serial;
+
+  std::unique_ptr<ThreadDb> thread_db_;
 };
 
 } // namespace rr

--- a/src/ThreadDb.cc
+++ b/src/ThreadDb.cc
@@ -1,0 +1,233 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "ThreadDb.h"
+#include "GdbServer.h"
+#include "Task.h"
+#include "TaskGroup.h"
+#include "log.h"
+
+extern "C" {
+// The proc_service/thread_db library has a very weird API.  It
+// requires the user of the library to provide certain functions which
+// it links to (rather than, say, having the library user supply a
+// struct of function pointers).  We have to ensure that these
+// functions have C linkage, so that libthread_db can find them.
+#include "proc_service.h"
+}
+
+#include <asm/prctl.h>
+#include <dlfcn.h>
+#include <linux/elf.h>
+#include <sys/reg.h>
+
+#define LIBRARY_NAME "libthread_db.so.1"
+
+// Needed for the logging API.
+using namespace rr;
+
+ps_err_e ps_pglobal_lookup(struct ps_prochandle* h, const char*,
+                           const char* symbol, psaddr_t* sym_addr) {
+  rr::remote_ptr<void> addr;
+  if (!h->db->query_symbol(symbol, &addr)) {
+    LOG(debug) << "ps_pglobal_lookup " << symbol << " failed";
+    return PS_NOSYM;
+  }
+  *sym_addr = reinterpret_cast<psaddr_t>(addr.as_int());
+  LOG(debug) << "ps_pglobal_lookup " << symbol << " OK";
+  return PS_OK;
+}
+
+ps_err_e ps_pdread(struct ps_prochandle* h, psaddr_t addr, void* buffer,
+                   size_t len) {
+  bool ok = true;
+  uintptr_t uaddr = reinterpret_cast<uintptr_t>(addr);
+  // We need any task associated with the task group.  Here we assume
+  // that all the tasks in the task group share VM, which is enforced
+  // by clone(2).
+  rr::Task* task = *h->task_group->task_set().begin();
+  task->read_bytes_helper(uaddr, len, buffer, &ok);
+  LOG(debug) << "ps_pdread " << ok;
+  return ok ? PS_OK : PS_ERR;
+}
+
+ps_err_e ps_pdwrite(struct ps_prochandle*, psaddr_t, const void*, size_t) {
+  FATAL() << "ps_pdwrite not implemented";
+  return PS_ERR;
+}
+
+ps_err_e ps_lgetregs(struct ps_prochandle* h, lwpid_t rec_tid,
+                     prgregset_t result) {
+  rr::Task* task = h->task_group->session()->find_task(rec_tid);
+  assert(task != nullptr);
+
+  struct ::user_regs_struct regs = task->regs().get_ptrace();
+  memcpy(result, static_cast<void*>(&regs), sizeof(regs));
+  LOG(debug) << "ps_lgetregs OK";
+  return PS_OK;
+}
+
+ps_err_e ps_lsetregs(struct ps_prochandle*, lwpid_t, const prgregset_t) {
+  FATAL() << "ps_lsetregs not implemented";
+  return PS_ERR;
+}
+
+ps_err_e ps_lgetfpregs(struct ps_prochandle*, lwpid_t, prfpregset_t*) {
+  FATAL() << "ps_lgetfpregs not implemented";
+  return PS_ERR;
+}
+
+ps_err_e ps_lsetfpregs(struct ps_prochandle*, lwpid_t, const prfpregset_t*) {
+  FATAL() << "ps_lsetfpregs not implemented";
+  return PS_ERR;
+}
+
+pid_t ps_getpid(struct ps_prochandle* h) {
+  LOG(debug) << "ps_getpid " << h->task_group->tgid;
+  return h->task_group->tgid;
+}
+
+ps_err_e ps_get_thread_area(const struct ps_prochandle* h, lwpid_t rec_tid,
+                            int val, psaddr_t* base) {
+  rr::Task* task = h->task_group->session()->find_task(rec_tid);
+  assert(task != nullptr);
+
+  if (task->arch() == rr::x86) {
+    unsigned int uval = static_cast<unsigned int>(val);
+    for (auto& area : task->thread_areas()) {
+      if (area.entry_number == uval) {
+        uintptr_t result = static_cast<uintptr_t>(area.base_addr);
+        *base = reinterpret_cast<psaddr_t>(result);
+        return PS_OK;
+      }
+    }
+    LOG(debug) << "ps_get_thread_area 32 failed";
+    return PS_ERR;
+  }
+
+  uintptr_t result;
+  switch (val) {
+    case FS:
+      result = task->regs().fs_base();
+      break;
+    case GS:
+      result = task->regs().gs_base();
+      break;
+    default:
+      LOG(debug) << "ps_get_thread_area PS_BADADDR";
+      return PS_BADADDR;
+  }
+
+  *base = reinterpret_cast<psaddr_t>(result);
+  return PS_OK;
+}
+
+rr::ThreadDb::ThreadDb(TaskGroup* task_group)
+    : initialized(false),
+      internal_handle(nullptr),
+      thread_db_library(nullptr),
+      td_ta_delete_fn(nullptr),
+      td_thr_tls_get_addr_fn(nullptr),
+      td_ta_map_lwp2thr_fn(nullptr) {
+  prochandle.task_group = task_group;
+  prochandle.db = this;
+}
+
+rr::ThreadDb::~ThreadDb() {
+  if (internal_handle) {
+    td_ta_delete_fn(internal_handle);
+  }
+  if (thread_db_library) {
+    dlclose(thread_db_library);
+  }
+}
+
+void rr::ThreadDb::register_symbol(const std::string& name,
+                                   remote_ptr<void> address) {
+  LOG(debug) << "register_symbol " << name;
+  symbols[name] = address;
+}
+
+bool rr::ThreadDb::query_symbol(const char* name, remote_ptr<void>* address) {
+  auto it = symbols.find(name);
+  if (it == symbols.end()) {
+    return false;
+  }
+  *address = it->second;
+  return true;
+}
+
+bool rr::ThreadDb::get_tls_address(pid_t rec_tid, size_t offset,
+                                   remote_ptr<void> load_module,
+                                   remote_ptr<void>* result) {
+  if (!initialize()) {
+    return false;
+  }
+
+  td_thrhandle_t th;
+  if (td_ta_map_lwp2thr_fn(internal_handle, rec_tid, &th) != TD_OK) {
+    return false;
+  }
+
+  psaddr_t load_module_addr = reinterpret_cast<psaddr_t>(load_module.as_int());
+  psaddr_t addr;
+  if (td_thr_tls_get_addr_fn(&th, load_module_addr, offset, &addr) != TD_OK) {
+    return false;
+  }
+  *result = remote_ptr<void>(reinterpret_cast<uintptr_t>(addr));
+  return true;
+}
+
+bool rr::ThreadDb::initialize() {
+  if (!load_library()) {
+    return false;
+  }
+
+  if (!td_ta_new_fn || td_ta_new_fn(&prochandle, &internal_handle) != TD_OK) {
+    LOG(debug) << "initialize td_ta_new_fn failed";
+    return false;
+  }
+
+  LOG(debug) << "initialize OK";
+  return true;
+}
+
+bool rr::ThreadDb::load_library() {
+  if (thread_db_library) {
+    LOG(debug) << "load_library already loaded: " << loaded;
+    return loaded;
+  }
+
+  thread_db_library = dlopen(LIBRARY_NAME, RTLD_NOW);
+  if (!thread_db_library) {
+    LOG(debug) << "load_library dlopen failed";
+    return false;
+  }
+
+  decltype(td_symbol_list) * td_symbol_list_fn;
+
+#define FIND_FUNCTION(Name)                                                    \
+  do {                                                                         \
+    Name##_fn = (decltype(Name)*)(dlsym(thread_db_library, #Name));            \
+    if (!Name##_fn) {                                                          \
+      LOG(debug) << "load_library failed to find " << #Name;                   \
+      return false;                                                            \
+    }                                                                          \
+  } while (0)
+
+  FIND_FUNCTION(td_thr_tls_get_addr);
+  FIND_FUNCTION(td_ta_delete);
+  FIND_FUNCTION(td_symbol_list);
+  FIND_FUNCTION(td_ta_new);
+  FIND_FUNCTION(td_ta_map_lwp2thr);
+
+#undef FIND_FUNCTION
+
+  for (const char** syms = td_symbol_list_fn(); *syms; ++syms) {
+    symbol_names.insert(*syms);
+  }
+
+  // Good to go.
+  loaded = true;
+  LOG(debug) << "load_library OK";
+  return true;
+}

--- a/src/ThreadDb.h
+++ b/src/ThreadDb.h
@@ -1,0 +1,123 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#ifndef RR_THREADDB_H_
+#define RR_THREADDB_H_
+
+#include "remote_ptr.h"
+#include <map>
+#include <set>
+#include <string>
+
+extern "C" {
+#include <thread_db.h>
+}
+
+namespace rr {
+class TaskGroup;
+class ThreadDb;
+}
+
+// This is declared as incomplete by the libthread_db API and is
+// expected to be defined by the API user.  We define it to hold just
+// pointers back to the task group and to the ThreadDb object.
+struct ps_prochandle {
+  rr::TaskGroup* task_group;
+  rr::ThreadDb* db;
+};
+
+namespace rr {
+
+/**
+ * This provides an interface to libthread_db.so to help with TLS
+ * lookup.  There is one instance per process, attached to the
+ * TaskGroup.
+ *
+ * The overall approach is that a libthread_db.so is loaded into rr
+ * when this class is initialized (see |load_library|).  This provides
+ * the GdbServer with a list of symbols whose addresses might be
+ * needed in order to resolve TLS accesses.
+ *
+ * Then, when the address of a TLS variable is requested by the
+ * debugger, GdbServer calls |get_tls_address|.  This uses the
+ * libthread_db "new" function ("td_ta_new"); if this succeeds then
+ * ThreadDb proceeds to use other APIs to find the desired address.
+ *
+ * ThreadDb works on a callback model, using symbols provided by the
+ * hosting application.  These are all defined in ThreadDb.cc.
+ */
+class ThreadDb {
+public:
+  explicit ThreadDb(TaskGroup*);
+  ~ThreadDb();
+
+  /**
+   * Return a set of the names of all the symbols that might be needed
+   * by libthread_db.  Also clears the current mapping of symbol names
+   * to addresses.
+   */
+  const std::set<std::string> get_symbols_and_clear_map() {
+    symbols.clear();
+    load_library();
+    return symbol_names;
+  }
+
+  /**
+   * Note that the symbol |name| has the given address.
+   */
+  void register_symbol(const std::string& name, remote_ptr<void> address);
+
+  /**
+   * Look up the symbol |name|.  If found, set |*address| and return
+   * true.  If not found, return false.
+   */
+  bool query_symbol(const char* name, remote_ptr<void>* address);
+
+  /**
+   * Look up a TLS address for thread |rec_tid|.  |offset| and
+   * |load_module| are as specified in the qGetTLSAddr packet.  If the
+   * address is found, set |*result| and return true.  Otherwise,
+   * return false.
+   */
+  bool get_tls_address(pid_t rec_tid, size_t offset,
+                       remote_ptr<void> load_module, remote_ptr<void>* result);
+
+private:
+  bool load_library();
+  bool initialize();
+
+  ThreadDb(ThreadDb&) = delete;
+  ThreadDb operator=(ThreadDb&) = delete;
+
+  // True if td_ta_new has succeeded.  We need two-phase
+  // initialization because td_ta_new won't work until all the symbols
+  // it needs have been resolved, and this might not be possible until
+  // the thread library has been loaded.
+  bool initialized;
+  // True if libthread_db has been successfully initialized, if all
+  // the functions exist, and if the list of needed symbol names has
+  // been computed.
+  bool loaded;
+
+  // The external handle for this thread, for libthread_db.
+  struct ps_prochandle prochandle;
+  // The internal handle for this thread, from libthread_db.
+  td_thragent_t* internal_handle;
+  // Handle on the libthread_db library itself.
+  void* thread_db_library;
+
+  // Functions from libthread_db.
+  decltype(td_ta_delete) * td_ta_delete_fn;
+  decltype(td_thr_tls_get_addr) * td_thr_tls_get_addr_fn;
+  decltype(td_ta_map_lwp2thr) * td_ta_map_lwp2thr_fn;
+  decltype(td_ta_new) * td_ta_new_fn;
+
+  // Set of all symbol names.
+  std::set<std::string> symbol_names;
+
+  // Map from symbol names to addresses.
+  std::map<std::string, remote_ptr<void> > symbols;
+};
+
+} // namespace rr
+
+#endif // RR_THREADDB_H_

--- a/src/test/tls.c
+++ b/src/test/tls.c
@@ -1,0 +1,23 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+__thread int tlsvar;
+
+void breakpoint_fn(void) {}
+
+void* thread_fn(void* arg) {
+  tlsvar = *(int*)arg;
+  breakpoint_fn();
+  return NULL;
+}
+
+int main(void) {
+  pthread_t thread;
+
+  int value = 97;
+  pthread_create(&thread, NULL, thread_fn, &value);
+  pthread_join(thread, NULL);
+
+  return 0;
+}

--- a/src/test/tls.py
+++ b/src/test/tls.py
@@ -1,0 +1,12 @@
+from rrutil import *
+
+send_gdb('break breakpoint_fn')
+expect_gdb('Breakpoint 1')
+
+send_gdb('c')
+expect_gdb('Breakpoint 1')
+
+send_gdb('print tlsvar')
+expect_gdb(' = 97')
+
+ok()

--- a/src/test/tls.run
+++ b/src/test/tls.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+record tls
+debug tls

--- a/third-party/proc-service/README
+++ b/third-party/proc-service/README
@@ -1,0 +1,16 @@
+proc_service.h provides some declarations used when implementing the
+API used by libthread_db to find TLS locations.
+
+This file is included in rr because it currently isn't installed by
+glibc.  There is a glibc bug open to address this:
+
+    https://sourceware.org/bugzilla/show_bug.cgi?id=20311
+
+However, rather than use the glibc version of this file and attempt to
+understand what the LGPL means, we've imported a version from FreeBSD;
+but slightly modified.  In particular, we:
+
+* Removed __BEGIN_DECLS and __END_DECLS uses
+* Renamed ps_pread and ps_pwrite to match glibc's names
+* Added declarations for ps_getpid and ps_get_thread_area
+* Reordered ps_err_e so that enumerators have the correct values

--- a/third-party/proc-service/proc_service.h
+++ b/third-party/proc-service/proc_service.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2004 David Xu <davidxu@freebsd.org>
+ * Copyright (c) 2004 Marcel Moolenaar
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHORS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD: src/include/proc_service.h,v 1.3.2.1 2006/05/17 02:28:14 davidxu Exp $
+ */
+
+#ifndef _PROC_SERVICE_H_
+#define	_PROC_SERVICE_H_
+
+#include <sys/types.h>
+#include <sys/procfs.h>
+
+typedef enum {
+	PS_OK = 0,		/* No errors. */
+	PS_ERR,			/* Generic error. */
+	PS_BADPID,		/* Bad process Id. */
+	PS_BADLID,		/* Bad LWP Id. */
+	PS_BADADDR,		/* Bad address. */
+	PS_NOSYM,		/* Symbol not found. */
+	PS_NOFREGS,		/* FPU register set not available. */
+} ps_err_e;
+
+struct ps_prochandle;		/* Opaque type. Defined by the implementor. */
+
+ps_err_e ps_lcontinue(struct ps_prochandle *, lwpid_t);
+ps_err_e ps_lgetfpregs(struct ps_prochandle *, lwpid_t, prfpregset_t *);
+ps_err_e ps_lgetregs(struct ps_prochandle *, lwpid_t, prgregset_t);
+ps_err_e ps_lsetfpregs(struct ps_prochandle *, lwpid_t, const prfpregset_t *);
+ps_err_e ps_lsetregs(struct ps_prochandle *, lwpid_t, const prgregset_t);
+#ifdef __i386__
+ps_err_e ps_lgetxmmregs (struct ps_prochandle *, lwpid_t, char *);
+ps_err_e ps_lsetxmmregs (struct ps_prochandle *, lwpid_t, const char *);
+#endif
+ps_err_e ps_lstop(struct ps_prochandle *, lwpid_t);
+ps_err_e ps_linfo(struct ps_prochandle *, lwpid_t, void *);
+ps_err_e ps_pcontinue(struct ps_prochandle *);
+ps_err_e ps_pdmodel(struct ps_prochandle *, int *);
+ps_err_e ps_pglobal_lookup(struct ps_prochandle *, const char *, const char *,
+    psaddr_t *);
+void	 ps_plog(const char *, ...);
+ps_err_e ps_pdread(struct ps_prochandle *, psaddr_t, void *, size_t);
+ps_err_e ps_pstop(struct ps_prochandle *);
+ps_err_e ps_pdwrite(struct ps_prochandle *, psaddr_t, const void *, size_t);
+
+pid_t ps_getpid(struct ps_prochandle *);
+ps_err_e ps_get_thread_area(const struct ps_prochandle*, lwpid_t, int,
+    psaddr_t *);
+
+#endif /* _PROC_SERVICE_H_ */


### PR DESCRIPTION
Fixes #146.

This adds support for the qGetTLSAddr and qSymbol packets from gdb,
which lets gdb access TLS in a replay.