### PR TITLE
Improve Monkeypatcher interfering branch heuristic

### DIFF
--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -361,7 +361,7 @@ bool Monkeypatcher::try_patch_syscall(RecordTask* t) {
   for (auto& hook : syscall_hooks) {
     if (memcmp(following_bytes, hook.next_instruction_bytes,
                hook.next_instruction_length) == 0) {
-      // Search for a following short-jump instruction that targets the zone
+      // Search for a following short-jump instruction that targets an instruction
       // after the syscall. False positives are OK.
       // glibc-2.23.1-8.fc24.x86_64's __clock_nanosleep needs this.
       bool found_potential_interfering_branch = false;
@@ -370,7 +370,7 @@ bool Monkeypatcher::try_patch_syscall(RecordTask* t) {
         // Check for short conditional or unconditional jump
         if (b == 0xeb || (b >= 0x70 && b < 0x80)) {
           int offset = i + 2 + (int8_t)following_bytes[i + 1];
-          if (offset >= 0 && offset < hook.next_instruction_length) {
+          if (hook.is_multi_instruction ? (offset >= 0 && offset < hook.next_instruction_length) : offset == 0) {
             LOG(debug) << "Found potential interfering branch at "
                        << r.ip().to_data_ptr<uint8_t>() + i;
             // We can't patch this because it would jump straight back into

--- a/src/preload/preload.c
+++ b/src/preload/preload.c
@@ -612,11 +612,11 @@ static void __attribute__((constructor)) init_process(void) {
   struct syscall_patch_hook syscall_patch_hooks[] = {
     /* pthread_cond_broadcast has 'int 80' followed by
      * cmp $-4095,%eax (in glibc-2.18-16.fc20.i686) */
-    { 5,
+    { 0, 5,
       { 0x3d, 0x01, 0xf0, 0xff, 0xff },
       (uintptr_t)_syscall_hook_trampoline_3d_01_f0_ff_ff },
     /* Our vdso syscall patch has 'int 80' followed by onp; nop; nop */
-    { 3, { 0x90, 0x90, 0x90 }, (uintptr_t)_syscall_hook_trampoline_90_90_90 }
+    { 0, 3, { 0x90, 0x90, 0x90 }, (uintptr_t)_syscall_hook_trampoline_90_90_90 }
   };
 
   /* Load GLIBC 2.1 version of pthread_create. Otherwise we may get the 2.0
@@ -637,44 +637,44 @@ static void __attribute__((constructor)) init_process(void) {
     /* Many glibc syscall wrappers (e.g. read) have 'syscall' followed
      * by
      * cmp $-4095,%rax (in glibc-2.18-16.fc20.x86_64) */
-    { 6,
+    { 0, 6,
       { 0x48, 0x3d, 0x01, 0xf0, 0xff, 0xff },
       (uintptr_t)_syscall_hook_trampoline_48_3d_01_f0_ff_ff },
     /* Many glibc syscall wrappers (e.g. __libc_recv) have 'syscall'
      * followed by
      * cmp $-4096,%rax (in glibc-2.18-16.fc20.x86_64) */
-    { 6,
+    { 0, 6,
       { 0x48, 0x3d, 0x00, 0xf0, 0xff, 0xff },
       (uintptr_t)_syscall_hook_trampoline_48_3d_00_f0_ff_ff },
     /* Many glibc syscall wrappers (e.g. read) have 'syscall' followed
      * by
      * mov (%rsp),%rdi (in glibc-2.18-16.fc20.x86_64) */
-    { 4,
+    { 0, 4,
       { 0x48, 0x8b, 0x3c, 0x24 },
       (uintptr_t)_syscall_hook_trampoline_48_8b_3c_24 },
     /* __lll_unlock_wake has 'syscall' followed by
      * pop %rdx; pop %rsi; ret */
-    { 3, { 0x5a, 0x5e, 0xc3 }, (uintptr_t)_syscall_hook_trampoline_5a_5e_c3 },
+    { 1, 3, { 0x5a, 0x5e, 0xc3 }, (uintptr_t)_syscall_hook_trampoline_5a_5e_c3 },
     /* posix_fadvise64 has 'syscall' followed by
      * mov %eax,%edx; neg %edx (in glibc-2.22-11.fc23.x86_64) */
-    { 4,
+    { 1, 4,
       { 0x89, 0xc2, 0xf7, 0xda },
       (uintptr_t)_syscall_hook_trampoline_89_c2_f7_da },
     /* Our VDSO vsyscall patches have 'syscall' followed by "nop; nop;
        nop" */
-    { 3,
+    { 1, 3,
       { 0x90, 0x90, 0x90 },
       (uintptr_t)_syscall_hook_trampoline_ba_01_00_00_00 },
     /* glibc-2.22-17.fc23.x86_64 has 'syscall' followed by 'mov $1,%rdx'
      * in
      * pthread_barrier_wait.
      */
-    { 5,
+    { 0, 5,
       { 0xba, 0x01, 0x00, 0x00, 0x00 },
       (uintptr_t)_syscall_hook_trampoline_ba_01_00_00_00 },
     /* pthread_sigmask has 'syscall' followed by 'mov %eax,%ecx; xor
        %edx,%edx' */
-    { 4,
+    { 1, 4,
       { 0x89, 0xc1, 0x31, 0xd2 },
       (uintptr_t)_syscall_hook_trampoline_89_c1_31_d2 }
   };

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -127,6 +127,7 @@
  * syscall and a hook function to patch with.
  */
 struct syscall_patch_hook {
+  uint8_t is_multi_instruction;
   uint8_t next_instruction_length;
   uint8_t next_instruction_bytes[6];
   uint64_t hook_address;


### PR DESCRIPTION
On Ubuntu 16.10, the glibc read syscall wrapper is not patched, due to
what rr thinks is an interfering branch. In reality, it's just an unfortunate
subsequence of a different instruction in a different function. We can
fix this (and the severe performance regression caused by it) by improving
the heuristic, since this unfortunate byte sequence appears to target,
one byte after the end of the syscall instruction, which is not a valid
jump target for an actual interfering branch.
