### PR TITLE
Allow `write` on fds that were MAP_SHARED if all mappings have been unmapped

### DIFF
--- a/src/MmappedFileMonitor.h
+++ b/src/MmappedFileMonitor.h
@@ -20,6 +20,7 @@ public:
   MmappedFileMonitor(Task* t, EmuFile::shr_ptr f);
 
   virtual Type type() { return Mmapped; }
+  void revive() { dead_ = false; }
 
   /**
    * During recording, note writes to mapped segments.
@@ -28,6 +29,8 @@ public:
                          int64_t offset);
 
 private:
+  // Whether this monitor is still actively monitoring
+  bool dead_;
   bool extant_;
   dev_t device_;
   ino_t inode_;

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3891,6 +3891,7 @@ static void process_mmap(RecordTask* t, size_t length, int prot, int flags,
       if (t->fd_table()->is_monitoring(fd)) {
         ASSERT(t, t->fd_table()->get_monitor(fd)->type() ==
                       FileMonitor::Type::Mmapped);
+        ((MmappedFileMonitor*)t->fd_table()->get_monitor(fd))->revive();
       } else {
         t->fd_table()->add_monitor(fd, new MmappedFileMonitor(t, fd));
       }

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -758,6 +758,7 @@ static void finish_shared_mmap(ReplayTask* t, AutoRemoteSyscalls& remote,
     if (t->fd_table()->is_monitoring(fd)) {
       ASSERT(t, t->fd_table()->get_monitor(fd)->type() ==
                     FileMonitor::Type::Mmapped);
+      ((MmappedFileMonitor*)t->fd_table()->get_monitor(fd))->revive();
     } else {
       t->fd_table()->add_monitor(fd, new MmappedFileMonitor(t, emufile));
     }

--- a/src/test/mmap_shared_write.c
+++ b/src/test/mmap_shared_write.c
@@ -63,6 +63,14 @@ int main(void) {
        ++i) {
     pwrite64(fd, &magic, sizeof(magic), i * sizeof(magic));
   }
+  check_mapping(&rpage[(3 * num_bytes) / sizeof(magic)], 0xdeadbeef,
+                2 * num_bytes / sizeof(*rpage));
+
+  munmap(rpage, 5 * num_bytes);
+
+  // We don't allow write on a page that is MAP_SHARED. However, we just
+  // unmapped all references, so this should be fine
+  write(fd, &magic, sizeof(magic));
 
   atomic_puts("EXIT-SUCCESS");
 


### PR DESCRIPTION
While we're at it, keep track of whether or not that's the case, to avoid having
to scan all mappings in the system on every write.

Reported by @yuyichao 