### PR TITLE
In sioc, ignore tun/tap devices

### DIFF
--- a/src/test/sioc.c
+++ b/src/test/sioc.c
@@ -72,6 +72,7 @@ static void get_ifconfig(int sockfd, struct ifreq* req, struct ifreq* eth_req) {
         eth_index = i;
         non_loop_index = i;
         break;
+      case 't':
       case 'l':
         break;
       default:


### PR DESCRIPTION
They don't support a number of the tested ioctls, causing this test
to fail.