### PR TITLE
Fix running valgrind on rr and issues identified it

### DIFF
--- a/src/AutoRemoteSyscalls.cc
+++ b/src/AutoRemoteSyscalls.cc
@@ -254,6 +254,7 @@ static void child_connect_socket(AutoRemoteSyscalls& remote,
                                  remote_ptr<void> buf_end, int child_sock,
                                  const char* path, int* cwd_fd) {
   typename Arch::sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr)); // Make valgrind happy.
   addr.sun_family = AF_UNIX;
   assert(strlen(path) < sizeof(addr.sun_path));
   // Skip leading '/' since we're going to access this relative to the root
@@ -325,6 +326,7 @@ static void child_sendmsg(AutoRemoteSyscalls& remote,
                           remote_ptr<socketcall_args<Arch> > sc_args,
                           remote_ptr<void> buf_end, int child_sock, int fd) {
   char cmsgbuf[Arch::cmsg_space(sizeof(fd))];
+  memset(cmsgbuf, 0, sizeof(cmsgbuf));
   // Pull the puppet strings to have the child send its fd
   // to us.  Similarly to above, we DONT_WAIT on the
   // call to finish, since it's likely not defined whether the

--- a/src/ElfReader.cc
+++ b/src/ElfReader.cc
@@ -151,6 +151,8 @@ SymbolTable ElfReaderImpl<Arch>::read_symbols(const char* symtab,
   for (size_t i = 0; i < symbol_list.size(); ++i) {
     auto& s = symbol_list[i];
     if (s.st_shndx >= sections.size()) {
+      // Don't leave this entry uninitialized
+      result.symbols[i] = SymbolTable::Symbol(0, 0);
       continue;
     }
     auto& section = sections[s.st_shndx];

--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -85,10 +85,11 @@ template <typename Arch> static void setup_preload_library_path(RecordTask* t) {
     }
     size_t next_colon = env.find(':', lib_pos);
     if (next_colon != string::npos) {
-      while (env[next_colon + 1] == ':' || env[next_colon + 1] == 0) {
+      while ((next_colon + 1 < env.length()) &&
+          (env[next_colon + 1] == ':' || env[next_colon + 1] == 0)) {
         ++next_colon;
       }
-      if (next_colon < lib_pos + sizeof(SYSCALLBUF_LIB_FILENAME_PADDED) - 1) {
+      if (next_colon + 1 < lib_pos + sizeof(SYSCALLBUF_LIB_FILENAME_PADDED) - 1) {
         LOG(debug) << "Insufficient space for " << lib_name
                    << " in LD_PRELOAD before next ':'";
         return;

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -113,7 +113,7 @@ struct Sighandlers {
   }
 
   void init_from_current_process() {
-    for (size_t i = 0; i < array_length(handlers); ++i) {
+    for (size_t i = 1; i < array_length(handlers); ++i) {
       Sighandler& h = handlers[i];
 
       NativeArch::kernel_sigaction sa;


### PR DESCRIPTION
This is part of #16. I wanted to be able to run valgrind on rr since I seem to have a tendency to forget to initialize variables ;). The second commit fixes the issues valgrind complained about during `valgrind rr record ls`. None of them too serious, but there was a string out of bounds access, which I suppose could cause a crash if you're unlucky.

For those following along at home, I have a valgrind patch for perf events ioctls, which may be needed: https://bugs.kde.org/show_bug.cgi?id=368419.