### PR TITLE
Rework syscallbuf initialization to not depend on using pthreads/glibc.

### DIFF
--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -101,6 +101,7 @@ static const string& gdb_rr_macros() {
        << "end\n"
        << "set unwindonsignal on\n"
        << "handle SIGURG stop\n"
+       << "handle SIGPWR nostop noprint\n"
        << "set prompt (rr) \n"
        << GdbCommandHandler::gdb_macros()
        // Try both "set target-async" and "maint set target-async" since

--- a/src/preload/preload.c
+++ b/src/preload/preload.c
@@ -547,9 +547,24 @@ static void init_thread(void) {
   struct rrcall_init_buffers_params args;
 
   assert(process_inited);
-  assert(!thread_inited);
 
-  if (!buffer_enabled) {
+  if (buffer_enabled) {
+    if (buffer) {
+      assert(thread_inited);
+      /**
+       * After a fork(), we retain a CoW mapping of our parent's syscallbuf.
+       * That's bad, because we don't want to use that buffer.  So drop the
+       * parent's copy and reinstall our own.
+       *
+       * FIXME: this "leaks" the parent's old copy in our address space.
+       */
+
+      buffer = NULL;
+      thread_inited = 0;
+    } else {
+      assert(!thread_inited);
+    }
+  } else {
     thread_inited = 1;
     return;
   }
@@ -579,15 +594,18 @@ static void init_thread(void) {
 }
 
 /**
- * After a fork(), we retain a CoW mapping of our parent's syscallbuf.
- * That's bad, because we don't want to use that buffer.  So drop the
- * parent's copy and reinstall our own.
+ * rr generates a SYSCALLBUF_DESCHED_SIGNAL when a qualifying clone(2) or
+ * fork() happens. This is the only SYSCALLBUF_DESCHED_SIGNAL that is
+ * ever actually delivered to the tracee. The others are consumed by rr itself.
  *
- * FIXME: this "leaks" the parent's old copy in our address space.
+ * The 'qualifying' bit above is extremely important. If init_thread is called
+ * after a clone(2) with CLONE_VM but no CLONE_SETTLS to give it a clean TLS,
+ * it's impossible for it to separate itself from the parent's syscallbuf.
+ * This happens with vfork() and can be made to happen with sufficiently strange
+ * clone(2) invocations. rr will not deliver us a signal in those cases.
  */
-static void post_fork_child(void) {
-  buffer = NULL;
-  thread_inited = 0;
+static void sig_init_thread(int sig) {
+  assert(sig == SYSCALLBUF_DESCHED_SIGNAL);
   init_thread();
 }
 
@@ -685,7 +703,7 @@ static void __attribute__((constructor)) init_process(void) {
 
   buffer_enabled = !!getenv(SYSCALLBUF_ENABLED_ENV_VAR);
 
-  pthread_atfork(NULL, NULL, post_fork_child);
+  signal(SYSCALLBUF_DESCHED_SIGNAL, sig_init_thread);
 
   params.syscallbuf_enabled = buffer_enabled;
   params.syscall_hook_trampoline = (void*)_syscall_hook_trampoline;
@@ -719,8 +737,6 @@ static void* thread_trampoline(void* arg) {
   struct thread_func_data data = *(struct thread_func_data*)arg;
   free(arg);
 
-  init_thread();
-
   return data.start_routine(data.arg);
 }
 
@@ -736,7 +752,6 @@ static void* thread_trampoline(void* arg) {
 int pthread_create(pthread_t* thread, const pthread_attr_t* attr,
                    void* (*start_routine)(void*), void* arg) {
   struct thread_func_data* data = malloc(sizeof(*data));
-  void* saved_buffer = buffer;
   int ret;
 
   /* Init syscallbuf now if we haven't yet (e.g. if pthread_create is called
@@ -746,10 +761,7 @@ int pthread_create(pthread_t* thread, const pthread_attr_t* attr,
 
   data->start_routine = start_routine;
   data->arg = arg;
-  /* Don't let the new thread use our TLS pointer. */
-  buffer = NULL;
   ret = real_pthread_create(thread, attr, thread_trampoline, data);
-  buffer = saved_buffer;
   return ret;
 }
 

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2415,6 +2415,17 @@ static void prepare_clone(RecordTask* t, TaskSyscallState& syscall_state) {
       syscall_state.syscall_entry_registers.original_syscallno());
   t->set_regs(r);
 
+  // Synthesize a SYSCALLBUF_DESCHED_SIGNAL in the tracee. This is the only time
+  // we'll ever actually deliver this signal to the tracee. preload.c has a
+  // handler that will initialize the syscallbuf when it is invoked.
+  //
+  // That signal handler assumes that either it is not sharing memory with the
+  // parent or it has new TLS.
+  if (!(flags & CLONE_VM) || (flags & CLONE_SETTLS)) {
+    new_task->push_event(SignalEvent(SYSCALLBUF_DESCHED_SIGNAL,
+                                     NONDETERMINISTIC_SIG, new_task->arch()));
+  }
+
   // We're in a PTRACE_EVENT_FORK/VFORK/CLONE so the next PTRACE_SYSCALL for
   // |t| will go to the exit of the syscall, as expected.
 }

--- a/src/test/reverse_continue_fork_subprocess.py
+++ b/src/test/reverse_continue_fork_subprocess.py
@@ -22,8 +22,7 @@ expect_gdb('stopped')
 
 send_gdb('stepi')
 send_gdb('reverse-stepi')
-send_gdb('reverse-stepi')
-expect_gdb('stopped')
+expect_gdb("<signal handler called>"); # SYSCALLBUF_DESCHED_SIGNAL
 send_gdb('reverse-cont')
 expect_gdb('stopped')
 


### PR DESCRIPTION
Syscall buffer initialization is currently implemented by hooking pthread_create and using pthread_at_fork handlers.  Programs that do not use pthread_create for new threads or glibc's fork to fork will not get their syscall buffers reinitialized in the child.  Chromium forks by calling clone(2) manually, so syscall buffering is currently disabled for child processes.

This commit replaces those hooks with a setup based on handling a synthesized SYSCALLBUF_DESCHED_SIGNAL that is dispatched to the newly created tracee task by rr.