### PR TITLE
Handle diversion in GdbCommand

### DIFF
--- a/src/GdbCommandHandler.cc
+++ b/src/GdbCommandHandler.cc
@@ -182,6 +182,12 @@ static vector<string> parse_cmd(string& str) {
   }
   LOG(debug) << "invoking command: " << cmd->name();
   string resp = cmd->invoke(gdb_server, t, args);
+
+  if (resp == GdbCommandHandler::cmd_end_diversion()) {
+    LOG(debug) << "cmd must run outside of diversion (" << resp << ")";
+    return resp;
+  }
+
   LOG(debug) << "cmd response: " << resp;
   return gdb_escape(resp + "\n");
 }

--- a/src/GdbCommandHandler.h
+++ b/src/GdbCommandHandler.h
@@ -31,6 +31,11 @@ public:
 
   static GdbCommand* command_for_name(const std::string& name);
 
+  /**
+   * Special return value for commands that immediatly end a diversion session
+   */
+  static std::string cmd_end_diversion() { return std::string("RRCmd_EndDiversion"); }
+
 private:
 };
 

--- a/src/test/history.py
+++ b/src/test/history.py
@@ -26,6 +26,10 @@ expect_gdb('i=2')
 send_gdb('back')
 send_gdb('frame')
 expect_gdb('i=1')
+
+# A diversion should not interfere with the history
+send_gdb('call strlen("abcd")')
+
 send_gdb('back')
 send_gdb('frame')
 expect_gdb('i=0')

--- a/src/test/when.py
+++ b/src/test/when.py
@@ -36,9 +36,10 @@ if ticks2 <= ticks:
 # Ensure 'when' terminates a diversion
 send_gdb('call strlen("abcd")')
 send_gdb('when')
-expect_gdb(re.compile(r'Current event: (\d+)'))
-t3 = eval(last_match().group(1));
-if t2 != t3:
-    failed('ERROR in third "when"')
+expect_gdb(re.compile(r'Current event not known \(diversion\?\)'))
+send_gdb('when-ticks')
+expect_gdb(re.compile(r'Current event not known \(diversion\?\)'))
+send_gdb('when-tid')
+expect_gdb(re.compile(r'Current event not known \(diversion\?\)'))
 
 ok()


### PR DESCRIPTION
This fixes the tests.

A few commits ago a RR command would end the diversion session but now there isn't an easy way to end a diversion session so doing something like |call strlen("abcd")| leave you inside a diversion session which is not intuitive for the user. Commands like 'back' wont work either which is unfortunate. I believe you're going to have to restart or go to a checkpoint to end the diversion ATM.