### PR TITLE
fixing comparison between unsigned and signed integer

### DIFF
--- a/src/ProcFdDirMonitor.cc
+++ b/src/ProcFdDirMonitor.cc
@@ -92,7 +92,7 @@ static void filter_dirents_arch(RecordTask* t) {
       t->set_regs(regs);
       // Explicitly record what the kernel may have touched and we discarded,
       // because it's userspace modification that will not be caught otherwise.
-      if (len > bytes) {
+      if (len > (size_t)bytes) {
         t->record_remote(ptr + bytes, len - bytes);
       }
       return;


### PR DESCRIPTION
Hi there,

I adding cast to address comparison between unsigned and signed integer expression. This cropped up on 3ea898e9f3401b126797bc04f2d96123f49ee495 when running `make`:

```
[ 64%] Building CXX object CMakeFiles/rr.dir/src/PerfCounters.cc.o
[ 65%] Building CXX object CMakeFiles/rr.dir/src/ProcFdDirMonitor.cc.o
/blah/rr/src/ProcFdDirMonitor.cc: In instantiation of ‘void rr::filter_dirents_arch(rr::RecordTask*) [with Arch = rr::X86Arch]’:
/blah/rr/src/ProcFdDirMonitor.cc:120:3:   required from here
/blah/rr/src/ProcFdDirMonitor.cc:95:15: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
       if (len > bytes) {
               ^
/blah/rr/src/ProcFdDirMonitor.cc: In instantiation of ‘void rr::filter_dirents_arch(rr::RecordTask*) [with Arch = rr::X64Arch]’:
/blah/rr/src/ProcFdDirMonitor.cc:120:3:   required from here
/blah/rr/src/ProcFdDirMonitor.cc:95:15: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
cc1plus: all warnings being treated as errors
CMakeFiles/rr.dir/build.make:805: recipe for target 'CMakeFiles/rr.dir/src/ProcFdDirMonitor.cc.o' failed
make[2]: *** [CMakeFiles/rr.dir/src/ProcFdDirMonitor.cc.o] Error 1
CMakeFiles/Makefile2:17477: recipe for target 'CMakeFiles/rr.dir/all' failed
make[1]: *** [CMakeFiles/rr.dir/all] Error 2
Makefile:147: recipe for target 'all' failed
make: *** [all] Error 2
Failed to execute: /home
```

Cheers,
tpltnt