### PR TITLE
[AutoRemoteSyscalls] Add mmap fallback when no stack is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -771,6 +771,7 @@ set(TESTS_WITH_PROGRAM
   mprotect_syscallbuf_overflow
   mutex_pi_stress
   priority
+  ptrace_remote_unmap
   # Not called ps, because that interferes with using real 'ps' in tests
   rr_ps
   read_big_struct

--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -207,6 +207,8 @@ public:
   enum SyscallWaiting { WAIT = 1, DONT_WAIT = 0 };
   void syscall_helper(SyscallWaiting wait, int syscallno, Registers& callregs);
 
+  MemParamsEnabled enable_mem_params() { return enable_mem_params_; }
+
 private:
   /**
    * Wait for the |DONT_WAIT| syscall |syscallno| initiated by
@@ -242,8 +244,14 @@ private:
   Registers initial_regs;
   remote_code_ptr initial_ip;
   remote_ptr<void> initial_sp;
+  remote_ptr<void> fixed_sp;
   int pending_syscallno;
   std::vector<uint8_t> replaced_bytes;
+
+  /* Whether we had to mmap a scratch region because none was found */
+  bool scratch_mem_was_mapped;
+
+  MemParamsEnabled enable_mem_params_;
 
   AutoRemoteSyscalls& operator=(const AutoRemoteSyscalls&) = delete;
   AutoRemoteSyscalls(const AutoRemoteSyscalls&) = delete;

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1545,7 +1545,7 @@ Task* Task::clone(int flags, remote_ptr<void> stack, remote_ptr<void> tls,
 }
 
 Task* Task::os_fork_into(Session* session) {
-  AutoRemoteSyscalls remote(this);
+  AutoRemoteSyscalls remote(this, AutoRemoteSyscalls::DISABLE_MEMORY_PARAMS);
   Task* child = os_clone(this, session, remote, rec_tid, serial,
                          // Most likely, we'll be setting up a
                          // CLEARTID futex.  That's not done

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1675,7 +1675,7 @@ static bool verify_ptrace_options(RecordTask* t,
   // We "support" PTRACE_O_SYSGOOD because we don't support PTRACE_SYSCALL yet
   static const int supported_ptrace_options =
       PTRACE_O_TRACESYSGOOD | PTRACE_O_TRACEEXIT | PTRACE_O_TRACEFORK |
-      PTRACE_O_TRACECLONE;
+      PTRACE_O_TRACECLONE | PTRACE_O_TRACEEXEC;
 
   if ((int)t->regs().arg4() & ~supported_ptrace_options) {
     LOG(debug) << "Unsupported ptrace options " << HEX(t->regs().arg4());
@@ -4171,10 +4171,14 @@ static void rec_process_syscall_arch(RecordTask* t,
 
     case Arch::execve:
       process_execve(t, syscall_state);
-      if (t->emulated_ptracer && !t->emulated_ptrace_seized &&
-          !(t->emulated_ptrace_options & PTRACE_O_TRACEEXEC)) {
-        // Inject legacy SIGTRAP-after-exec
-        t->tgkill(SIGTRAP);
+      if (t->emulated_ptracer) {
+        if (t->emulated_ptrace_options & PTRACE_O_TRACEEXEC) {
+          t->emulate_ptrace_stop(
+              WaitStatus::for_ptrace_event(PTRACE_EVENT_EXEC));
+        } else if (!t->emulated_ptrace_seized) {
+          // Inject legacy SIGTRAP-after-exec
+          t->tgkill(SIGTRAP);
+        }
       }
       break;
 

--- a/src/test/ptrace_remote_unmap.c
+++ b/src/test/ptrace_remote_unmap.c
@@ -1,0 +1,156 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+#include <ctype.h>
+
+#define RR_PAGE_ADDR 0x70000000
+
+static char* trim_leading_blanks(char* str) {
+  char* trimmed = str;
+  while (isblank(*trimmed)) {
+    ++trimmed;
+  }
+  return trimmed;
+}
+
+long checked_ptrace(enum __ptrace_request request, pid_t pid, void* addr,
+                    void* data) {
+  long ret = ptrace(request, pid, addr, data);
+  assert(ret != -1);
+  return ret;
+}
+
+extern char syscall_addr;
+static __attribute__((noinline, used)) void my_syscall(void) {
+#if defined(__i386)
+  __asm__ __volatile__("syscall_addr: int $0x80\n\t");
+#elif defined(__x86_64__)
+  __asm__ __volatile__("syscall_addr: syscall\n\t");
+#endif
+}
+
+void munmap_remote(pid_t child, uintptr_t start, size_t size) {
+  struct user_regs_struct regs;
+  struct iovec iov;
+  int status;
+  pid_t wret;
+  iov.iov_base = &regs;
+  iov.iov_len = sizeof(regs);
+  checked_ptrace(PTRACE_GETREGSET, child, (void*)NT_PRSTATUS, &iov);
+#ifdef __i386
+  regs.eip = (uintptr_t)&syscall_addr;
+  regs.eax = __NR_munmap;
+  regs.ebx = start;
+  regs.ecx = size;
+#else
+  regs.rip = (uintptr_t)&syscall_addr;
+  regs.rax = __NR_munmap;
+  regs.rdi = start;
+  regs.rsi = size;
+  regs.rdx = 0;
+  regs.r10 = 0;
+  regs.r8 = 0;
+  regs.r9 = 0;
+#endif
+  checked_ptrace(PTRACE_SETREGSET, child, (void*)NT_PRSTATUS, &iov);
+  // Execute the syscall
+  checked_ptrace(PTRACE_SYSCALL, child, 0, 0);
+  // Wait until entry trap
+  wret = waitpid(child, &status, __WALL | WSTOPPED);
+  assert(wret = child);
+  assert(WSTOPSIG(status) == (SIGTRAP | 0x80));
+
+  checked_ptrace(PTRACE_SYSCALL, child, 0, 0);
+  // Wait until exit trap
+  wret = waitpid(child, &status, __WALL | WSTOPPED);
+  assert(wret = child);
+  assert(WSTOPSIG(status) == (SIGTRAP | 0x80));
+  // Verify that the syscall didn't fail
+  checked_ptrace(PTRACE_GETREGSET, child, (void*)NT_PRSTATUS, &iov);
+#ifdef __i386
+  assert(regs.eax != -1);
+#else
+  assert(regs.rax != (uintptr_t)-1);
+#endif
+}
+
+#ifdef __i386
+static const uint8_t syscall_instr[] = { 0xcd, 0x80 };
+#else
+static const uint8_t syscall_instr[] = { 0x0f, 0x05, 0x00, 0x00 };
+#endif
+
+static __attribute__((noinline)) void breakpoint(void) {
+  int break_here = 1;
+  (void)break_here;
+}
+
+int main(void) {
+  pid_t child;
+  if (0 == (child = fork())) {
+    raise(SIGSTOP);
+    char* args[] = { "/proc/self/exe", NULL };
+    execve("/proc/self/exe", args, environ);
+  }
+
+  // Wait until stopped
+  int status;
+  pid_t wret = waitpid(child, &status, __WALL | WSTOPPED);
+  assert(wret == child);
+  assert(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP);
+
+  // Now PTRACE_SEIZE the child
+  checked_ptrace(PTRACE_SEIZE, child, NULL,
+                 (void*)(PTRACE_O_TRACESYSGOOD | PTRACE_O_TRACEEXEC));
+
+  // That caused another stop
+  wret = waitpid(child, &status, __WALL | WSTOPPED);
+  assert(wret = child);
+
+  // Continue until the exec
+  checked_ptrace(PTRACE_CONT, child, 0, 0);
+  // This should be the exec stop
+  wret = waitpid(child, &status, __WALL | WSTOPPED);
+  assert(wret = child);
+  assert(status >> 8 == (SIGTRAP | (PTRACE_EVENT_EXEC << 8)));
+
+  // Ok, now start unmapping the remote mappings
+  char path[200];
+  snprintf(path, 200, "/proc/%d/maps", child);
+  FILE* maps_file = fopen(path, "r");
+
+  while (!feof(maps_file)) {
+    char line[PATH_MAX * 2];
+    if (!fgets(line, sizeof(line), maps_file)) {
+      break;
+    }
+
+    uint64_t start, end, offset, inode;
+    int dev_major, dev_minor;
+    char flags[32];
+    int chars_scanned;
+    int nparsed = sscanf(line, "%" SCNx64 "-%" SCNx64 " %31s %" SCNx64
+                               " %x:%x %" SCNu64 " %n",
+                         &start, &end, flags, &offset, &dev_major, &dev_minor,
+                         &inode, &chars_scanned);
+    assert(8 /*number of info fields*/ == nparsed ||
+           7 /*num fields if name is blank*/ == nparsed);
+
+    // trim trailing newline, if any
+    int last_char = strlen(line) - 1;
+    if (line[last_char] == '\n') {
+      line[last_char] = 0;
+    }
+    char* name = trim_leading_blanks(line + chars_scanned);
+
+    if ((start <= (uintptr_t)&syscall_addr && (uintptr_t)&syscall_addr < end) ||
+        start == RR_PAGE_ADDR || strcmp(name, "[vsyscall]") == 0)
+      continue;
+
+    munmap_remote(child, start, end - start);
+  }
+  breakpoint();
+
+  atomic_printf("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/ptrace_remote_unmap.py
+++ b/src/test/ptrace_remote_unmap.py
@@ -1,0 +1,14 @@
+from rrutil import *
+
+send_gdb('break breakpoint')
+expect_gdb('Breakpoint 1')
+send_gdb('c')
+expect_gdb('Breakpoint 1')
+send_gdb('checkpoint')
+expect_gdb('Checkpoint 1 at')
+send_gdb('restart 1')
+expect_gdb('stopped')
+send_gdb('rc')
+expect_gdb('stopped')
+
+ok()

--- a/src/test/ptrace_remote_unmap.run
+++ b/src/test/ptrace_remote_unmap.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+record ptrace_remote_unmap$bitness
+debug ptrace_remote_unmap


### PR DESCRIPTION
When replaying an rr replay, the inner tracee can end up in a a situation where
it has no mapping that can be used as AutoRemoteSyscall's scratch area. If this
happens while we are trying to clone that task (e.g. during reverse stepping),
we used to crash because cloning (or rather opening the mem fd afterwards)
requires memory parameters. To mitigate this add a worst-case fallback, which
allocates one page worth of RW memory to use as a scratch area.

Add a corresponding test. Originally I just added an `rc` to the record_replay test, but
it looks like this wasn't the last of the issues with reverse continuing a recorded replay,
so I wrote a dedicated test for just this issue. Lastly, I used PTRACE_O_TRACEEXEC
in that test, so I added the minimal snippet to give the proper emulated trap.