### PR TITLE
Get rr working with chromium

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,6 +444,7 @@ set(BASIC_TESTS
   clone_bad_stack
   clone_file_range
   clone_immediate_exit
+  clone_newflags
   clone_untraced
   constructor
   creat_address_not_truncated

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,7 @@ set(RR_SOURCES
   src/kernel_metadata.cc
   src/log.cc
   src/MagicSaveDataMonitor.cc
+  src/MmappedFileMonitor.cc
   src/MonitoredSharedMemory.cc
   src/Monkeypatcher.cc
   src/PerfCounters.cc
@@ -519,6 +520,7 @@ set(BASIC_TESTS
   mmap_shared
   mmap_shared_multiple
   mmap_shared_subpage
+  mmap_shared_write
   mmap_short_file
   mmap_tmpfs
   mprotect

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,7 @@ set(RR_SOURCES
   src/MonitoredSharedMemory.cc
   src/Monkeypatcher.cc
   src/PerfCounters.cc
+  src/ProcFdDirMonitor.cc
   src/ProcMemMonitor.cc
   src/PsCommand.cc
   src/RecordCommand.cc
@@ -554,6 +555,7 @@ set(BASIC_TESTS
   prctl_deathsig
   prctl_name
   prctl_tsc
+  proc_fds
   proc_mem
   protect_rr_fds
   prw

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -843,6 +843,7 @@ set(TESTS_WITHOUT_PROGRAM
   final_sigkill
   first_instruction
   fork_exec_info_thr
+  gcrypt_rdrand
   get_thread_list
   hardlink_mmapped_files
   mprotect_step

--- a/src/FdTable.cc
+++ b/src/FdTable.cc
@@ -85,8 +85,17 @@ void FdTable::did_dup(int from, int to) {
 }
 
 void FdTable::did_close(int fd) {
+  LOG(debug) << "Close fd " << fd;
   fds.erase(fd);
   update_syscallbuf_fds_disabled(fd);
+}
+
+FileMonitor* FdTable::get_monitor(int fd) {
+  auto it = fds.find(fd);
+  if (it == fds.end()) {
+    return NULL;
+  }
+  return it->second.get();
 }
 
 static bool is_fd_monitored_in_any_task(AddressSpace* vm, int fd) {

--- a/src/FdTable.cc
+++ b/src/FdTable.cc
@@ -24,12 +24,12 @@ void FdTable::add_monitor(int fd, FileMonitor* monitor) {
   update_syscallbuf_fds_disabled(fd);
 }
 
-bool FdTable::allow_close(int fd) {
+bool FdTable::is_rr_fd(int fd) {
   auto it = fds.find(fd);
   if (it == fds.end()) {
-    return true;
+    return false;
   }
-  return it->second->allow_close();
+  return it->second->is_rr_fd();
 }
 
 bool FdTable::emulate_ioctl(int fd, RecordTask* t, uint64_t* result) {
@@ -56,6 +56,14 @@ bool FdTable::emulate_read(int fd, RecordTask* t,
     return false;
   }
   return it->second->emulate_read(t, ranges, offset, result);
+}
+
+void FdTable::filter_getdents(int fd, RecordTask* t) {
+  auto it = fds.find(fd);
+  if (it == fds.end()) {
+    return;
+  }
+  it->second->filter_getdents(t);
 }
 
 Switchable FdTable::will_write(Task* t, int fd) {

--- a/src/FdTable.h
+++ b/src/FdTable.h
@@ -43,6 +43,8 @@ public:
 
   bool is_monitoring(int fd) { return fds.count(fd) > 0; }
 
+  FileMonitor* get_monitor(int fd);
+
   /**
    * Regenerate syscallbuf_fds_disabled in task |t|.
    * Called during initialization of the preload library.

--- a/src/FdTable.h
+++ b/src/FdTable.h
@@ -23,7 +23,8 @@ public:
   bool emulate_read(int fd, RecordTask* t,
                     const std::vector<FileMonitor::Range>& ranges,
                     int64_t offset, uint64_t* result);
-  bool allow_close(int fd);
+  void filter_getdents(int fd, RecordTask* t);
+  bool is_rr_fd(int fd);
   Switchable will_write(Task* t, int fd);
   void did_write(Task* t, int fd, const std::vector<FileMonitor::Range>& ranges,
                  int64_t offset = -1);

--- a/src/FileMonitor.h
+++ b/src/FileMonitor.h
@@ -29,6 +29,7 @@ public:
     MagicSaveData,
     Mmapped,
     Preserve,
+    ProcFd,
     ProcMem,
     Stdio,
     VirtualPerfCounter,
@@ -37,10 +38,11 @@ public:
   virtual Type type() { return Base; }
 
   /**
-   * Overriding this to return false will cause close() (and related fd-smashing
-   * operations such as dup2) to return EBADF.
+   * Overriding this to return true will cause close() (and related fd-smashing
+   * operations such as dup2) to return EBADF, and hide it from the tracee's
+   * /proc/pid/fd/
    */
-  virtual bool allow_close() { return true; }
+  virtual bool is_rr_fd() { return false; }
 
   /**
    * Notification that task |t| is about to write |data| bytes of length
@@ -90,6 +92,12 @@ public:
                             uint64_t*) {
     return false;
   }
+
+  /**
+   * Allows the FileMonitor to rewrite the output of a getdents/getdents64 call
+   * if desired.
+   */
+  virtual void filter_getdents(RecordTask*) { }
 };
 
 } // namespace rr

--- a/src/FileMonitor.h
+++ b/src/FileMonitor.h
@@ -24,6 +24,18 @@ public:
 
   virtual ~FileMonitor() {}
 
+  enum Type {
+    Base,
+    MagicSaveData,
+    Mmapped,
+    Preserve,
+    ProcMem,
+    Stdio,
+    VirtualPerfCounter,
+  };
+
+  virtual Type type() { return Base; }
+
   /**
    * Overriding this to return false will cause close() (and related fd-smashing
    * operations such as dup2) to return EBADF.

--- a/src/MagicSaveDataMonitor.h
+++ b/src/MagicSaveDataMonitor.h
@@ -14,6 +14,8 @@ class MagicSaveDataMonitor : public FileMonitor {
 public:
   MagicSaveDataMonitor() {}
 
+  virtual Type type() { return MagicSaveData; }
+
   /**
    * During recording, record the written data.
    * During replay, check that the written data matches what was recorded.

--- a/src/MmappedFileMonitor.cc
+++ b/src/MmappedFileMonitor.cc
@@ -1,0 +1,72 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "MmappedFileMonitor.h"
+
+#include "RecordSession.h"
+#include "RecordTask.h"
+#include "log.h"
+
+using namespace std;
+
+namespace rr {
+
+MmappedFileMonitor::MmappedFileMonitor(Task* t, int fd) {
+  ASSERT(t, !t->session().is_replaying());
+  stat_ = t->stat_fd(fd);
+}
+
+MmappedFileMonitor::MmappedFileMonitor(Task* t, EmuFile::shr_ptr f) {
+  ASSERT(t, t->session().is_replaying());
+  emu_file_ = f;
+}
+
+void MmappedFileMonitor::did_write(Task* t, const std::vector<Range>& ranges,
+				   int64_t offset) {
+  if (ranges.empty()) {
+    return;
+  }
+
+  ASSERT(t, offset >= 0)
+      << "Only pwrite/pwritev supported on /proc/<pid>/mem currently";
+  // XXX to fix that, we'd have to grab the file offset from
+  // /proc/<pid>/fdinfo.
+
+  bool is_replay = t->session().is_replaying();
+  for (auto v : t->session().vms()) {
+    for (auto m : v->maps()) {
+      auto km = m.map;
+
+      if (is_replay) {
+        if (!emu_file_ || emu_file_ != m.emu_file) {
+          continue;
+        }
+      } else {
+        if (km.device() != stat_.st_dev || km.inode() != stat_.st_ino) {
+          continue;
+        }
+      }
+
+      // stat matches.
+      ASSERT(t, km.flags() & MAP_SHARED);
+      uint64_t mapping_offset = km.file_offset_bytes();
+      int64_t local_offset = offset;
+      for (auto r : ranges) {
+        remote_ptr<void> start = km.start() + local_offset - mapping_offset;
+        MemoryRange mr(start, r.length);
+        if (km.intersects(mr)) {
+          if (is_replay) {
+            // If we're writing beyond the EmuFile's end, resize it.
+            emu_file_->ensure_size(local_offset + r.length);
+          } else {
+            // We will record multiple writes if the file is mapped multiple
+            // times. This is inefficient, but not wrong.
+            static_cast<RecordTask*>(t)->record_remote(km.intersect(mr));
+          }
+        }
+        local_offset += r.length;
+      }
+    }
+  }
+}
+
+} // namespace rr

--- a/src/MmappedFileMonitor.h
+++ b/src/MmappedFileMonitor.h
@@ -1,0 +1,37 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#ifndef RR_MMAPPED_FILE_MONITOR_H_
+#define RR_MMAPPED_FILE_MONITOR_H_
+
+#include "EmuFs.h"
+#include "FileMonitor.h"
+
+#include <sys/stat.h>
+
+namespace rr {
+
+/**
+ * A FileMonitor to track writes to files that are mmapped in so they can be
+ * replayed.
+ */
+class MmappedFileMonitor : public FileMonitor {
+public:
+  MmappedFileMonitor(Task* t, int fd);
+  MmappedFileMonitor(Task* t, EmuFile::shr_ptr f);
+
+  virtual Type type() { return Mmapped; }
+
+  /**
+   * During recording, note writes to mapped segments.
+   */
+  virtual void did_write(Task* t, const std::vector<Range>& ranges,
+                         int64_t offset);
+
+private:
+  struct stat stat_;
+  EmuFile::shr_ptr emu_file_;
+};
+
+} // namespace rr
+
+#endif /* RR_MMAPPED_FILE_MONITOR_H_ */

--- a/src/PreserveFileMonitor.h
+++ b/src/PreserveFileMonitor.h
@@ -20,6 +20,7 @@ namespace rr {
 class PreserveFileMonitor : public FileMonitor {
 public:
   PreserveFileMonitor() {}
+  virtual Type type() { return Preserve; }
   virtual bool allow_close() { return false; }
 };
 

--- a/src/PreserveFileMonitor.h
+++ b/src/PreserveFileMonitor.h
@@ -10,7 +10,7 @@ namespace rr {
 /**
  * A FileMonitor that does no monitoring of I/O itself, but prevents the file
  * descriptor from being closed (except via privileged syscalls made by
- * preload.c).
+ * preload.c) or seen in /proc/pid/fd/.
  *
  * The mere existence of this monitor disables syscall buffering for the fd, so
  * we get syscall traps for close() etc on the fd. Then
@@ -21,7 +21,7 @@ class PreserveFileMonitor : public FileMonitor {
 public:
   PreserveFileMonitor() {}
   virtual Type type() { return Preserve; }
-  virtual bool allow_close() { return false; }
+  virtual bool is_rr_fd() { return true; }
 };
 
 } // namespace rr

--- a/src/ProcFdDirMonitor.cc
+++ b/src/ProcFdDirMonitor.cc
@@ -1,0 +1,133 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "ProcFdDirMonitor.h"
+
+#include <dirent.h>
+#include <stdlib.h>
+
+#include "AutoRemoteSyscalls.h"
+#include "RecordSession.h"
+#include "RecordTask.h"
+#include "log.h"
+
+using namespace std;
+
+namespace rr {
+
+ProcFdDirMonitor::ProcFdDirMonitor(Task* t, const string& pathname) {
+  // XXX this makes some assumptions about namespaces... Probably fails
+  // if |t| is not the same pid namespace as rr
+  int ends_with_slash = (pathname.back() == '/');
+  if (pathname.substr(0, 6) == string("/proc/") &&
+      pathname.substr(pathname.size() - 3 - ends_with_slash,
+		      3) == string("/fd")) {
+    string s = pathname.substr(6, pathname.size() - 9 - ends_with_slash);
+    char* end;
+    int tid = strtol(s.c_str(), &end, 10);
+    if (!*end) {
+      Task* target = t->session().find_task(tid);
+      if (target) {
+        tuid = target->tuid();
+      }
+    }
+  }
+}
+
+// returns the number of valid dirent structs left in the buffer
+template <typename D>
+static int filter_dirent_structs(RecordTask* t, uint8_t* buf, size_t size) {
+  int bytes = 0;
+  size_t current_offset = 0;
+  while (1) {
+    if (current_offset == size) {
+      break;
+    }
+
+    D* current_struct = reinterpret_cast<D*>(buf + current_offset);
+    auto next_off = current_offset + current_struct->d_reclen;
+
+    char* fname = (char*)current_struct->d_name;
+    char* end;
+    int fd = strtol(fname, &end, 10);
+    if (!*end && t->fd_table()->is_rr_fd(fd)) {
+      // Skip this entry.
+      memmove(current_struct, buf + next_off, size - next_off);
+      size -= (next_off - current_offset);
+      next_off = current_offset;
+    } else {
+      // Either this is a tracee fd or not an fd at all (e.g. '.')
+      bytes += current_struct->d_reclen;
+    }
+
+    current_offset = next_off;
+  }
+
+  return bytes;
+}
+
+template <typename Arch>
+static void filter_dirents_arch(RecordTask* t) {
+  auto regs = t->regs();
+  remote_ptr<uint8_t> ptr(regs.arg2());
+  size_t len = regs.arg3();
+
+  if (regs.syscall_failed() || !regs.syscall_result()) {
+    return;
+  }
+
+  while (1) {
+    vector<uint8_t> buf = t->read_mem(ptr, len);
+    int bytes = regs.syscall_result();
+    if (regs.syscallno() == Arch::getdents64) {
+      bytes = filter_dirent_structs<typename Arch::dirent64>(t, buf.data(),
+                                                             bytes);
+    } else {
+      bytes = filter_dirent_structs<typename Arch::dirent>(t, buf.data(),
+                                                           bytes);
+    }
+
+    if (bytes > 0) {
+      t->write_mem(ptr, buf.data(), bytes);
+      regs.set_syscall_result(bytes);
+      t->set_regs(regs);
+      // Explicitly record what the kernel may have touched and we discarded,
+      // because it's userspace modification that will not be caught otherwise.
+      if (len > bytes) {
+        t->record_remote(ptr + bytes, len - bytes);
+      }
+      return;
+    }
+
+    // We filtered out all the entries, so we need to repeat the syscall.
+    {
+      AutoRemoteSyscalls remote(t);
+      remote.syscall(regs.original_syscallno(), regs.arg1(), regs.arg2(),
+                     regs.arg3());
+      regs = t->regs();
+    }
+
+    if (regs.syscall_failed() || regs.syscall_result() == 0) {
+      // Save the new syscall result, and record the buffer we will otherwise
+      // ignore.
+      t->record_remote(ptr, len);
+      t->set_regs(regs);
+      return;
+    }
+  }
+}
+
+static void filter_dirents(RecordTask* t) {
+  RR_ARCH_FUNCTION(filter_dirents_arch, t->arch(), t);
+}
+
+void ProcFdDirMonitor::filter_getdents(RecordTask* t) {
+  ASSERT(t, !t->session().is_replaying());
+  auto* target = static_cast<RecordTask*>(t->session().find_task(tuid));
+  if (!target) {
+    return;
+  }
+
+  filter_dirents(t);
+}
+
+} // namespace rr

--- a/src/ProcFdDirMonitor.h
+++ b/src/ProcFdDirMonitor.h
@@ -1,0 +1,30 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#ifndef RR_PROC_FD_DIR_MONITOR_H_
+#define RR_PROC_FD_DIR_MONITOR_H_
+
+#include "FileMonitor.h"
+#include "TaskishUid.h"
+
+namespace rr {
+
+/**
+ * A FileMonitor to intercept enumerations of /proc/<pid>/fd so that entries
+ * for rr's private fds can be hidden when <pid> is a tracee.
+ */
+class ProcFdDirMonitor : public FileMonitor {
+public:
+  ProcFdDirMonitor(Task* t, const std::string& pathname);
+
+  virtual Type type() { return ProcFd; }
+
+  virtual void filter_getdents(RecordTask* t);
+
+private:
+  // 0 if this doesn't object doesn't refer to a tracee's proc-mem.
+  TaskUid tuid;
+};
+
+} // namespace rr
+
+#endif /* RR_PROC_FD_DIR_MONITOR_H_ */

--- a/src/ProcMemMonitor.h
+++ b/src/ProcMemMonitor.h
@@ -16,6 +16,8 @@ class ProcMemMonitor : public FileMonitor {
 public:
   ProcMemMonitor(Task* t, const std::string& pathname);
 
+  virtual Type type() { return ProcMem; }
+
   /**
    * During replay, copy writes to tracee |tid|'s memory.
    */

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1652,6 +1652,11 @@ static string lookup_by_path(const string& name) {
   // it is useless when running under rr.
   env.push_back("MOZ_GDB_SLEEP=0");
 
+  // OpenSSL uses RDRAND, but we can disable it. These bitmasks are inverted
+  // and ANDed with the results of CPUID. The number below is 2^62, which is the
+  // bit for RDRAND support.
+  env.push_back("OPENSSL_ia32cap=~4611686018427387904:~0");
+
   shr_ptr session(
       new RecordSession(full_path, argv, env, syscallbuf, bind_cpu));
   return session;

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -325,6 +325,9 @@ public:
   template <typename T> void record_remote(remote_ptr<T> addr) {
     record_remote(addr, sizeof(T));
   }
+  void record_remote(const MemoryRange& range) {
+    record_remote(range.start(), range.size());
+  }
   // Record as much as we can of the bytes in this range.
   void record_remote_fallible(remote_ptr<void> addr, ssize_t num_bytes);
 

--- a/src/ReplayTask.cc
+++ b/src/ReplayTask.cc
@@ -121,7 +121,8 @@ const TraceFrame& ReplayTask::current_trace_frame() {
 ssize_t ReplayTask::set_data_from_trace() {
   auto buf = trace_reader().read_raw_data();
   if (!buf.addr.is_null() && buf.data.size() > 0) {
-    write_bytes_helper(buf.addr, buf.data.size(), buf.data.data());
+    auto t = session().find_task(buf.rec_tid);
+    t->write_bytes_helper(buf.addr, buf.data.size(), buf.data.data());
   }
   return buf.data.size();
 }
@@ -130,7 +131,8 @@ void ReplayTask::apply_all_data_records_from_trace() {
   TraceReader::RawData buf;
   while (trace_reader().read_raw_data_for_frame(current_trace_frame(), buf)) {
     if (!buf.addr.is_null() && buf.data.size() > 0) {
-      write_bytes_helper(buf.addr, buf.data.size(), buf.data.data());
+      auto t = session().find_task(buf.rec_tid);
+      t->write_bytes_helper(buf.addr, buf.data.size(), buf.data.data());
     }
   }
 }

--- a/src/StdioMonitor.h
+++ b/src/StdioMonitor.h
@@ -22,6 +22,8 @@ public:
    */
   StdioMonitor(int original_fd) : original_fd(original_fd) {}
 
+  virtual Type type() { return Stdio; }
+
   /**
    * Make writes to stdout/stderr blocking, to avoid nondeterminism in the
    * order in which the kernel actually performs such writes.

--- a/src/VirtualPerfCounterMonitor.h
+++ b/src/VirtualPerfCounterMonitor.h
@@ -20,6 +20,8 @@ public:
   VirtualPerfCounterMonitor(Task* t, Task* target,
                             const struct perf_event_attr& attr);
 
+  virtual Type type() { return VirtualPerfCounter; }
+
   virtual bool emulate_ioctl(RecordTask* t, uint64_t* result);
   virtual bool emulate_fcntl(RecordTask* t, uint64_t* result);
   virtual bool emulate_read(RecordTask* t, const std::vector<Range>& ranges,

--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -8,6 +8,7 @@
 #include <arpa/inet.h>
 #include <asm/ldt.h>
 #include <assert.h>
+#include <dirent.h>
 #include <elf.h>
 #include <fcntl.h>
 #include <linux/capability.h>

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1297,6 +1297,24 @@ struct BaseArch : public wordsize,
     ptr<void> data;
   };
   RR_VERIFY_TYPE(usbdevfs_ctrltransfer);
+
+  struct dirent {
+    ino_t d_ino;
+    off_t d_off;
+    uint16_t d_reclen;
+    //    uint8_t d_type;
+    uint8_t d_name[256];
+  };
+  RR_VERIFY_TYPE(dirent);
+
+  struct dirent64 {
+    ino64_t d_ino;
+    off64_t d_off;
+    uint16_t d_reclen;
+    uint8_t d_type;
+    uint8_t d_name[256];
+  };
+  RR_VERIFY_TYPE(dirent64);
 };
 
 struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1752,4 +1752,9 @@ typedef X64Arch NativeArch;
 
 } // namespace rr
 
+// New in the 4.6 kernel.
+#ifndef CLONE_NEWCGROUP
+#define CLONE_NEWCGROUP 0x02000000
+#endif
+
 #endif /* RR_KERNEL_ABI_H */

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -343,6 +343,10 @@ inline static int is_blacklisted_filename(const char* filename) {
          !strcmp("/usr/share/alsa/alsa.conf", filename);
 }
 
+inline static int is_gcrypt_deny_file(const char* filename) {
+  return !strcmp("/etc/gcrypt/hwf.deny", filename);
+}
+
 inline static int is_terminal(const char* filename) {
   return !strncmp("/dev/tty", filename, 8) || !strncmp("/dev/pts", filename, 8);
 }
@@ -363,7 +367,9 @@ inline static int is_proc_mem_file(const char* filename) {
  * common cases) is a problem. Maybe we could afford fstat after every open...
  */
 inline static int allow_buffered_open(const char* filename) {
-  return !is_blacklisted_filename(filename) && !is_terminal(filename) &&
+  return !is_blacklisted_filename(filename) &&
+         !is_gcrypt_deny_file(filename) &&
+         !is_terminal(filename) &&
          !is_proc_mem_file(filename);
 }
 

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -358,6 +358,20 @@ inline static int is_proc_mem_file(const char* filename) {
   return !strcmp(filename + strlen(filename) - 4, "/mem");
 }
 
+inline static int is_proc_fd_dir(const char* filename) {
+  if (strncmp("/proc/", filename, 6)) {
+    return 0;
+  }
+
+  int len = strlen(filename);
+  const char* fd_bit = filename + len;
+  if (*fd_bit == '/') {
+    fd_bit--;
+  }
+
+  return !strncmp(fd_bit - 3, "/fd", 3);
+}
+
 /**
  * Returns nonzero if an attempted open() of |filename| can be syscall-buffered.
  * When this returns zero, the open must be forwarded to the rr process.
@@ -370,7 +384,8 @@ inline static int allow_buffered_open(const char* filename) {
   return !is_blacklisted_filename(filename) &&
          !is_gcrypt_deny_file(filename) &&
          !is_terminal(filename) &&
-         !is_proc_mem_file(filename);
+         !is_proc_mem_file(filename) &&
+         !is_proc_fd_dir(filename);
 }
 
 #endif /* RR_PRELOAD_INTERFACE_H_ */

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -177,7 +177,12 @@ template <typename Arch> static void prepare_clone(ReplayTask* t) {
     // and we can't allow that.
     // Block CLONE_CHILD_CLEARTID because we'll emulate that ourselves.
     // Block CLONE_VFORK for the reasons below.
-    flags = r.arg1() & ~(CLONE_UNTRACED | CLONE_CHILD_CLEARTID | CLONE_VFORK);
+    // Block CLONE_NEW* from replay, any effects it had were dealt with during
+    // recording.
+    uintptr_t disallowed_clone_flags = CLONE_UNTRACED | CLONE_CHILD_CLEARTID |
+      CLONE_VFORK | CLONE_NEWIPC | CLONE_NEWNET | CLONE_NEWNS | CLONE_NEWPID |
+      CLONE_NEWUSER | CLONE_NEWUTS | CLONE_NEWCGROUP;
+    flags = r.arg1() & ~disallowed_clone_flags;
     r.set_arg1(flags);
   } else if (Arch::vfork == sys) {
     // We can't perform a real vfork, because the kernel won't let the vfork

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -30,6 +30,7 @@
 #include "AutoRemoteSyscalls.h"
 #include "EmuFs.h"
 #include "MmappedFileMonitor.h"
+#include "ProcFdDirMonitor.h"
 #include "ProcMemMonitor.h"
 #include "ReplaySession.h"
 #include "ReplayTask.h"
@@ -1018,6 +1019,8 @@ static void handle_opened_files(ReplayTask* t) {
       t->fd_table()->add_monitor(fd, new StdioMonitor(STDERR_FILENO));
     } else if (is_proc_mem_file(pathname.c_str())) {
       t->fd_table()->add_monitor(fd, new ProcMemMonitor(t, pathname));
+    } else if (is_proc_fd_dir(pathname.c_str())) {
+      t->fd_table()->add_monitor(fd, new ProcFdDirMonitor(t, pathname));
     } else {
       ASSERT(t, false) << "Why did we write filename " << pathname;
     }

--- a/src/test/clone_newflags.c
+++ b/src/test/clone_newflags.c
@@ -1,0 +1,37 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+static void overwrite_file(const char* path, ssize_t num_bytes) {
+  const int magic = 0x5a5a5a5a;
+  int fd = open(path, O_TRUNC | O_RDWR, 0600);
+  size_t i;
+  for (i = 0; i < num_bytes / sizeof(magic); ++i) {
+    write(fd, &magic, sizeof(magic));
+  }
+  close(fd);
+}
+
+int main(void) {
+  pid_t child;
+  int ret;
+  int status;
+
+  char name[] = "/tmp/rr-clone-newflags-XXXXXX";
+  int fd = mkstemp(name);
+
+  overwrite_file(name, 0x1000);
+
+  child = syscall(SYS_clone, CLONE_NEWUSER | SIGCHLD, 0, 0, 0, 0);
+  if (!child) {
+    mmap(NULL, 0x1000, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    atomic_puts("EXIT-SUCCESS");
+    return 77;
+  }
+  ret = wait(&status);
+  test_assert(0 == unlink(name));
+  test_assert(child == ret);
+  test_assert(WIFEXITED(status) && 77 == WEXITSTATUS(status));
+
+  return 0;
+}

--- a/src/test/gcrypt_rdrand.run
+++ b/src/test/gcrypt_rdrand.run
@@ -1,0 +1,9 @@
+source `dirname $0`/util.sh
+
+# Override record since there's no program here.
+
+function record { exe=$1;
+    just_record $exe "$2 $3 $4 $5"
+}
+
+compare_test intel-rdrand "" "cat /etc/gcrypt/hwf.deny"

--- a/src/test/mmap_shared_write.c
+++ b/src/test/mmap_shared_write.c
@@ -1,0 +1,70 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+static void check_mapping(int* page, int magic, ssize_t nr_ints) {
+  int i;
+  for (i = 0; i < nr_ints; ++i) {
+    test_assert(page[i] == magic);
+  }
+  atomic_printf("  %p has the correct values\n", page);
+}
+
+int main(void) {
+  size_t num_bytes = sysconf(_SC_PAGESIZE);
+  char file_name[] = "/tmp/rr-test-mremap-XXXXXX";
+  int fd = mkstemp(file_name);
+  int* rpage;
+
+  test_assert(fd >= 0);
+
+  int magic = 0x5a5a5a5a;
+  size_t i;
+  for (i = 0; i < 3 * num_bytes / sizeof(magic); ++i) {
+    pwrite64(fd, &magic, sizeof(magic), i * sizeof(magic));
+  }
+
+  rpage = mmap(NULL, num_bytes, PROT_READ, MAP_SHARED, fd, 0);
+  atomic_printf("rpage:%p\n", rpage);
+  test_assert(rpage != (void*)-1);
+
+  magic = 0xa5a5a5a5;
+  for (i = 0; i < num_bytes / sizeof(magic); ++i) {
+    pwrite64(fd, &magic, sizeof(magic), i * sizeof(magic));
+  }
+
+  check_mapping(rpage, 0xa5a5a5a5, num_bytes / sizeof(*rpage));
+
+  magic = 0x5a5a5a5a;
+  for (i = 0; i < num_bytes / sizeof(magic); ++i) {
+    pwrite64(fd, &magic, sizeof(magic), i * sizeof(magic));
+  }
+
+  check_mapping(rpage, 0x5a5a5a5a, num_bytes / sizeof(*rpage));
+
+  magic = 0xa5a5a5a5;
+  for (i = 0; i < num_bytes / sizeof(magic); ++i) {
+    pwrite64(fd, &magic, sizeof(magic), num_bytes + i * sizeof(magic));
+  }
+
+  check_mapping(rpage, 0x5a5a5a5a, num_bytes / sizeof(*rpage));
+
+  magic = 0xdeadbeef;
+  pwrite64(fd, &magic, sizeof(magic), num_bytes / 2);
+
+  test_assert(rpage[num_bytes / (sizeof(magic) * 2)] == magic);
+  test_assert(rpage[0] != magic);
+
+  pwrite64(fd, &magic, sizeof(magic), num_bytes - 2);
+  test_assert(rpage[num_bytes / sizeof(magic) - 1] == (int)0xbeef5a5a);
+
+  rpage = mremap(rpage, num_bytes, 5 * num_bytes, MREMAP_MAYMOVE);
+  for (i = 3 * num_bytes / sizeof(magic); i < 5 * num_bytes / sizeof(magic); ++i) {
+    pwrite64(fd, &magic, sizeof(magic), i * sizeof(magic));
+  }
+
+  atomic_puts("EXIT-SUCCESS");
+
+  return 0;
+
+}

--- a/src/test/proc_fds.c
+++ b/src/test/proc_fds.c
@@ -1,0 +1,61 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+#include <dirent.h>
+#include <unistd.h>
+
+pthread_barrier_t bar;
+
+void* thread_func(__attribute__((unused)) void* name) {
+  pthread_barrier_wait(&bar);
+  sleep(1);
+  return NULL;
+}
+
+int main(void) {
+  // Empirically tested to be enough to make ProcFdDirMonitor
+  // repeat the getdents call.
+  const int NUM_THREADS = 20;
+  
+  int i;
+  for (i = 0; i < 15; i++) {
+    dup(2);
+  }
+
+  close(RR_MAGIC_SAVE_DATA_FD);
+
+  /* init barrier */
+  pthread_barrier_init(&bar, NULL, NUM_THREADS + 1);
+  /* Create independent threads each of which will execute
+   * function */
+  for (i = 0; i < NUM_THREADS; i++) {
+    pthread_t thread;
+    pthread_create(&thread, NULL, thread_func, NULL);
+  }
+
+  pthread_barrier_wait(&bar);
+
+  const char proc_fd_path[] = "/proc/self/fd";
+  int fd = syscall(SYS_open, proc_fd_path, O_DIRECTORY);
+  test_assert(fd >= 0);
+
+  char buf[128];
+  char* current;
+  int bytes;
+  while((bytes = syscall(SYS_getdents64, fd, &buf, sizeof(buf)))) {
+    current = buf;
+    while (current != buf + bytes) {
+      struct dirent* ent = (struct dirent*)current;
+      char* end;
+      int fd = strtol(ent->d_name, &end, 10);
+      if (!*end) {
+        test_assert(fd < 20); // Other fds should be cloaked!
+      }
+      current += ent->d_reclen;
+    }
+  }
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/shared_map.c
+++ b/src/test/shared_map.c
@@ -36,7 +36,7 @@ int main(void) {
   test_assert(WIFEXITED(status) && WEXITSTATUS(status) == 77);
 
   memset(buf, 3, 10);
-  test_assert(10 == write(fd, buf, 10));
+  test_assert(10 == pwrite(fd, buf, 10, 0));
   test_assert(0 == fsync(fd));
   test_assert(0 == close(fd));
   test_assert(0 == unlink("tmp.txt"));

--- a/src/util.cc
+++ b/src/util.cc
@@ -805,4 +805,17 @@ bool uses_invisible_guard_page() {
   return !is_pax_kernel;
 }
 
+void copy_file(Task* t, int dest_fd, int src_fd) {
+  char buf[1024];
+  while (1) {
+    ssize_t bytes_read = read(src_fd, buf, sizeof(buf));
+    ASSERT(t, bytes_read >= 0);
+    if (!bytes_read) {
+      break;
+    }
+    ssize_t bytes_written = write(dest_fd, buf, bytes_read);
+    ASSERT(t, bytes_written == bytes_read);
+  }
+}
+
 } // namespace rr

--- a/src/util.h
+++ b/src/util.h
@@ -262,6 +262,8 @@ std::vector<std::string> read_proc_status_fields(pid_t tid, const char* name,
  */
 bool uses_invisible_guard_page();
 
+void copy_file(Task* t, int dest_fd, int src_fd);
+
 } // namespace rr
 
 #endif /* RR_UTIL_H_ */


### PR DESCRIPTION
The heavy lifting here is hiding all of rr's private fds from Chromium's sandboxing code.  To do this, we get rid of the constant MAGIC_SAVE_DATA_FD (replacing it with a syscall that hands out a dynamically constructed fd instead) and hide rr's remaining fd's beyond the current fd limit.  It's not necessary for chromium, but we could lie about the maximum fd limit to stop the tracee from raising the current limit into rr's private area.

We also have to disable RDRAND support in both OpenSSL (BoringSSL thankfully uses the same env var) and gcrypt (used by chromium's native password keyring integration).

Chromium builds SQLite in a special way that uses mmap for reading but syscalls for writing.  Support for that is added for the simple cases (the fd being written to and the fd that was mmapped are the same).

Finally, CLONE_NEWUSER needs to be stripped from clone() during replay so that rr can poke the tracee.