### PR TITLE
Add a history command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -735,6 +735,7 @@ set(TESTS_WITH_PROGRAM
   getcwd
   goto_event
   hello
+  history
   ignored_async_usr1
   immediate_restart
   int3_ok

--- a/src/GdbCommand.cc
+++ b/src/GdbCommand.cc
@@ -114,6 +114,9 @@ static SimpleGdbCommand info_checkpoints("info checkpoints",
 
 /*static*/ void GdbCommand::init_auto_args() {
   checkpoint.add_auto_arg("rr-where");
+
+  back.add_post_cmd("frame");
+  forward.add_post_cmd("frame");
 }
 
 } // namespace rr

--- a/src/GdbCommand.h
+++ b/src/GdbCommand.h
@@ -41,7 +41,16 @@ public:
     cmd_auto_args.push_back(auto_arg);
   }
 
+  /**
+   * Execute a gdb command after this command such as 'frame' to give context
+   * after jumping.
+   */
+  void add_post_cmd(const std::string& post_cmd) {
+    cmd_post_cmds.push_back(post_cmd);
+  }
+
   const std::vector<std::string>& auto_args() const { return cmd_auto_args; }
+  const std::vector<std::string>& post_cmds() const { return cmd_post_cmds; }
 
   /**
    * Setup all the automatic auto_args for our commands.
@@ -51,6 +60,7 @@ public:
 private:
   const std::string cmd_name;
   std::vector<std::string> cmd_auto_args;
+  std::vector<std::string> cmd_post_cmds;
 };
 
 class SimpleGdbCommand : public GdbCommand {

--- a/src/GdbCommandHandler.cc
+++ b/src/GdbCommandHandler.cc
@@ -101,8 +101,14 @@ class RRCmd(gdb.Command):
         response = gdb_unescape(rv_match.group(1))
         gdb.write(response)
 
-end
+def history_push(p):
+    gdb.execute("rr-history-push", to_string=True)
 
+# Automatically push an history entry when the program execution stops
+# (signal, breakpoint). This is fired before an interactive prompt is shown.
+gdb.events.stop.connect(history_push)
+
+end
 )Delimiter");
 
   if (gdb_command_list) {

--- a/src/GdbServer.h
+++ b/src/GdbServer.h
@@ -104,6 +104,9 @@ public:
                                   const ExtraRegisters& extra_regs,
                                   GdbRegister which);
 
+  ReplayTimeline& get_timeline() {
+    return timeline;
+  }
 private:
   GdbServer(std::unique_ptr<GdbConnection>& dbg, Task* t);
 

--- a/src/test/history.c
+++ b/src/test/history.c
@@ -1,0 +1,17 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+static void breakpointA(__attribute__((unused)) int i) {
+  int break_here = 1;
+  (void)break_here;
+}
+
+int main(void) {
+  int i;
+  for (i = 0; i < 5; ++i) {
+    breakpointA(i);
+  }
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/history.py
+++ b/src/test/history.py
@@ -1,0 +1,47 @@
+from rrutil import *
+
+send_gdb('b breakpointA')
+expect_gdb('Breakpoint 1')
+send_gdb('c')
+
+expect_gdb('i=0')
+send_gdb('c')
+expect_gdb('i=1')
+send_gdb('c')
+expect_gdb('i=2')
+send_gdb('c')
+expect_gdb('i=3')
+send_gdb('c')
+expect_gdb('i=4')
+
+send_gdb('forward')
+expect_gdb("Can't go forward. No more history entries.")
+
+send_gdb('back')
+send_gdb('frame')
+expect_gdb('i=3')
+send_gdb('back')
+send_gdb('frame')
+expect_gdb('i=2')
+send_gdb('back')
+send_gdb('frame')
+expect_gdb('i=1')
+send_gdb('back')
+send_gdb('frame')
+expect_gdb('i=0')
+
+# Clear the forward stack by pushing a new entry
+send_gdb('c')
+send_gdb('frame')
+expect_gdb('i=1')
+send_gdb('forward')
+expect_gdb("Can't go forward. No more history entries.")
+
+send_gdb('back')
+send_gdb('frame')
+expect_gdb('i=0')
+
+send_gdb('d 1')
+expect_gdb('c')
+
+ok()

--- a/src/test/history.py
+++ b/src/test/history.py
@@ -18,27 +18,21 @@ send_gdb('forward')
 expect_gdb("Can't go forward. No more history entries.")
 
 send_gdb('back')
-send_gdb('frame')
 expect_gdb('i=3')
 send_gdb('back')
-send_gdb('frame')
 expect_gdb('i=2')
 send_gdb('back')
-send_gdb('frame')
 expect_gdb('i=1')
 send_gdb('back')
-send_gdb('frame')
 expect_gdb('i=0')
 
 # Clear the forward stack by pushing a new entry
 send_gdb('c')
-send_gdb('frame')
 expect_gdb('i=1')
 send_gdb('forward')
 expect_gdb("Can't go forward. No more history entries.")
 
 send_gdb('back')
-send_gdb('frame')
 expect_gdb('i=0')
 
 send_gdb('d 1')

--- a/src/test/history.run
+++ b/src/test/history.run
@@ -1,0 +1,2 @@
+source `dirname $0`/util.sh
+debug_test


### PR DESCRIPTION
I left out the 'history' or 'info history' command. This is because the command would require a 'rr-where' command to be executed after each gdb.stop and could hurt interactivity performance. I bet it's not that much but for now I'd rather get this landed and we can fork a different discussion on how costly that command is, if we have a faster alternative and if the delay is acceptable.