### PR TITLE
Don't fall over if a system call modifies a breakpoint location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -772,6 +772,7 @@ set(TESTS_WITH_PROGRAM
   interrupt
   intr_ptrace_decline
   invalid_jump
+  jit_proc_mem
   link
   madvise_dontfork
   main_thread_exit

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -709,6 +709,13 @@ public:
     thread_locals_tuid_ = tuid;
   }
 
+  /**
+   * Call this when the memory at [addr,addr+len) was externally overwritten.
+   * This will attempt to update any breakpoints that may be set within the
+   * range (resetting them and storing the new value).
+   */
+  void maybe_update_breakpoints(Task* t, remote_ptr<uint8_t> addr, size_t len);
+
 private:
   struct Breakpoint;
   typedef std::map<remote_code_ptr, Breakpoint> BreakpointMap;

--- a/src/ReplayTask.cc
+++ b/src/ReplayTask.cc
@@ -123,6 +123,8 @@ ssize_t ReplayTask::set_data_from_trace() {
   if (!buf.addr.is_null() && buf.data.size() > 0) {
     auto t = session().find_task(buf.rec_tid);
     t->write_bytes_helper(buf.addr, buf.data.size(), buf.data.data());
+    t->vm()->maybe_update_breakpoints(t, buf.addr.cast<uint8_t>(),
+                                      buf.data.size());
   }
   return buf.data.size();
 }
@@ -133,6 +135,8 @@ void ReplayTask::apply_all_data_records_from_trace() {
     if (!buf.addr.is_null() && buf.data.size() > 0) {
       auto t = session().find_task(buf.rec_tid);
       t->write_bytes_helper(buf.addr, buf.data.size(), buf.data.data());
+      t->vm()->maybe_update_breakpoints(t, buf.addr.cast<uint8_t>(),
+                                        buf.data.size());
     }
   }
 }

--- a/src/test/jit_proc_mem.c
+++ b/src/test/jit_proc_mem.c
@@ -1,0 +1,37 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+#define _FILE_OFFSET_BITS 64
+
+#include "rrutil.h"
+#include <stdlib.h>
+
+typedef int (*printf_func)(const char* fmt, ...);
+
+int template_function(printf_func f, char* text) {
+  f(text);
+  return 0;
+}
+
+static __attribute__((noinline)) void breakpoint(void) {
+  int break_here = 1;
+  (void)break_here;
+}
+
+extern char __etext; // end of text section
+int main(void) {
+  void* space = mmap(NULL, 4096, PROT_EXEC | PROT_READ,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  int memfd = open("/proc/self/mem", O_RDWR);
+  breakpoint();
+
+  // It doesn't matter if we copy more than template_function, we jus
+  // shouldn't fall off the end of the text section.
+  size_t nbytes = (uintptr_t)&__etext - (uintptr_t)template_function;
+  ssize_t to_write = nbytes > 4096 ? 4096 : nbytes;
+  int nwritten =
+      pwrite(memfd, (void*)template_function, to_write, (uintptr_t)space);
+  assert(to_write == nwritten);
+
+  int ret = ((int (*)(printf_func, char*))space)(atomic_printf, "EXIT-SUCCESS");
+  breakpoint();
+  return ret;
+}

--- a/src/test/jit_proc_mem.py
+++ b/src/test/jit_proc_mem.py
@@ -1,0 +1,18 @@
+from rrutil import *
+
+send_gdb('break breakpoint')
+expect_gdb('Breakpoint 1')
+send_gdb('c')
+expect_gdb('Breakpoint 1')
+send_gdb('c')
+expect_gdb('Breakpoint 1')
+send_gdb('up')
+send_gdb('b *space')
+expect_gdb('Breakpoint 2')
+
+# Should hit breakpoint 2 here rather than making it all the way back to
+# the first instance of breakpoint 1.
+send_gdb('rc')
+expect_gdb('Breakpoint 2')
+
+ok()

--- a/src/test/jit_proc_mem.run
+++ b/src/test/jit_proc_mem.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+record jit_proc_mem$bitness
+debug jit_proc_mem


### PR DESCRIPTION
JITs sometimes use /proc/self/mem or proc_vm_writev to write data
directly to an RX page. See #1821 for a description on why this
caused problems before. This commit fixes that case (scenario 1 in
that issue), but does not fix the more complicated cases.