### PR TITLE
Handle the sigmask modifying aspects of ppoll and pselect6.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,6 +555,7 @@ set(BASIC_TESTS
   personality
   pthread_rwlocks
   poll_sig_race
+  ppoll
   prctl
   prctl_deathsig
   prctl_name
@@ -631,6 +632,7 @@ set(BASIC_TESTS
   signalfd
   sigprocmask
   sigprocmask_in_syscallbuf_sighandler
+  sigprocmask_rr_sigs
   sigprocmask_syscallbuf
   sigqueueinfo
   sigreturn

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -458,6 +458,15 @@ public:
    */
   void set_tid_and_update_serial(pid_t tid);
 
+  /**
+   * Push or pop the current sigmask (reloading it if necessary) to handle
+   * ppoll/pselect. The stack is only one level deep, and pushing and not
+   * popping is ok if the sigmask gets restored another way (e.g. because
+   * a signal handler was invoked).
+   */
+  void push_sigmask(sig_set_t new_sigs);
+  void pop_sigmask();
+
 private:
   ~RecordTask();
 
@@ -579,6 +588,7 @@ public:
   // of stop.
   EmulatedStopType emulated_stop_type;
   sig_set_t blocked_sigs;
+  sig_set_t previously_blocked_sigs;
   int handling_deterministic_signal;
 
   // Syscallbuf state

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1049,6 +1049,11 @@ struct BaseArch : public wordsize,
   typedef __sigset_t sigset_t;
   RR_VERIFY_TYPE(sigset_t);
 
+  typedef struct {
+    ptr<const sigset_t> ss;
+    size_t ss_len;
+  } pselect6_arg6;
+
   struct kernel_sigaction {
     ptr<void> k_sa_handler;
     unsigned_long sa_flags;

--- a/src/test/intr_pselect.c
+++ b/src/test/intr_pselect.c
@@ -3,7 +3,7 @@
 #include "rrutil.h"
 
 static int pipefds[2];
-static int pselect_pipe(int timeout) {
+static int pselect_pipe(int timeout, sigset_t* sigmask) {
   fd_set set;
 
   FD_ZERO(&set);
@@ -11,30 +11,39 @@ static int pselect_pipe(int timeout) {
   struct timespec t;
   t.tv_sec = timeout;
   t.tv_nsec = 0;
-  sigset_t sigmask;
-  sigemptyset(&sigmask);
 
   errno = 0;
   return pselect(pipefds[0] + 1, &set, NULL, NULL, timeout ? &t : NULL,
-                 &sigmask);
+                 sigmask);
 }
 
 static int caught_signal;
 static void handle_signal(__attribute__((unused)) int sig) { ++caught_signal; }
 
 int main(void) {
+  sigset_t sigmask;
+  sigemptyset(&sigmask);
+
   pipe(pipefds);
 
   signal(SIGALRM, SIG_IGN);
   alarm(1);
   atomic_puts("ignoring SIGALRM, going into pselect ...");
-  test_assert(0 == pselect_pipe(2) && 0 == errno);
+  test_assert(0 == pselect_pipe(2, &sigmask) && 0 == errno);
+
+  /* Test that the signal mask is correct in rr when the SIGALRM is delivered */
+  sigaddset(&sigmask, SIGCHLD);
 
   signal(SIGALRM, handle_signal);
   alarm(1);
   atomic_puts("handling SIGALRM, going into pselect ...");
-  test_assert(-1 == pselect_pipe(0) && EINTR == errno);
+  test_assert(-1 == pselect_pipe(0, &sigmask) && EINTR == errno);
   test_assert(1 == caught_signal);
+
+  sigaddset(&sigmask, SIGALRM);
+  alarm(1);
+  atomic_puts("blocking SIGALRM, going into pselect ...");
+  test_assert(0 == pselect_pipe(2, &sigmask) && 0 == errno);
 
   atomic_puts("EXIT-SUCCESS");
   return 1;

--- a/src/test/ppoll.c
+++ b/src/test/ppoll.c
@@ -1,0 +1,61 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+#include <poll.h>
+
+#define NUM_ITERATIONS 10
+
+static void handle_sig(__attribute__((unused)) int sig) {
+  sigset_t after_sigset;
+  int ret = sigprocmask(SIG_BLOCK, NULL, &after_sigset);
+  test_assert(ret == 0);
+  test_assert(sigismember(&after_sigset, SIGCHLD));
+}
+
+int main(void) {
+  int fds[2];
+  struct pollfd pfd;
+  int i;
+
+  struct timespec t;
+  t.tv_sec = 1;
+  t.tv_nsec = 0;
+
+  sigset_t sigset;
+  test_assert(0 == sigemptyset(&sigset));
+  test_assert(0 == sigaddset(&sigset, SIGCHLD));
+
+  signal(SIGALRM, &handle_sig);
+
+  pipe2(fds, O_NONBLOCK);
+
+  pfd.fd = fds[0];
+  pfd.events = POLLIN;
+  for (i = 0; i < NUM_ITERATIONS; ++i) {
+    int ret;
+
+    atomic_printf("iteration %d\n", i);
+    if (i % 2 == 0) {
+      ualarm(100000, 0);
+    } else if (fork() == 0) {
+      usleep(100000);
+      return 0;
+    }
+
+    ret = ppoll(&pfd, 1, &t, &sigset);
+    if (i % 2 == 0) {
+      test_assert(ret == -1 && errno == EINTR);
+    } else {
+      test_assert(ret == 0);
+    }
+
+    sigset_t after_sigset;
+    ret = sigprocmask(SIG_BLOCK, NULL, &after_sigset);
+    test_assert(ret == 0);
+    test_assert(!sigismember(&after_sigset, SIGCHLD));
+  }
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/sigprocmask_rr_sigs.c
+++ b/src/test/sigprocmask_rr_sigs.c
@@ -1,0 +1,19 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+int main(void) {
+  sigset_t mask, oldmask;
+  int err;
+
+  sigfillset(&mask);
+  /* SIGPWR is used internally by rr, and we won't be able to turn it off.
+     rr shouldn't observably change `mask` when it does this though */
+  err = sigprocmask(SIG_BLOCK, &mask, &oldmask);
+  test_assert(err == 0);
+
+  test_assert(sigismember(&mask, SIGPWR) == 1);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
The recent changes to more aggressively verify that our signal states are correct exposed a bug when running Chromium.  We're not handing ppoll and pselect6's adjustments to the sigmask at all.

This PR generalizes the infrastructure used for sigprocmask a bit and then uses it for ppoll and pselect6.