### PR TITLE
Fix rr-cmd to handle DiversionSession (fix issue 1791)

### DIFF
--- a/src/GdbCommand.cc
+++ b/src/GdbCommand.cc
@@ -31,7 +31,11 @@ static std::vector<ReplayTimeline::Mark> back_stack;
 static ReplayTimeline::Mark current_history_cp;
 static std::vector<ReplayTimeline::Mark> forward_stack;
 static SimpleGdbCommand rr_history_push(
-    "rr-history-push", [](GdbServer& gdb_server, Task*, const vector<string>&) {
+    "rr-history-push", [](GdbServer& gdb_server, Task* t, const vector<string>&) {
+      if (!t->session().is_replaying()) {
+        // Don't create new history state inside a diversion
+        return string();
+      }
       if (current_history_cp) {
         back_stack.push_back(current_history_cp);
       }

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -606,7 +606,6 @@ bool GdbServer::diverter_process_debugger_requests(
     switch (req->type) {
       case DREQ_RESTART:
       case DREQ_DETACH:
-      case DREQ_RR_CMD:
         diversion_refcount = 0;
         return false;
 
@@ -640,6 +639,16 @@ bool GdbServer::diverter_process_debugger_requests(
         }
         dbg->reply_write_siginfo();
         continue;
+
+      case DREQ_RR_CMD:
+        if (req->target.tid) {
+          Task* task = diversion_session.find_task(req->target.tid);
+          if (task) {
+            dbg->reply_rr_cmd(
+                GdbCommandHandler::process_command(*this, task, req->text()));
+          }
+        }
+        break;
 
       default:
         break;


### PR DESCRIPTION
Please double check how I get my task in a diversion session. I'm not sure if that's the right way to do it.

With this PR the test passes locally.