### PR TITLE
Make rr compile with clang/libc++/msan and fix reported errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(CMAKE_C_FLAGS_DEBUG "-O0 -Werror")
 set(CMAKE_C_FLAGS_RELEASE "-O2")
 # Define __STDC_LIMIT_MACROS so |#include <stdint.h>| works as expected.
 # Define __STDC_FORMAT_MACROS so |#include <inttypes.h>| works as expected.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__USE_LARGEFILE64 -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++0x -pthread -g3 -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__USE_LARGEFILE64 -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++14 -pthread -g3 -Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -Werror")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -g3")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,7 @@ target_link_libraries(rrpreload
 
 add_executable(rr_exec_stub src/exec_stub.c)
 post_build_executable(rr_exec_stub)
-set_target_properties(rr_exec_stub PROPERTIES LINK_FLAGS -nostdlib)
+set_target_properties(rr_exec_stub PROPERTIES LINK_FLAGS -nostartfiles)
 set_source_files_properties(src/exec_stub.c
                             COMPILE_FLAGS "-fno-stack-protector")
 

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1817,14 +1817,18 @@ void RecordSession::terminate_recording() {
 
   LOG(info) << "Processing termination request ...";
 
+  pid_t ttid = t ? t->tid : 0;
+  auto tticks = t ? t->tick_count() : 0;
+
   // This will write unstable exit events for all tasks.
   kill_all_tasks();
+  t = nullptr; // t is now deallocated
 
   LOG(info) << "  recording final TRACE_TERMINATION event ...";
 
-  TraceFrame frame(trace_out.time(), t ? t->tid : 0,
+  TraceFrame frame(trace_out.time(), ttid,
                    Event(EV_TRACE_TERMINATION, NO_EXEC_INFO, RR_NATIVE_ARCH),
-                   t ? t->tick_count() : 0);
+                   tticks);
   trace_out.write_frame(frame);
   trace_out.close();
 }

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -123,6 +123,7 @@ struct Sighandlers {
         assert(EINVAL == errno);
         continue;
       }
+      msan_unpoison(&sa, sizeof(NativeArch::kernel_sigaction)); 
 
       h.init_arch<NativeArch>(sa);
     }

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -187,8 +187,13 @@ struct BasicInfo {
 void TraceWriter::write_frame(const TraceFrame& frame) {
   auto& events = writer(EVENTS);
 
-  BasicInfo basic_info = { frame.time(), frame.tid(), frame.event().encode(),
-                           frame.ticks(), frame.monotonic_time() };
+  BasicInfo basic_info;
+  memset(&basic_info, 0, sizeof(BasicInfo));
+  basic_info.global_time = frame.time();
+  basic_info.tid_ = frame.tid();
+  basic_info.ev = frame.event().encode();
+  basic_info.ticks_ = frame.ticks();
+  basic_info.monotonic_sec = frame.monotonic_time();
   events << basic_info;
   if (!events.good()) {
     FATAL() << "Tried to save " << sizeof(basic_info)

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -310,7 +310,7 @@ TraceTaskEvent TraceReader::read_task_event() {
   auto& tasks = reader(TASKS);
   TraceTaskEvent r;
   TraceFrame::Time time;
-  char type;
+  char type = TraceTaskEvent::NONE;
   tasks >> time >> type >> r.tid_;
   r.type_ = (TraceTaskEvent::Type)type;
   switch (r.type()) {
@@ -327,6 +327,8 @@ TraceTaskEvent TraceReader::read_task_event() {
       // Should be EOF only
       assert(!tasks.good());
       break;
+    default:
+      assert(false && "Corrupt Trace?");
   }
   return r;
 }

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -881,7 +881,11 @@ struct BaseArch : public wordsize,
     ptr<socklen_t> addrlen;
   };
 
-  struct accept4_args : public accept_args {
+  struct accept4_args {
+    signed_int sockfd;
+    char __pad[sizeof(ptr<void>) - sizeof(int)];
+    ptr<sockaddr> addr;
+    ptr<socklen_t> addrlen;
     signed_long flags;
   };
 

--- a/src/log.cc
+++ b/src/log.cc
@@ -62,11 +62,22 @@ static string simple_to_lower(const string& s) {
   return string(buf);
 }
 
+#if __has_attribute(require_constant_initialization)
+#define _CONSTANT_STATIC __attribute__((__require_constant_initialization__)) static
+#else
+#define _CONSTANT_STATIC static
+#endif
+
 static bool log_globals_initialized = false;
 static LogLevel default_level = LOG_error;
-static unique_ptr<unordered_map<string, LogLevel> > level_map;
-static unique_ptr<unordered_map<const char*, LogModule> > log_modules;
-static unique_ptr<stringstream> logging_stream;
+
+// These need to be available to other static constructors, so we need to be sure
+// that they const constant-initialized. Unfortunately some versions of C++ libraries
+// have a bug that causes them not to be. _CONSTANT_STATIC should turn this into
+// a compile error rather than a runtime crash for compilers that support the attribute.
+_CONSTANT_STATIC unique_ptr<unordered_map<string, LogLevel> > level_map;
+_CONSTANT_STATIC unique_ptr<unordered_map<const char*, LogModule> > log_modules;
+_CONSTANT_STATIC std::unique_ptr<stringstream> logging_stream;
 
 static void init_log_globals() {
   if (log_globals_initialized) {

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1082,6 +1082,7 @@ static Switchable prepare_semctl(RecordTask* t, TaskSyscallState& syscall_state,
       _semun un_arg;
       un_arg.buf = &ds;
       int ret = _semctl(semid, 0, IPC_STAT, un_arg);
+      msan_unpoison(&ds, sizeof(semid64_ds));
       ASSERT(t, ret == 0);
 
       ParamSize size = sizeof(unsigned short) * ds.sem_nsems;
@@ -3835,6 +3836,7 @@ static void process_shmat(RecordTask* t, int shmid, int shm_flags,
 
   struct shmid64_ds ds;
   int ret = _shmctl(shmid, IPC_STAT, &ds);
+  msan_unpoison(&ds, sizeof(semid64_ds));
   ASSERT(t, !ret) << "shmid should be readable by rr since rr has the same "
                      "UID as tracees";
   size_t size = ceil_page_size(ds.shm_segsz);

--- a/src/remote_ptr.h
+++ b/src/remote_ptr.h
@@ -84,9 +84,9 @@ public:
   bool is_null() const { return !ptr; }
 
   template <typename U>
-  remote_ptr<typename std::remove_cv<U>::type> field(U* dummy) const {
-    return remote_ptr<typename std::remove_cv<U>::type>(
-        ptr + reinterpret_cast<uintptr_t>(dummy));
+  remote_ptr<typename std::remove_cv<U>::type> field(U*,
+                                                     uintptr_t offset) const {
+    return remote_ptr<typename std::remove_cv<U>::type>(ptr + offset);
   }
   T* dummy() { return nullptr; }
   const T* dummy() const { return nullptr; }
@@ -104,7 +104,12 @@ private:
  * returns a remote_ptr pointing to field f of the struct pointed to by
  * remote_ptr p
  */
-#define REMOTE_PTR_FIELD(p, f) (p).field(&(p).dummy()->f)
+#define REMOTE_PTR_FIELD(p, f)                                                 \
+  ((p).field(                                                                  \
+      ((typename std::remove_reference<decltype((p).dummy()->f)>::type*)       \
+           nullptr),                                                           \
+      offsetof(typename std::remove_reference<decltype(*(p).dummy())>::type,   \
+               f)))
 
 template <typename T>
 std::ostream& operator<<(std::ostream& stream, remote_ptr<T> p) {

--- a/src/util.h
+++ b/src/util.h
@@ -265,6 +265,17 @@ bool uses_invisible_guard_page();
 
 void copy_file(Task* t, int dest_fd, int src_fd);
 
+#if defined(__has_feature)
+#  if __has_feature(memory_sanitizer)
+extern "C" void __msan_unpoison(void *, size_t);
+inline void msan_unpoison(void *ptr, size_t n) { __msan_unpoison(ptr, n); };
+#  else
+inline void msan_unpoison(void *ptr, size_t n) { (void)ptr; (void)n; };
+#  endif
+#else
+inline void msan_unpoison(void *ptr, size_t n) { (void)ptr; (void)n; };
+#endif
+
 } // namespace rr
 
 #endif /* RR_UTIL_H_ */


### PR DESCRIPTION
The part where e5cc434 switches the C++ standard may not be required depending on which way the upstream review goes, but it shouldn't be harmful either, unless you want to maintain compatibility with older compilers.