### PR TITLE
Fix a GCC 6.1 compile error with Linux kernel 4.7

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1524,7 +1524,7 @@ template <typename Arch>
 static void copy_tls_arch(const Task::CapturedState& state,
                           AutoRemoteSyscalls& remote) {
   if (Arch::clone_tls_type == Arch::UserDescPointer) {
-    for (const struct user_desc& t : state.thread_areas) {
+    for (const auto& t : state.thread_areas) {
       AutoRestoreMem remote_tls(remote, (const uint8_t*)&t, sizeof(t));
       LOG(debug) << "    setting tls " << remote_tls.get();
       remote.infallible_syscall(


### PR DESCRIPTION
I got the following compile error under GCC 6.1.1, CMake 3.6.1 and Linux kernel 4.7.2:
```
[ 47%] Building CXX object CMakeFiles/rr.dir/src/Task.cc.o
/home/yen/tmp/rr/src/Task.cc: In function ‘void rr::copy_tls_arch(const rr::Task::CapturedState&, rr::AutoRemoteSyscalls&)’:
/home/yen/tmp/rr/src/Task.cc:1527:16: error: types may not be defined in a for-range-declaration [-Werror]
     for (const struct user_desc& t : state.thread_areas) {
                ^~~~~~
cc1plus: all warnings being treated as errors
```
Actually I don't know why the original declaration statement fails. This patch just fixes my problem.