### PR TITLE
PAGE_SIZE -> sysconf(_SC_PAGESIZE)

### DIFF
--- a/src/test/call_function.c
+++ b/src/test/call_function.c
@@ -53,8 +53,9 @@ void print_time(void) {
 
 static void make_stack_executable(void) {
   int v = 0;
-  void* p = (void*)((uintptr_t)&v & ~((uintptr_t)PAGE_SIZE - 1));
-  int ret = mprotect(p, PAGE_SIZE, PROT_READ | PROT_WRITE | PROT_EXEC);
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  void* p = (void*)((uintptr_t)&v & ~((uintptr_t)page_size - 1));
+  int ret = mprotect(p, page_size, PROT_READ | PROT_WRITE | PROT_EXEC);
   test_assert(ret == 0 || errno == EACCES);
 }
 

--- a/src/test/clone_vfork.c
+++ b/src/test/clone_vfork.c
@@ -24,7 +24,8 @@ int main(int argc, char* argv[]) {
   test_assert(2 == argc);
   exe = argv[1];
 
-  shared = (int*)mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  shared = (int*)mmap(NULL, page_size, PROT_READ | PROT_WRITE,
                       MAP_ANONYMOUS | MAP_SHARED, -1, 0);
 
   child = clone(clonefunc, child_stack + sizeof(child_stack),

--- a/src/test/dconf_mock.c
+++ b/src/test/dconf_mock.c
@@ -13,7 +13,8 @@ int main(int argc, __attribute__((unused)) char* argv[]) {
   fd = open("dconf/user", O_CREAT | O_RDWR, 0600);
   test_assert(fd >= 0);
   test_assert(0 == ftruncate(fd, 2));
-  p = (char*)mmap(NULL, PAGE_SIZE, PROT_READ | (argc == 2 ? PROT_WRITE : 0),
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  p = (char*)mmap(NULL, page_size, PROT_READ | (argc == 2 ? PROT_WRITE : 0),
                   MAP_SHARED, fd, 0);
   test_assert(MAP_FAILED != p);
 

--- a/src/test/madvise.c
+++ b/src/test/madvise.c
@@ -2,12 +2,13 @@
 
 #include "rrutil.h"
 
-#define PAGE_ZEROES (PAGE_SIZE / sizeof(int))
+size_t page_size = 0;
+#define PAGE_ZEROES (page_size / sizeof(int))
 
 static size_t count_page_zeroes(int* p) {
   size_t zeroes = 0;
   size_t i;
-  for (i = 0; i < PAGE_SIZE / sizeof(*p); ++i) {
+  for (i = 0; i < page_size / sizeof(*p); ++i) {
     if (!p[i]) {
       ++zeroes;
     }
@@ -17,7 +18,7 @@ static size_t count_page_zeroes(int* p) {
 
 static void set_page_values_nonzero(int* p) {
   size_t i;
-  for (i = 0; i < PAGE_SIZE / sizeof(*p); ++i) {
+  for (i = 0; i < page_size / sizeof(*p); ++i) {
     p[i] = i + 1;
   }
 }
@@ -25,19 +26,20 @@ static void set_page_values_nonzero(int* p) {
 int main(void) {
   int* page;
   void* fixed_area;
+  page_size = sysconf(_SC_PAGESIZE);
 
   fixed_area =
-      mmap(NULL, PAGE_SIZE * 5, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+      mmap(NULL, page_size * 5, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   test_assert(fixed_area != MAP_FAILED);
-  test_assert(0 == munmap(fixed_area, PAGE_SIZE * 5));
+  test_assert(0 == munmap(fixed_area, page_size * 5));
 
-  page = mmap(fixed_area + PAGE_SIZE, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  page = mmap(fixed_area + page_size, page_size, PROT_READ | PROT_WRITE,
               MAP_FIXED | MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   test_assert(page != MAP_FAILED);
   test_assert(count_page_zeroes(page) == PAGE_ZEROES);
 
   set_page_values_nonzero(page);
-  test_assert(0 == madvise(page, PAGE_SIZE, MADV_DONTNEED));
+  test_assert(0 == madvise(page, page_size, MADV_DONTNEED));
   test_assert(count_page_zeroes(page) == PAGE_ZEROES);
 
   set_page_values_nonzero(page);
@@ -45,12 +47,12 @@ int main(void) {
   test_assert(count_page_zeroes(page) == PAGE_ZEROES);
 
   set_page_values_nonzero(page);
-  test_assert(-1 == madvise(fixed_area - 1, PAGE_SIZE * 5, MADV_DONTNEED));
+  test_assert(-1 == madvise(fixed_area - 1, page_size * 5, MADV_DONTNEED));
   test_assert(EINVAL == errno);
   /* check this madvise had no effect */
   test_assert(count_page_zeroes(page) < PAGE_ZEROES);
 
-  test_assert(-1 == madvise(fixed_area, PAGE_SIZE * 5, MADV_DONTNEED));
+  test_assert(-1 == madvise(fixed_area, page_size * 5, MADV_DONTNEED));
   test_assert(ENOMEM == errno);
   /* check this madvise did take effect */
   test_assert(count_page_zeroes(page) == PAGE_ZEROES);

--- a/src/test/madvise_dontfork.c
+++ b/src/test/madvise_dontfork.c
@@ -9,11 +9,12 @@ int main(void) {
   pid_t pid;
   int status;
 
-  page = mmap(NULL, PAGE_SIZE * 2, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  page = mmap(NULL, page_size * 2, PROT_READ | PROT_WRITE,
               MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   test_assert(page != MAP_FAILED);
 
-  test_assert(0 == madvise(page, PAGE_SIZE, MADV_DONTFORK));
+  test_assert(0 == madvise(page, page_size, MADV_DONTFORK));
 
   breakpoint();
 
@@ -21,10 +22,10 @@ int main(void) {
 
   pid = fork();
   if (!pid) {
-    test_assert(-1 == madvise(page, PAGE_SIZE, MADV_NORMAL));
+    test_assert(-1 == madvise(page, page_size, MADV_NORMAL));
     test_assert(ENOMEM == errno);
 
-    page[PAGE_SIZE] = 2;
+    page[page_size] = 2;
 
     atomic_puts("EXIT-SUCCESS");
     return 77;

--- a/src/test/madvise_free.c
+++ b/src/test/madvise_free.c
@@ -3,11 +3,12 @@
 #include "rrutil.h"
 
 int main(void) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
   void* p =
-      mmap(NULL, PAGE_SIZE, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+      mmap(NULL, page_size, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   test_assert(p != MAP_FAILED);
 
-  test_assert(-1 == madvise(p, PAGE_SIZE, MADV_FREE));
+  test_assert(-1 == madvise(p, page_size, MADV_FREE));
 
   atomic_puts("EXIT-SUCCESS");
 

--- a/src/test/mincore.c
+++ b/src/test/mincore.c
@@ -6,9 +6,10 @@
 
 int main(int argc, __attribute__((unused)) char* argv[]) {
   unsigned char* buf;
-  void* p = (void*)((long)&argc & ~(long)(PAGE_SIZE - 1));
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  void* p = (void*)((long)&argc & ~(long)(page_size - 1));
   ALLOCATE_GUARD(buf, 'q');
-  test_assert(0 == mincore(p, PAGE_SIZE, buf));
+  test_assert(0 == mincore(p, page_size, buf));
   /* I guess we can't actually check mincore's results in any way */
   VERIFY_GUARD(buf);
 

--- a/src/test/mlock.c
+++ b/src/test/mlock.c
@@ -3,12 +3,13 @@
 #include "rrutil.h"
 
 int main(void) {
-  void* p = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  void* p = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
                  MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   test_assert(p != MAP_FAILED);
 
-  test_assert(0 == mlock(p, PAGE_SIZE) || errno == ENOMEM || errno == EPERM);
-  test_assert(0 == munlock(p, PAGE_SIZE));
+  test_assert(0 == mlock(p, page_size) || errno == ENOMEM || errno == EPERM);
+  test_assert(0 == munlock(p, page_size));
   test_assert(0 == mlockall(MCL_CURRENT) || errno == ENOMEM || errno == EPERM);
   test_assert(0 == munlockall());
 

--- a/src/test/mmap_shared_prot.c
+++ b/src/test/mmap_shared_prot.c
@@ -13,7 +13,8 @@ int main(void) {
      patching etc */
   waitpid(-2, NULL, 0);
 
-  p = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  p = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS,
            -1, 0);
   test_assert(p != MAP_FAILED);
 
@@ -26,11 +27,11 @@ int main(void) {
     return 0;
   }
 
-  test_assert(0 == mprotect(p, PAGE_SIZE, PROT_READ));
+  test_assert(0 == mprotect(p, page_size, PROT_READ));
 
   breakpoint();
 
-  test_assert(0 == mprotect(p, PAGE_SIZE, PROT_READ | PROT_WRITE));
+  test_assert(0 == mprotect(p, page_size, PROT_READ | PROT_WRITE));
 
   *p = *p + 1;
 

--- a/src/test/mprotect_growsdown.c
+++ b/src/test/mprotect_growsdown.c
@@ -7,19 +7,20 @@ int main(void) {
 
   /* map 3 pages since the first page will be made into a guard page by the
      kernel */
-  p = mmap(NULL, PAGE_SIZE * 3, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  p = mmap(NULL, page_size * 3, PROT_READ | PROT_WRITE,
            MAP_PRIVATE | MAP_ANONYMOUS | MAP_GROWSDOWN, -1, 0);
   test_assert(p != MAP_FAILED);
 
   test_assert(
-      0 == mprotect(p + PAGE_SIZE * 2, PAGE_SIZE, PROT_NONE | PROT_GROWSDOWN));
+      0 == mprotect(p + page_size * 2, page_size, PROT_NONE | PROT_GROWSDOWN));
 
-  test_assert(-1 == mprotect(p + 1, PAGE_SIZE, PROT_NONE | PROT_GROWSDOWN));
+  test_assert(-1 == mprotect(p + 1, page_size, PROT_NONE | PROT_GROWSDOWN));
   test_assert(EINVAL == errno);
 
-  p = (char*)(((uintptr_t)main) & ~((uintptr_t)PAGE_SIZE - 1));
+  p = (char*)(((uintptr_t)main) & ~((uintptr_t)page_size - 1));
   test_assert(-1 ==
-              mprotect(p, PAGE_SIZE, PROT_READ | PROT_EXEC | PROT_GROWSDOWN));
+              mprotect(p, page_size, PROT_READ | PROT_EXEC | PROT_GROWSDOWN));
   test_assert(EINVAL == errno);
 
   atomic_puts("EXIT-SUCCESS");

--- a/src/test/mprotect_syscallbuf_overflow.c
+++ b/src/test/mprotect_syscallbuf_overflow.c
@@ -4,11 +4,12 @@
 
 int main(void) {
   int i;
+  size_t page_size = sysconf(_SC_PAGESIZE);
   void* p =
-      mmap(NULL, PAGE_SIZE, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+      mmap(NULL, page_size, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   test_assert(p != MAP_FAILED);
   for (i = 0; i < 10000; ++i) {
-    test_assert(0 == mprotect(p, PAGE_SIZE, PROT_READ | PROT_WRITE));
+    test_assert(0 == mprotect(p, page_size, PROT_READ | PROT_WRITE));
   }
   atomic_puts("EXIT-SUCCESS");
   return 0;

--- a/src/test/mremap_grow.c
+++ b/src/test/mremap_grow.c
@@ -4,7 +4,8 @@
 
 int main(void) {
   int fd = open("temp", O_RDWR | O_CREAT, 0700);
-  char buf[PAGE_SIZE * 2];
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  char buf[page_size * 2];
   char* p;
 
   test_assert(fd >= 0);
@@ -13,14 +14,14 @@ int main(void) {
   memset(buf, 1, sizeof(buf));
   test_assert((ssize_t)sizeof(buf) == write(fd, buf, sizeof(buf)));
 
-  p = (char*)mmap(NULL, PAGE_SIZE, PROT_READ, MAP_PRIVATE, fd, 0);
+  p = (char*)mmap(NULL, page_size, PROT_READ, MAP_PRIVATE, fd, 0);
   test_assert(p != MAP_FAILED);
   test_assert(p[0] == 1);
 
-  p = (char*)mremap(p, PAGE_SIZE, PAGE_SIZE * 2, MREMAP_MAYMOVE);
+  p = (char*)mremap(p, page_size, page_size * 2, MREMAP_MAYMOVE);
   test_assert(p != MAP_FAILED);
   test_assert(p[0] == 1);
-  test_assert(p[PAGE_SIZE] == 1);
+  test_assert(p[page_size] == 1);
 
   atomic_puts("EXIT-SUCCESS");
   return 0;

--- a/src/test/mremap_grow_shared.c
+++ b/src/test/mremap_grow_shared.c
@@ -4,20 +4,21 @@
 
 int main(__attribute((unused)) int argc, char* argv[]) {
   int fd = open(argv[0], O_RDONLY);
-  char buf[PAGE_SIZE * 2];
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  char buf[page_size * 2];
   char* p;
 
   test_assert(fd >= 0);
   test_assert((ssize_t)sizeof(buf) == read(fd, buf, sizeof(buf)));
 
-  p = (char*)mmap(NULL, PAGE_SIZE, PROT_READ, MAP_SHARED, fd, 0);
+  p = (char*)mmap(NULL, page_size, PROT_READ, MAP_SHARED, fd, 0);
   test_assert(p != MAP_FAILED);
   test_assert(p[0] == buf[0]);
 
-  p = (char*)mremap(p, PAGE_SIZE, PAGE_SIZE * 2, MREMAP_MAYMOVE);
+  p = (char*)mremap(p, page_size, page_size * 2, MREMAP_MAYMOVE);
   test_assert(p != MAP_FAILED);
   test_assert(p[0] == buf[0]);
-  test_assert(p[PAGE_SIZE] == buf[PAGE_SIZE]);
+  test_assert(p[page_size] == buf[page_size]);
 
   atomic_puts("EXIT-SUCCESS");
   return 0;

--- a/src/test/mremap_shrink.c
+++ b/src/test/mremap_shrink.c
@@ -3,10 +3,11 @@
 #include "rrutil.h"
 
 int main(void) {
-  void* p = mmap(NULL, 3 * PAGE_SIZE, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  void* p = mmap(NULL, 3 * page_size, PROT_READ | PROT_WRITE,
                  MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-  void* p2 = mremap(p, 3 * PAGE_SIZE, 2 * PAGE_SIZE, 0);
-  void* p3 = mremap(p, 2 * PAGE_SIZE, PAGE_SIZE, MREMAP_MAYMOVE);
+  void* p2 = mremap(p, 3 * page_size, 2 * page_size, 0);
+  void* p3 = mremap(p, 2 * page_size, page_size, MREMAP_MAYMOVE);
 
   atomic_printf("%p %p %p\n", p, p2, p3);
   atomic_puts("EXIT-SUCCESS");

--- a/src/test/munmap_segv.c
+++ b/src/test/munmap_segv.c
@@ -8,7 +8,8 @@ static void sighandler(__attribute__((unused)) int sig) {
 }
 
 int main(void) {
-  char* p = (char*)mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  char* p = (char*)mmap(NULL, page_size, PROT_READ | PROT_WRITE,
                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   test_assert(p != MAP_FAILED);
 
@@ -16,7 +17,7 @@ int main(void) {
 
   *p = 'a';
 
-  test_assert(0 == munmap(p, PAGE_SIZE));
+  test_assert(0 == munmap(p, page_size));
   *p = 'b';
 
   return 0;

--- a/src/test/numa.c
+++ b/src/test/numa.c
@@ -21,12 +21,13 @@ static long mbind(void* start, unsigned long len, int mode,
 }
 
 int main(void) {
-  void* p = mmap(NULL, 16 * PAGE_SIZE, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  void* p = mmap(NULL, 16 * page_size, PROT_READ | PROT_WRITE,
                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   int ret;
 
   test_assert(p != MAP_FAILED);
-  ret = mbind(p, 16 * PAGE_SIZE, MPOL_PREFERRED, NULL, 0, MPOL_MF_MOVE);
+  ret = mbind(p, 16 * page_size, MPOL_PREFERRED, NULL, 0, MPOL_MF_MOVE);
   test_assert(ret == 0 || (ret == -1 && errno == ENOSYS));
 
   atomic_puts("EXIT-SUCCESS");

--- a/src/test/ptrace_signals.c
+++ b/src/test/ptrace_signals.c
@@ -14,7 +14,8 @@ int main(void) {
   int status;
   int pipe_fds[2];
 
-  p = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  p = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED,
            -1, 0);
   test_assert(MAP_FAILED != p);
   p[0] = 0;

--- a/src/test/robust_futex.c
+++ b/src/test/robust_futex.c
@@ -23,7 +23,8 @@ int main(void) {
 
   test_assert(0 == pipe(pipe_fds));
 
-  mutex = (pthread_mutex_t*)mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  mutex = (pthread_mutex_t*)mmap(NULL, page_size, PROT_READ | PROT_WRITE,
                                  MAP_SHARED | MAP_ANONYMOUS, -1, 0);
 
   pthread_mutexattr_init(&attr);

--- a/src/test/search.c
+++ b/src/test/search.c
@@ -22,22 +22,23 @@ int main(int argc, __attribute__((unused)) char* argv[]) {
 
   argc_ptr = &argc;
 
-  p = (char*)mmap(NULL, PAGE_SIZE * 4, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  p = (char*)mmap(NULL, page_size * 4, PROT_READ | PROT_WRITE,
                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   test_assert(p != MAP_FAILED);
-  p_end = p + PAGE_SIZE * 4;
+  p_end = p + page_size * 4;
 
   /* Don't copy the whole buf. If we do, we may trigger memcpy routines
    * that copy state to registers which are later spilled to the stack,
    * causing false positives. These short memcpys are performed using volatile
    * registers.
    */
-  memcpy(p + PAGE_SIZE, buf, 12);
-  memcpy(p + PAGE_SIZE * 2, buf, 12);
+  memcpy(p + page_size, buf, 12);
+  memcpy(p + page_size * 2, buf, 12);
 
-  test_assert(0 == munmap(p, PAGE_SIZE));
-  test_assert(0 == munmap(p + PAGE_SIZE * 3, PAGE_SIZE));
-  test_assert(0 == mprotect(p + PAGE_SIZE, PAGE_SIZE, PROT_NONE));
+  test_assert(0 == munmap(p, page_size));
+  test_assert(0 == munmap(p + page_size * 3, page_size));
+  test_assert(0 == mprotect(p + page_size, page_size, PROT_NONE));
 
   breakpoint();
 

--- a/src/test/sem.c
+++ b/src/test/sem.c
@@ -128,7 +128,8 @@ int main(void) {
   pid_t child;
   int status;
 
-  shmem = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  shmem = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
                MAP_ANONYMOUS | MAP_SHARED, -1, 0);
   test_assert(shmem != (void*)-1);
 

--- a/src/test/set_tid_address.c
+++ b/src/test/set_tid_address.c
@@ -31,9 +31,10 @@ int main(void) {
   test_assert(0 == syscall(SYS_futex, &v, FUTEX_WAIT, 1, NULL, NULL, 0));
   test_assert(0 == v);
 
-  p = mmap(NULL, PAGE_SIZE, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  p = mmap(NULL, page_size, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   test_assert(p != MAP_FAILED);
-  test_assert(0 == munmap(p, PAGE_SIZE));
+  test_assert(0 == munmap(p, page_size));
 
   pthread_create(&thread, NULL, run_thread2, NULL);
   test_assert(1 == read(pipe_fds[0], &ch, 1));

--- a/src/test/shared_map.c
+++ b/src/test/shared_map.c
@@ -4,7 +4,8 @@
 
 int main(void) {
   int fd = open("tmp.txt", O_RDWR | O_CREAT | O_EXCL, 0700);
-  char buf[PAGE_SIZE];
+  ssize_t page_size = sysconf(_SC_PAGESIZE);
+  char buf[page_size];
   char* p;
   char* q;
   pid_t child;
@@ -12,11 +13,11 @@ int main(void) {
 
   test_assert(fd >= 0);
   memset(buf, 1, sizeof(buf));
-  test_assert(PAGE_SIZE == write(fd, buf, PAGE_SIZE));
+  test_assert(page_size == write(fd, buf, page_size));
   test_assert(0 == close(fd));
 
   fd = open("tmp.txt", O_RDWR);
-  p = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  p = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   test_assert(p != MAP_FAILED);
   test_assert(p[0] == 1);
   test_assert(p[9] == 1);
@@ -25,7 +26,7 @@ int main(void) {
 
   child = fork();
   if (!child) {
-    q = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    q = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     test_assert(q != MAP_FAILED);
     test_assert(q[0] == 2);
     test_assert(q[9] == 2);

--- a/src/test/shm.c
+++ b/src/test/shm.c
@@ -4,7 +4,7 @@
 
 /* Make SIZE not a multiple of the page size, to ensure we handle that case.
    But make sure it's even, since we divide it by two. */
-#define SIZE ((int)(16 * PAGE_SIZE) - 10)
+#define SIZE ((int)(16 * page_size) - 10)
 
 static int shmid;
 
@@ -20,6 +20,8 @@ static int run_child(void) {
   struct shmid_ds* ds;
   struct shminfo* info;
   struct shm_info* info2;
+
+  size_t page_size = sysconf(_SC_PAGESIZE);
 
   ALLOCATE_GUARD(ds, 'd');
   test_assert(0 == shmctl(shmid, IPC_STAT, ds));
@@ -86,6 +88,8 @@ static int run_child(void) {
 int main(void) {
   pid_t child;
   int status;
+
+  size_t page_size = sysconf(_SC_PAGESIZE);
 
   shmid = shmget(IPC_PRIVATE, SIZE, 0666);
   test_assert(shmid >= 0);

--- a/src/test/stack_growth_with_guard.c
+++ b/src/test/stack_growth_with_guard.c
@@ -6,28 +6,30 @@ static char* volatile end_of_guard_addr;
 static volatile char got_segv;
 
 static void handler(__attribute__((unused)) int sig) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
   test_assert(end_of_guard_addr ==
-              mmap(end_of_guard_addr, PAGE_SIZE, PROT_READ | PROT_WRITE,
+              mmap(end_of_guard_addr, page_size, PROT_READ | PROT_WRITE,
                    MAP_ANONYMOUS | MAP_FIXED | MAP_PRIVATE, -1, 0));
   got_segv = 1;
 }
 
 int main(void) {
   int local_var;
+  size_t page_size = sysconf(_SC_PAGESIZE);
   char* guard_addr =
-      (char*)(((uintptr_t)&local_var) & ~((uintptr_t)PAGE_SIZE - 1)) -
-      262 * PAGE_SIZE;
+      (char*)(((uintptr_t)&local_var) & ~((uintptr_t)page_size - 1)) -
+      262 * page_size;
   int i;
-  test_assert(guard_addr == mmap(guard_addr, PAGE_SIZE * 128, PROT_NONE,
+  test_assert(guard_addr == mmap(guard_addr, page_size * 128, PROT_NONE,
                                  MAP_ANONYMOUS | MAP_FIXED | MAP_PRIVATE, -1,
                                  0));
-  end_of_guard_addr = guard_addr + PAGE_SIZE * 128;
+  end_of_guard_addr = guard_addr + page_size * 128;
   atomic_printf("guard_addr=%p end_of_guard_addr=%p\n", guard_addr,
                 end_of_guard_addr);
 
   /* Extend mapping close to the actual address we want to test. */
   for (i = 127; i >= 5; --i) {
-    end_of_guard_addr[PAGE_SIZE * i] = 77;
+    end_of_guard_addr[page_size * i] = 77;
   }
 
   signal(SIGSEGV, handler);

--- a/src/test/stack_overflow.c
+++ b/src/test/stack_overflow.c
@@ -27,7 +27,8 @@ int main(void) {
   pid_t child;
   int status;
 
-  depth = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  depth = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
                MAP_ANONYMOUS | MAP_SHARED, -1, 0);
   test_assert(depth != MAP_FAILED);
 

--- a/src/test/stack_overflow_with_guard.c
+++ b/src/test/stack_overflow_with_guard.c
@@ -27,7 +27,8 @@ int main(int argc, __attribute__((unused)) char* argv[]) {
   pid_t child;
   int status;
 
-  depth = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  depth = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
                MAP_ANONYMOUS | MAP_SHARED, -1, 0);
   test_assert(depth != MAP_FAILED);
 
@@ -43,9 +44,9 @@ int main(int argc, __attribute__((unused)) char* argv[]) {
     test_assert(0 == sigaction(SIGSEGV, &act, NULL));
 
     void* p =
-        (void*)((size_t)(fake_sp - 8 * PAGE_SIZE) & ~(size_t)(PAGE_SIZE - 1));
+        (void*)((size_t)(fake_sp - 8 * page_size) & ~(size_t)(page_size - 1));
 
-    test_assert(mmap(p, PAGE_SIZE, PROT_NONE,
+    test_assert(mmap(p, page_size, PROT_NONE,
                      MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0) == p);
 
     return recurse();

--- a/src/test/unexpected_stack_growth.c
+++ b/src/test/unexpected_stack_growth.c
@@ -21,12 +21,12 @@ int main(void) {
   char v;
   char* fix_addr;
   void* p;
+  size_t page_size = sysconf(_SC_PAGESIZE);
 
   breakpoint();
-
   fix_addr =
-      (char*)(((uintptr_t)&v - 256 * 1024) & ~(uintptr_t)(PAGE_SIZE - 1));
-  p = mmap(fix_addr, PAGE_SIZE, PROT_READ | PROT_WRITE,
+      (char*)(((uintptr_t)&v - 256 * 1024) & ~(uintptr_t)(page_size - 1));
+  p = mmap(fix_addr, page_size, PROT_READ | PROT_WRITE,
            MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   test_assert(p == fix_addr);
 

--- a/src/test/vfork_shared.c
+++ b/src/test/vfork_shared.c
@@ -7,9 +7,10 @@ static int* p;
 int main(void) {
   pid_t child;
   int status;
+  size_t page_size = sysconf(_SC_PAGESIZE);
 
   if (0 == (child = vfork())) {
-    p = (int*)mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+    p = (int*)mmap(NULL, page_size, PROT_READ | PROT_WRITE,
                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     *p = 88;
     test_assert(p != MAP_FAILED);

--- a/src/test/vm_readv_writev.c
+++ b/src/test/vm_readv_writev.c
@@ -4,98 +4,100 @@
 
 static void clear(unsigned char* p) {
   size_t i;
-  for (i = 0; i < (unsigned)PAGE_SIZE; ++i) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  for (i = 0; i < (unsigned)page_size; ++i) {
     p[i] = i & 0xFF;
   }
 }
 
 int main(void) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
   unsigned char* p =
-      (unsigned char*)mmap(NULL, PAGE_SIZE * 2, PROT_READ | PROT_WRITE,
+      (unsigned char*)mmap(NULL, page_size * 2, PROT_READ | PROT_WRITE,
                            MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   struct iovec in_iov[2];
   struct iovec out_iov[2];
   int ret;
 
   test_assert(p != MAP_FAILED);
-  test_assert(0 == munmap(p + PAGE_SIZE, PAGE_SIZE));
+  test_assert(0 == munmap(p + page_size, page_size));
 
   in_iov[0].iov_base = p;
   in_iov[0].iov_len = 2;
   in_iov[1].iov_base = p + 3;
   in_iov[1].iov_len = 3;
-  out_iov[0].iov_base = p + PAGE_SIZE - 6;
+  out_iov[0].iov_base = p + page_size - 6;
   out_iov[0].iov_len = 3;
-  out_iov[1].iov_base = p + PAGE_SIZE - 1;
+  out_iov[1].iov_base = p + page_size - 1;
   out_iov[1].iov_len = 2;
 
   clear(p);
   test_assert(4 == process_vm_readv(getpid(), out_iov, 2, in_iov, 2, 0));
   test_assert(out_iov[1].iov_len == 2);
-  test_assert(p[PAGE_SIZE - 7] == ((PAGE_SIZE - 7) & 0xff));
-  test_assert(p[PAGE_SIZE - 6] == 0);
-  test_assert(p[PAGE_SIZE - 5] == 1);
-  test_assert(p[PAGE_SIZE - 4] == 3);
-  test_assert(p[PAGE_SIZE - 3] == ((PAGE_SIZE - 3) & 0xff));
-  test_assert(p[PAGE_SIZE - 2] == ((PAGE_SIZE - 2) & 0xff));
-  test_assert(p[PAGE_SIZE - 1] == 4);
+  test_assert(p[page_size - 7] == ((page_size - 7) & 0xff));
+  test_assert(p[page_size - 6] == 0);
+  test_assert(p[page_size - 5] == 1);
+  test_assert(p[page_size - 4] == 3);
+  test_assert(p[page_size - 3] == ((page_size - 3) & 0xff));
+  test_assert(p[page_size - 2] == ((page_size - 2) & 0xff));
+  test_assert(p[page_size - 1] == 4);
   clear(p);
   ret = process_vm_writev(getpid(), in_iov, 2, out_iov, 2, 0);
   if (3 == ret) {
     test_assert(out_iov[1].iov_len == 2);
-    test_assert(p[PAGE_SIZE - 7] == ((PAGE_SIZE - 7) & 0xff));
-    test_assert(p[PAGE_SIZE - 6] == 0);
-    test_assert(p[PAGE_SIZE - 5] == 1);
-    test_assert(p[PAGE_SIZE - 4] == 3);
-    test_assert(p[PAGE_SIZE - 3] == ((PAGE_SIZE - 3) & 0xff));
-    test_assert(p[PAGE_SIZE - 2] == ((PAGE_SIZE - 2) & 0xff));
-    test_assert(p[PAGE_SIZE - 1] == ((PAGE_SIZE - 1) & 0xff));
+    test_assert(p[page_size - 7] == ((page_size - 7) & 0xff));
+    test_assert(p[page_size - 6] == 0);
+    test_assert(p[page_size - 5] == 1);
+    test_assert(p[page_size - 4] == 3);
+    test_assert(p[page_size - 3] == ((page_size - 3) & 0xff));
+    test_assert(p[page_size - 2] == ((page_size - 2) & 0xff));
+    test_assert(p[page_size - 1] == ((page_size - 1) & 0xff));
   } else {
     test_assert(4 == ret);
     test_assert(out_iov[1].iov_len == 2);
-    test_assert(p[PAGE_SIZE - 7] == ((PAGE_SIZE - 7) & 0xff));
-    test_assert(p[PAGE_SIZE - 6] == 0);
-    test_assert(p[PAGE_SIZE - 5] == 1);
-    test_assert(p[PAGE_SIZE - 4] == 3);
-    test_assert(p[PAGE_SIZE - 3] == ((PAGE_SIZE - 3) & 0xff));
-    test_assert(p[PAGE_SIZE - 2] == ((PAGE_SIZE - 2) & 0xff));
-    test_assert(p[PAGE_SIZE - 1] == 4);
+    test_assert(p[page_size - 7] == ((page_size - 7) & 0xff));
+    test_assert(p[page_size - 6] == 0);
+    test_assert(p[page_size - 5] == 1);
+    test_assert(p[page_size - 4] == 3);
+    test_assert(p[page_size - 3] == ((page_size - 3) & 0xff));
+    test_assert(p[page_size - 2] == ((page_size - 2) & 0xff));
+    test_assert(p[page_size - 1] == 4);
   }
 
-  out_iov[1].iov_base = p + PAGE_SIZE - 2;
+  out_iov[1].iov_base = p + page_size - 2;
   out_iov[1].iov_len = 3;
 
   clear(p);
   test_assert(5 == process_vm_readv(getpid(), out_iov, 2, in_iov, 2, 0));
-  test_assert(p[PAGE_SIZE - 7] == ((PAGE_SIZE - 7) & 0xff));
-  test_assert(p[PAGE_SIZE - 6] == 0);
-  test_assert(p[PAGE_SIZE - 5] == 1);
-  test_assert(p[PAGE_SIZE - 4] == 3);
-  test_assert(p[PAGE_SIZE - 3] == ((PAGE_SIZE - 3) & 0xff));
-  test_assert(p[PAGE_SIZE - 2] == 4);
-  test_assert(p[PAGE_SIZE - 1] == 5);
+  test_assert(p[page_size - 7] == ((page_size - 7) & 0xff));
+  test_assert(p[page_size - 6] == 0);
+  test_assert(p[page_size - 5] == 1);
+  test_assert(p[page_size - 4] == 3);
+  test_assert(p[page_size - 3] == ((page_size - 3) & 0xff));
+  test_assert(p[page_size - 2] == 4);
+  test_assert(p[page_size - 1] == 5);
   clear(p);
   ret = process_vm_writev(getpid(), in_iov, 2, out_iov, 2, 0);
   if (3 == ret) {
-    test_assert(p[PAGE_SIZE - 7] == ((PAGE_SIZE - 7) & 0xff));
-    test_assert(p[PAGE_SIZE - 6] == 0);
-    test_assert(p[PAGE_SIZE - 5] == 1);
-    test_assert(p[PAGE_SIZE - 4] == 3);
-    test_assert(p[PAGE_SIZE - 3] == ((PAGE_SIZE - 3) & 0xff));
-    test_assert(p[PAGE_SIZE - 2] == ((PAGE_SIZE - 2) & 0xff));
-    test_assert(p[PAGE_SIZE - 1] == ((PAGE_SIZE - 1) & 0xff));
+    test_assert(p[page_size - 7] == ((page_size - 7) & 0xff));
+    test_assert(p[page_size - 6] == 0);
+    test_assert(p[page_size - 5] == 1);
+    test_assert(p[page_size - 4] == 3);
+    test_assert(p[page_size - 3] == ((page_size - 3) & 0xff));
+    test_assert(p[page_size - 2] == ((page_size - 2) & 0xff));
+    test_assert(p[page_size - 1] == ((page_size - 1) & 0xff));
   } else {
     test_assert(5 == ret);
-    test_assert(p[PAGE_SIZE - 7] == ((PAGE_SIZE - 7) & 0xff));
-    test_assert(p[PAGE_SIZE - 6] == 0);
-    test_assert(p[PAGE_SIZE - 5] == 1);
-    test_assert(p[PAGE_SIZE - 4] == 3);
-    test_assert(p[PAGE_SIZE - 3] == ((PAGE_SIZE - 3) & 0xff));
-    test_assert(p[PAGE_SIZE - 2] == 4);
-    test_assert(p[PAGE_SIZE - 1] == 5);
+    test_assert(p[page_size - 7] == ((page_size - 7) & 0xff));
+    test_assert(p[page_size - 6] == 0);
+    test_assert(p[page_size - 5] == 1);
+    test_assert(p[page_size - 4] == 3);
+    test_assert(p[page_size - 3] == ((page_size - 3) & 0xff));
+    test_assert(p[page_size - 2] == 4);
+    test_assert(p[page_size - 1] == 5);
   }
 
-  in_iov[0].iov_base = p + PAGE_SIZE - 1;
+  in_iov[0].iov_base = p + page_size - 1;
   in_iov[0].iov_len = 2;
   out_iov[0].iov_base = p;
   out_iov[0].iov_len = 3;
@@ -107,12 +109,12 @@ int main(void) {
     test_assert(p[1] == 1);
   } else {
     test_assert(1 == ret);
-    test_assert(p[0] == ((PAGE_SIZE - 1) & 0xff));
+    test_assert(p[0] == ((page_size - 1) & 0xff));
     test_assert(p[1] == 1);
   }
   clear(p);
   test_assert(1 == process_vm_writev(getpid(), in_iov, 1, out_iov, 1, 0));
-  test_assert(p[0] == ((PAGE_SIZE - 1) & 0xff));
+  test_assert(p[0] == ((page_size - 1) & 0xff));
   /* Linux kernel bug: should be 1, but sometimes is zero ---
      extra data written. https://bugzilla.kernel.org/show_bug.cgi?id=113541 */
   if (p[1] == 0) {
@@ -120,9 +122,9 @@ int main(void) {
   }
   test_assert(p[1] == 1 || p[1] == 0);
 
-  in_iov[0].iov_base = p + PAGE_SIZE - 4;
+  in_iov[0].iov_base = p + page_size - 4;
   in_iov[0].iov_len = 2;
-  in_iov[1].iov_base = p + PAGE_SIZE - 2;
+  in_iov[1].iov_base = p + page_size - 2;
   in_iov[1].iov_len = 3;
   out_iov[0].iov_base = p;
   out_iov[0].iov_len = 1;
@@ -132,28 +134,28 @@ int main(void) {
   clear(p);
   ret = process_vm_readv(getpid(), out_iov, 2, in_iov, 2, 0);
   if (2 == ret) {
-    test_assert(p[0] == ((PAGE_SIZE - 4) & 0xff));
+    test_assert(p[0] == ((page_size - 4) & 0xff));
     test_assert(p[1] == 1);
-    test_assert(p[2] == ((PAGE_SIZE - 3) & 0xff));
+    test_assert(p[2] == ((page_size - 3) & 0xff));
     test_assert(p[3] == 3);
     test_assert(p[4] == 4);
     test_assert(p[5] == 5);
   } else {
     test_assert(4 == ret);
-    test_assert(p[0] == ((PAGE_SIZE - 4) & 0xff));
+    test_assert(p[0] == ((page_size - 4) & 0xff));
     test_assert(p[1] == 1);
-    test_assert(p[2] == ((PAGE_SIZE - 3) & 0xff));
-    test_assert(p[3] == ((PAGE_SIZE - 2) & 0xff));
-    test_assert(p[4] == ((PAGE_SIZE - 1) & 0xff));
+    test_assert(p[2] == ((page_size - 3) & 0xff));
+    test_assert(p[3] == ((page_size - 2) & 0xff));
+    test_assert(p[4] == ((page_size - 1) & 0xff));
     test_assert(p[5] == 5);
   }
   clear(p);
   test_assert(4 == process_vm_writev(getpid(), in_iov, 2, out_iov, 2, 0));
-  test_assert(p[0] == ((PAGE_SIZE - 4) & 0xff));
+  test_assert(p[0] == ((page_size - 4) & 0xff));
   test_assert(p[1] == 1);
-  test_assert(p[2] == ((PAGE_SIZE - 3) & 0xff));
-  test_assert(p[3] == ((PAGE_SIZE - 2) & 0xff));
-  test_assert(p[4] == ((PAGE_SIZE - 1) & 0xff));
+  test_assert(p[2] == ((page_size - 3) & 0xff));
+  test_assert(p[3] == ((page_size - 2) & 0xff));
+  test_assert(p[4] == ((page_size - 1) & 0xff));
   if (p[5] == 0) {
     atomic_puts("Kernel bug detected!");
   }

--- a/src/test/watchpoint_syscall.c
+++ b/src/test/watchpoint_syscall.c
@@ -7,10 +7,11 @@ static void breakpoint(void) {}
 static char* p;
 
 int main(void) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
   int fd = open("/dev/zero", O_RDONLY);
   test_assert(fd >= 0);
 
-  p = (char*)mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  p = (char*)mmap(NULL, page_size, PROT_READ | PROT_WRITE,
                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   test_assert(p != MAP_FAILED);
 
@@ -23,11 +24,11 @@ int main(void) {
 
   *p = 'b';
 
-  test_assert(p == mmap(p, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  test_assert(p == mmap(p, page_size, PROT_READ | PROT_WRITE,
                         MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0));
   test_assert(*p == 0);
 
-  test_assert(0 == munmap(p, PAGE_SIZE));
+  test_assert(0 == munmap(p, page_size));
 
   atomic_puts("EXIT-SUCCESS");
 


### PR DESCRIPTION
For architectures where PAGE_SIZE is variable and thus not defined
as a constant.

Left over from experimenting with rr on other architectures (on hold
for now), but figured I'd put up the mechanical bits to save myself
or others time next time around.