### PR TITLE
Enable recording of mq_open and friends.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,6 +529,7 @@ set(BASIC_TESTS
   mprotect_heterogenous
   mprotect_none
   mprotect_stack
+  mq
   mremap
   mremap_grow
   mremap_grow_shared

--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -16,6 +16,7 @@
 #include <linux/filter.h>
 #include <linux/futex.h>
 #include <linux/ipc.h>
+#include <linux/mqueue.h>
 #include <linux/msg.h>
 #include <linux/net.h>
 #include <linux/sem.h>

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1315,6 +1315,15 @@ struct BaseArch : public wordsize,
     uint8_t d_name[256];
   };
   RR_VERIFY_TYPE(dirent64);
+
+  struct mq_attr {
+    signed_long mq_flags ;
+    signed_long mq_maxmsg ;
+    signed_long mq_msgsize ;
+    signed_long mq_curmsgs ;
+    signed_long __reserved[4] ;
+  };
+  RR_VERIFY_TYPE(mq_attr);
 };
 
 struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3481,6 +3481,14 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
       return PREVENT_SWITCH;
     }
 
+    case Arch::mq_timedreceive: {
+      syscall_state.reg_parameter(
+          2, ParamSize::from_syscall_result<typename Arch::ssize_t>(
+                 (size_t)t->regs().arg3()));
+      syscall_state.reg_parameter<unsigned>(4);
+      return ALLOW_SWITCH;
+    }
+
     default:
       // Invalid syscalls return -ENOSYS. Assume any such
       // result means the syscall was completely ignored by the

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -1333,12 +1333,15 @@ vserver = InvalidSyscall(x86=273, x64=236)
 mbind = EmulatedSyscall(x86=274, x64=237)
 get_mempolicy = UnsupportedSyscall(x86=275, x64=239)
 set_mempolicy = UnsupportedSyscall(x86=276, x64=238)
-mq_open = UnsupportedSyscall(x86=277, x64=240)
-mq_unlink = UnsupportedSyscall(x86=278, x64=241)
-mq_timedsend = UnsupportedSyscall(x86=279, x64=242)
-mq_timedreceive = UnsupportedSyscall(x86=280, x64=243)
-mq_notify = UnsupportedSyscall(x86=281, x64=244)
-mq_getsetattr = UnsupportedSyscall(x86=282, x64=245)
+
+#
+mq_open = EmulatedSyscall(x86=277, x64=240)
+mq_unlink = EmulatedSyscall(x86=278, x64=241)
+mq_timedsend = EmulatedSyscall(x86=279, x64=242)
+mq_timedreceive = IrregularEmulatedSyscall(x86=280, x64=243)
+mq_notify = EmulatedSyscall(x86=281, x64=244)
+mq_getsetattr = EmulatedSyscall(x86=282, x64=245, arg3="struct Arch::mq_attr")
+
 kexec_load = UnsupportedSyscall(x86=283, x64=246)
 
 #  int waitid(idtype_t idtype, id_t id, siginfo_t *infop, int options);

--- a/src/test/mq.c
+++ b/src/test/mq.c
@@ -1,0 +1,56 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+#include <mqueue.h>
+
+int main(void) {
+
+  mqd_t mq_a ;
+  mqd_t mq_b ;
+  struct mq_attr mq_attr ;
+  struct mq_attr mq_attr_test ;
+  char msg[] = "Hello" ;
+  char buffer[1024] = { 0 } ;   /* 'C' fills in the rest of the array with 0s. */
+  unsigned prio ;
+  struct timespec expiry ;
+
+  mq_attr.mq_flags = 0 ;
+  mq_attr.mq_maxmsg = 10 ;
+  mq_attr.mq_msgsize = 1024 ;
+  mq_attr.mq_curmsgs = 0 ;
+  mq_a = mq_open("/test-queue", O_WRONLY | O_CREAT, 0777, &mq_attr) ;
+  test_assert(mq_a != -1) ;
+
+  mq_b = mq_open("/test-queue", O_RDONLY) ;
+  test_assert(mq_b != -1) ;
+
+  test_assert(mq_getattr(mq_a, &mq_attr_test) == 0) ;
+  test_assert(mq_attr_test.mq_flags == mq_attr.mq_flags) ;
+  test_assert(mq_attr_test.mq_maxmsg == mq_attr.mq_maxmsg) ;
+  test_assert(mq_attr_test.mq_msgsize == mq_attr.mq_msgsize) ;
+  test_assert(mq_attr_test.mq_curmsgs == 0) ;
+
+  test_assert(mq_getattr(mq_b, &mq_attr_test) == 0) ;
+  test_assert(mq_attr_test.mq_flags == mq_attr.mq_flags) ;
+  test_assert(mq_attr_test.mq_maxmsg == mq_attr.mq_maxmsg) ;
+  test_assert(mq_attr_test.mq_msgsize == mq_attr.mq_msgsize) ;
+  test_assert(mq_attr_test.mq_curmsgs == 0) ;
+
+  test_assert(sizeof(msg) == 6) ;
+  test_assert(mq_send(mq_a, msg, sizeof(msg), 100) == 0) ;
+  test_assert(mq_getattr(mq_b, &mq_attr_test) == 0) ;
+  test_assert(mq_attr_test.mq_curmsgs == 1) ;
+
+  prio = ~0 ;
+  test_assert(mq_receive(mq_b, buffer, sizeof(buffer), &prio) == sizeof(msg)) ;
+  test_assert(memcmp(msg, buffer, sizeof(msg)) == 0) ;
+  test_assert(prio == 100) ;
+
+  clock_gettime(CLOCK_REALTIME, &expiry) ;
+  expiry.tv_sec += 2 ;
+  test_assert(mq_timedreceive(mq_b, buffer, sizeof(buffer), &prio, &expiry) == -1) ;
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
Recording of mq_open (and friends) is really about recording the values from mq_timedreceive.