### PR TITLE
Unlink mq after we're done with it

### DIFF
--- a/src/test/mq.c
+++ b/src/test/mq.c
@@ -52,6 +52,8 @@ int main(void) {
   test_assert(mq_timedreceive(mq_b, buffer, sizeof(buffer), &prio, &expiry) ==
               -1);
 
+  mq_unlink(mq_name);
+
   atomic_puts("EXIT-SUCCESS");
   return 0;
 }


### PR DESCRIPTION
There's a global number of mqs and they did not previously get cleaned up when
this test exists, so it's possible to reach that limit relatively quickly
by running rr tests.