### PR TITLE
Improve rr's modeling of the process's signal mask

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -588,6 +588,7 @@ set(BASIC_TESTS
   rlimit
   robust_futex
   rusage
+  samask
   save_data_fd
   # sched_attr ... disabled since suitable headers are not widely available yet
   sched_setaffinity

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,7 @@ set(BASIC_TESTS
   daemon
   desched_blocking_poll
   dup
+  doublesegv
   epoll_create
   epoll_create1
   eventfd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,6 +621,7 @@ set(BASIC_TESTS
   sigqueueinfo
   sigreturn
   sigreturn_reg
+  sigreturnmask
   sigrt
   sigstop
   sigstop2

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -996,6 +996,7 @@ static bool inject_handled_signal(RecordTask* t) {
 
   int sig = t->ev().Signal().siginfo.si_signo;
   t->resume_execution(RESUME_SINGLESTEP, RESUME_WAIT, RESUME_NO_TICKS, sig);
+  t->apply_sig_sa_mask(sig);
   if (!t->signal_handler_nodefer(sig))
     t->set_sig_blocked(sig);
 

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -996,6 +996,8 @@ static bool inject_handled_signal(RecordTask* t) {
 
   int sig = t->ev().Signal().siginfo.si_signo;
   t->resume_execution(RESUME_SINGLESTEP, RESUME_WAIT, RESUME_NO_TICKS, sig);
+  if (!t->signal_handler_nodefer(sig))
+    t->set_sig_blocked(sig);
 
   // It's been observed that when tasks enter
   // sighandlers, the singlestep operation above

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -900,17 +900,18 @@ void RecordTask::update_sigaction_arch(const Registers& regs) {
     // TODO: discard attempts to handle or ignore signals
     // that can't be by POSIX
     typename Arch::kernel_sigaction sa;
-    size_t sigset_size = min(sizeof(typename Arch::sigset_t), regs.arg4());
     memset(&sa, 0, sizeof(sa));
-    read_bytes_helper(
-        new_sigaction,
-        sizeof(sa) - (sizeof(typename Arch::sigset_t) - sigset_size), &sa);
+    read_bytes_helper(new_sigaction, sizeof(sa), &sa);
     sighandlers->get(sig).init_arch<Arch>(sa);
   }
 }
 
 void RecordTask::update_sigaction(const Registers& regs) {
   RR_ARCH_FUNCTION(update_sigaction_arch, regs.arch(), regs);
+}
+
+void RecordTask::set_new_sigmask(uint64_t new_sigmask) {
+  blocked_sigs = new_sigmask;
 }
 
 void RecordTask::update_sigmask(const Registers& regs) {

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -199,6 +199,11 @@ public:
    * Update this task's sigmask to be new_sigmask
    */
   void set_new_sigmask(uint64_t new_sigmask);
+  /**
+   * Update this task's sigmask to block all signals specified in sa_mask of
+   * |sig|'s current sigaction
+   */
+  void apply_sig_sa_mask(int sig);
 
   /**
    * Stashed-signal API: if a signal becomes pending at an

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -173,6 +173,10 @@ public:
    */
   bool signal_handler_takes_siginfo(int sig) const;
   /**
+   * Return true if SA_NODEFER is set for |sig|
+   */
+  bool signal_handler_nodefer(int sig) const;
+  /**
    * Return |sig|'s current sigaction. Returned as raw bytes since the
    * data is architecture-dependent.
    */

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -195,6 +195,10 @@ public:
    * Set the siginfo for the signal-stop of this.
    */
   void set_siginfo(const siginfo_t& si);
+  /**
+   * Update this task's sigmask to be new_sigmask
+   */
+  void set_new_sigmask(uint64_t new_sigmask);
 
   /**
    * Stashed-signal API: if a signal becomes pending at an

--- a/src/record_signal.cc
+++ b/src/record_signal.cc
@@ -34,7 +34,7 @@ namespace rr {
 static __inline__ unsigned long long rdtsc(void) { return __rdtsc(); }
 
 template <typename Arch> static size_t sigaction_sigset_size_arch() {
-  return Arch::sigaction_sigset_size;
+  return sizeof(typename Arch::kernel_sigset_t);
 }
 
 static size_t sigaction_sigset_size(SupportedArch arch) {

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3437,8 +3437,9 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
           REMOTE_PTR_FIELD(REMOTE_PTR_FIELD(frameptr, uc), uc_sigmask);
       // User space sigset_t is larger than the kernel one, but since we only
       // care about what the kernel sees, load that one.
-      uint64_t oldmask = t->read_mem(
-          oldmaskptr.template cast<typename Arch::kernel_sigset_t>());
+      static_assert(sizeof(typename Arch::kernel_sigset_t) == sizeof(uint64_t),
+                    "Kernel mask size grew?");
+      uint64_t oldmask = t->read_mem(oldmaskptr.template cast<uint64_t>());
       t->set_new_sigmask(oldmask);
       return PREVENT_SWITCH;
     }

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -612,7 +612,7 @@ fsync = EmulatedSyscall(x86=118, x64=74)
 # When the Linux kernel creates the stack frame for a signal handler,
 # a call to sigreturn() is inserted into the stack frame so that upon
 # return from the signal handler, sigreturn() will be called.
-sigreturn = EmulatedSyscall(x86=119)
+sigreturn = IrregularEmulatedSyscall(x86=119)
 
 #  int clone(int (*fn)(void *), void *child_stack, int flags, void *arg, (pid_t
 #*ptid, struct user_desc *tls, pid_t *ctid));
@@ -894,7 +894,7 @@ getresgid = EmulatedSyscall(x86=171, x64=120, arg1="typename Arch::legacy_gid_t"
 #
 prctl = IrregularEmulatedSyscall(x86=172, x64=157)
 
-rt_sigreturn = EmulatedSyscall(x86=173, x64=15)
+rt_sigreturn = IrregularEmulatedSyscall(x86=173, x64=15)
 rt_sigaction = EmulatedSyscall(x86=174, x64=13, arg3="typename Arch::kernel_sigaction")
 rt_sigprocmask = IrregularEmulatedSyscall(x86=175, x64=14)
 

--- a/src/test/doublesegv.c
+++ b/src/test/doublesegv.c
@@ -1,0 +1,53 @@
+#include "rrutil.h"
+
+int handler_pipe_fd;
+
+static void fault_handler(int sig, __attribute__((unused)) siginfo_t* si,
+                          __attribute__((unused)) void* context) {
+  sigset_t oldset;
+  sigprocmask(0, NULL, &oldset);
+  test_assert(sigismember(&oldset, SIGSEGV) &&
+              "SIGSEGV should be blocked here");
+  write(handler_pipe_fd, &sig, sizeof(int));
+  *((int*)1) = 0;
+  // raise(SIGSEGV);
+  test_assert(0 && "Should not reach here");
+}
+
+static void* do_thread(__attribute__((unused)) void* p) {
+  raise(SIGSEGV);
+  test_assert(0 && "Should not reach here!");
+  return NULL;
+}
+
+int main(void) {
+  pid_t child;
+  int status;
+  pthread_t thread;
+  int pipe_fds[2];
+  pipe(pipe_fds);
+  handler_pipe_fd = pipe_fds[1];
+
+  if ((child = fork()) == 0) {
+    struct sigaction act;
+    act.sa_sigaction = fault_handler;
+    act.sa_flags = SA_ONSTACK | SA_SIGINFO;
+    sigemptyset(&act.sa_mask);
+    sigaction(SIGSEGV, &act, NULL);
+
+    pthread_create(&thread, NULL, do_thread, NULL);
+    test_assert(0 == sched_yield());
+    sleep(1000);
+    test_assert(0 && "Should not reach here");
+    return 0;
+  }
+
+  int handler_sig;
+
+  test_assert(read(pipe_fds[0], &handler_sig, sizeof(int)) == sizeof(int));
+  test_assert(handler_sig == SIGSEGV);
+  test_assert(child == wait(&status));
+  test_assert(WIFSIGNALED(status) && WTERMSIG(status) == SIGSEGV);
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/sigreturnmask.c
+++ b/src/test/sigreturnmask.c
@@ -1,0 +1,51 @@
+#include "rrutil.h"
+
+static void segv_handler(__attribute__((unused)) int sig,
+                         __attribute__((unused)) siginfo_t* si,
+                         __attribute__((unused)) void* context) {
+  test_assert(0 && "Should not reach here");
+}
+
+static void usr1_handler(__attribute__((unused)) int sig,
+                         __attribute__((unused)) siginfo_t* si,
+                         __attribute__((unused)) void* context) {
+  ucontext_t* ctx = (ucontext_t*)context;
+  sigaddset(&ctx->uc_sigmask, SIGSEGV);
+  return;
+}
+
+static void* do_thread(__attribute__((unused)) void* p) {
+  raise(SIGUSR1); // just a strange way to spell sigprocmask
+  // Generate SIGSEGV. Can't use raise, because that will be blocked
+  (*(int*)1) = 0; 
+  test_assert(0 && "Should not reach here!");
+  return NULL;
+}
+
+int main(void) {
+  pid_t child;
+  int status;
+  pthread_t thread;
+
+  if ((child = fork()) == 0) {
+    struct sigaction act;
+    act.sa_sigaction = segv_handler;
+    act.sa_flags = SA_ONSTACK | SA_SIGINFO;
+    sigemptyset(&act.sa_mask);
+    sigaction(SIGSEGV, &act, NULL);
+
+    act.sa_sigaction = usr1_handler;
+    sigaction(SIGUSR1, &act, NULL);
+
+    pthread_create(&thread, NULL, do_thread, NULL);
+    test_assert(0 == sched_yield());
+    sleep(1000);
+    test_assert(0 && "Should not reach here");
+    return 0;
+  }
+
+  test_assert(child == wait(&status));
+  test_assert(WIFSIGNALED(status) && WTERMSIG(status) == SIGSEGV);
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
As #1764 showed, rr needs to have an accurate idea of which signals are blocked in order to avoid deadlock. There were several modifications to the signal mask not currently modeled by rr. This PR implements the ones I know about:
 - If SA_NODEFER is not set, the signal is blocked upon entry to the signal handler (fixes #1764)
 - Upon sigreturn the signal mask is restored from a saved value on the stack
 - Upon entry to a signal handler all signals set in sa_mask are blocked
