### PR TITLE
Two performance improvements when recording wine

### DIFF
--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -182,7 +182,7 @@ public:
    */
   const std::vector<uint8_t>& signal_action(int sig) const;
   /** Return true iff |sig| is blocked for this. */
-  bool is_sig_blocked(int sig) const;
+  bool is_sig_blocked(int sig);
 
   /** Set |sig| to be treated as blocked. */
   void set_sig_blocked(int sig);
@@ -467,6 +467,14 @@ private:
    * May queue signals for specific tasks.
    */
   void send_synthetic_SIGCHLD_if_necessary();
+
+  /**
+   * Reload, resp. write back the current mask of blocked signals to the shadow
+   * copy in this tasks's preload globals such that we can effectively track,
+   * changes made to the mask by buffered syscalls.
+   */
+   void reload_sigmask();
+   void writeback_sigmask();
 
   /**
    * Call this when SYS_sigaction is finishing with |regs|.

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1431,7 +1431,7 @@ Task* Task::clone(int flags, remote_ptr<void> stack, remote_ptr<void> tls,
   t->thread_areas_ = thread_areas_;
   // When cloning a task in the same session, the new task's thread-locals
   // are not initialized ... unless CLONE_SET_TLS is set.
-  if (other_session) {
+  if (other_session || !(CLONE_SHARE_VM & flags)) {
     t->thread_locals_initialized = thread_locals_initialized;
   }
   if (CLONE_SET_TLS & flags) {

--- a/src/preload/preload.c
+++ b/src/preload/preload.c
@@ -627,6 +627,7 @@ static void __attribute__((constructor)) init_process(void) {
   extern RR_HIDDEN void _syscall_hook_trampoline_89_c2_f7_da(void);
   extern RR_HIDDEN void _syscall_hook_trampoline_90_90_90(void);
   extern RR_HIDDEN void _syscall_hook_trampoline_ba_01_00_00_00(void);
+  extern RR_HIDDEN void _syscall_hook_trampoline_89_c1_31_d2(void);
 
   struct syscall_patch_hook syscall_patch_hooks[] = {
     /* Many glibc syscall wrappers (e.g. read) have 'syscall' followed by
@@ -661,7 +662,11 @@ static void __attribute__((constructor)) init_process(void) {
      */
     { 5,
       { 0xba, 0x01, 0x00, 0x00, 0x00 },
-      (uintptr_t)_syscall_hook_trampoline_ba_01_00_00_00 }
+      (uintptr_t)_syscall_hook_trampoline_ba_01_00_00_00 },
+    /* pthread_sigmask has 'syscall' followed by 'mov %eax,%ecx; xor %edx,%edx' */
+    { 4,
+      { 0x89, 0xc1, 0x31, 0xd2 },
+      (uintptr_t)_syscall_hook_trampoline_89_c1_31_d2 }
   };
 
   real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
@@ -2302,6 +2307,63 @@ static long sys_getrusage(const struct syscall_info* call) {
   return commit_raw_syscall(syscallno, ptr, ret);
 }
 
+// The alignment of this struct is incorrect, but as long as it's not
+// used inside other structures, defining it this way makes the code below
+// easier.
+typedef uint64_t kernel_sigset_t;
+
+static long sys_rt_sigprocmask(const struct syscall_info* call) {
+  const int syscallno = SYS_rt_sigprocmask;
+  long ret;
+  kernel_sigset_t modified_set;
+  void* oldset2 = NULL;
+
+  void* ptr = prep_syscall();
+
+  int how = (int)call->args[0];
+  const kernel_sigset_t* set = (const kernel_sigset_t*)call->args[1];
+  kernel_sigset_t* oldset = (kernel_sigset_t*)call->args[2];
+
+  if (oldset) {
+    oldset2 = ptr;
+    ptr += sizeof(kernel_sigset_t);
+  }
+  if (!start_commit_buffered_syscall(syscallno, ptr, WONT_BLOCK)) {
+    return traced_raw_syscall(call);
+  }
+
+  if (set && (how == SIG_BLOCK || how == SIG_SETMASK)) {
+    local_memcpy(&modified_set, set, sizeof(kernel_sigset_t));
+    // SIGSTKFLT (PerfCounters::TIME_SLICE_SIGNAL) and
+    // SIGPWR(SYSCALLBUF_DESCHED_SIGNAL) are used by rr
+    modified_set &= ~(((uint64_t)1) << (SIGSTKFLT - 1)) &
+                    ~(((uint64_t)1) << (SIGPWR - 1));
+    set = &modified_set;
+  }
+
+  ret = untraced_syscall4(syscallno, how, set, oldset2, call->args[3]);
+  if (ret == 0) {
+    if (oldset2)
+      local_memcpy(oldset, oldset2, sizeof(kernel_sigset_t));
+    if (set) {
+      struct syscallbuf_hdr* hdr = buffer_hdr();
+      switch (how) {
+        case SIG_UNBLOCK:
+          hdr->blocked_sigs &= ~*set;
+          break;
+        case SIG_BLOCK:
+          hdr->blocked_sigs |= *set;
+          break;
+        case SIG_SETMASK:
+          hdr->blocked_sigs = *set;
+          break;
+      }
+    }
+  }
+
+  return commit_raw_syscall(syscallno, ptr, ret);
+}
+
 static long syscall_hook_internal(const struct syscall_info* call) {
   switch (call->no) {
 #define CASE(syscallname)                                                      \
@@ -2324,6 +2386,7 @@ static long syscall_hook_internal(const struct syscall_info* call) {
 #else
     CASE(fcntl);
 #endif
+    CASE(rt_sigprocmask);
     CASE(fgetxattr);
     CASE(flistxattr);
     CASE_GENERIC_NONBLOCKING_FD(fsetxattr);

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -293,6 +293,13 @@ struct syscallbuf_hdr {
    * When it's zero, the desched signal can safely be
    * discarded. */
   uint8_t desched_signal_may_be_relevant;
+  /* A copy of the tasks's signal mask. Updated by both preload and rr in
+   * response to events that change the signal mask. RR stores this in
+   * RecordTask::blocked_sigs, but since some signal mask affecting system
+   * calls may be buffered, that value may be out of date until rr reloads it
+   * from here.
+   */
+   uint64_t blocked_sigs;
 
   struct syscallbuf_record recs[0];
 } __attribute__((__packed__));

--- a/src/preload/syscall_hook.S
+++ b/src/preload/syscall_hook.S
@@ -265,6 +265,12 @@ SYSCALLHOOK_START(_syscall_hook_trampoline_ba_01_00_00_00)
         mov $1,%edx
 SYSCALLHOOK_END(_syscall_hook_trampoline_ba_01_00_00_00)
 
+SYSCALLHOOK_START(_syscall_hook_trampoline_89_c1_31_d2)
+        call _syscall_hook_trampoline
+        mov %eax,%ecx
+        xor %edx,%edx
+SYSCALLHOOK_END(_syscall_hook_trampoline_89_c1_31_d2)
+
 _syscall_hook_end:
 
 #endif /* __x86_64__ */

--- a/src/test/sigprocmask.c
+++ b/src/test/sigprocmask.c
@@ -11,14 +11,15 @@ static void handle_usr1(__attribute__((unused)) int sig) {
 
 int main(void) {
   sigset_t mask, oldmask;
-  int i, dummy = 0;
+  int i, err, dummy = 0;
 
   signal(SIGUSR1, handle_usr1);
 
   sigemptyset(&mask);
   sigaddset(&mask, SIGUSR1);
   /* The libc function invokes rt_sigprocmask. */
-  sigprocmask(SIG_BLOCK, &mask, &oldmask);
+  err = sigprocmask(SIG_BLOCK, &mask, &oldmask);
+  test_assert(err == 0);
 
   raise(SIGUSR1);
 

--- a/src/util.cc
+++ b/src/util.cc
@@ -357,6 +357,10 @@ static void iterate_checksums(Task* t, ChecksumMode mode,
       auto hdr = t->read_mem(child_hdr);
       mem.resize(sizeof(hdr) + hdr.num_rec_bytes +
                  sizeof(struct syscallbuf_record));
+      /* Zero out the shadow copy of blocked_sigs, we don't keep track of it
+      * during replay, so this makes sure we don't run into problems because
+      * of it. */
+      ((struct syscallbuf_hdr*)mem.data())->blocked_sigs = 0;
     }
 
     uint32_t checksum = compute_checksum(mem.data(), mem.size());


### PR DESCRIPTION
First add syscall buffering for rt_sigprocmask, second if a clone forks the address space, keep the state of thread local initialization since there won't be an explicit re-initialization (and without this the syscallbuf is effectively disabled).