### PR TITLE
Move the preload library to /usr/lib/rr/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ enable_testing()
 set(BUILD_SHARED_LIBS ON)
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
-set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
+set(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib/rr)
 
 set(WILL_RUN_TESTS ON CACHE BOOL "Run tests")
 
@@ -357,8 +357,8 @@ install(PROGRAMS scripts/signal-rr-recording.sh
 
 install(TARGETS rr ${RR_BIN} rrpreload rr_exec_stub
   RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
+  LIBRARY DESTINATION lib/rr
+  ARCHIVE DESTINATION lib/rr)
 
 # Build 32-bit librrpreload on 64-bit builds.
 # We copy the source files into '32' subdirectories in the output
@@ -406,8 +406,8 @@ if(rr_32BIT AND rr_64BIT)
 
   install(TARGETS rrpreload_32 rr_exec_stub_32
     RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib)
+    LIBRARY DESTINATION lib/rr
+    ARCHIVE DESTINATION lib/rr)
 endif()
 
 ##--------------------------------------------------

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1570,7 +1570,7 @@ bool RecordSession::prepare_to_inject_signal(RecordTask* t,
 }
 
 static string find_syscall_buffer_library() {
-  string lib_path = exe_directory() + "../lib/";
+  string lib_path = exe_directory() + "../lib/rr/";
   string file_name = lib_path + SYSCALLBUF_LIB_FILENAME;
   if (access(file_name.c_str(), F_OK) != 0) {
     // File does not exist. Assume install put it in LD_LIBRARY_PATH.


### PR DESCRIPTION
Since the preload library is only used for rr, it feels more
appropriate to use a private directory under /usr/lib (see the FHS at
http://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s06.html for
details).

Signed-off-by: Stephen Kitt <steve@sk2.org>