### PR TITLE
Support `write` calls on monitored file descriptors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,7 @@ set(RR_SOURCES
   src/ExtraRegisters.cc
   src/fast_forward.cc
   src/FdTable.cc
+  src/FileMonitor.cc
   src/Flags.cc
   src/ftrace.cc
   src/GdbCommand.cc

--- a/src/FdTable.cc
+++ b/src/FdTable.cc
@@ -50,7 +50,7 @@ bool FdTable::emulate_fcntl(int fd, RecordTask* t, uint64_t* result) {
 
 bool FdTable::emulate_read(int fd, RecordTask* t,
                            const std::vector<FileMonitor::Range>& ranges,
-                           int64_t offset, uint64_t* result) {
+                           FileMonitor::LazyOffset& offset, uint64_t* result) {
   auto it = fds.find(fd);
   if (it == fds.end()) {
     return false;
@@ -76,7 +76,7 @@ Switchable FdTable::will_write(Task* t, int fd) {
 
 void FdTable::did_write(Task* t, int fd,
                         const std::vector<FileMonitor::Range>& ranges,
-                        int64_t offset) {
+                        FileMonitor::LazyOffset& offset) {
   auto it = fds.find(fd);
   if (it != fds.end()) {
     it->second->did_write(t, ranges, offset);

--- a/src/FdTable.h
+++ b/src/FdTable.h
@@ -22,12 +22,13 @@ public:
   bool emulate_fcntl(int fd, RecordTask* t, uint64_t* result);
   bool emulate_read(int fd, RecordTask* t,
                     const std::vector<FileMonitor::Range>& ranges,
-                    int64_t offset, uint64_t* result);
+                    FileMonitor::LazyOffset& offset, uint64_t* result);
   void filter_getdents(int fd, RecordTask* t);
   bool is_rr_fd(int fd);
   Switchable will_write(Task* t, int fd);
+  bool needs_offset(Task* t, int fd, bool for_write);
   void did_write(Task* t, int fd, const std::vector<FileMonitor::Range>& ranges,
-                 int64_t offset = -1);
+                 FileMonitor::LazyOffset& offset);
   void did_dup(int from, int to);
   void did_close(int fd);
 

--- a/src/FileMonitor.cc
+++ b/src/FileMonitor.cc
@@ -1,0 +1,91 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "FileMonitor.h"
+
+#include <linux/limits.h>
+
+#include <rr/rr.h>
+
+#include <vector>
+
+#include "RecordTask.h"
+#include "ReplayTask.h"
+#include "Session.h"
+#include "log.h"
+
+namespace rr {
+using namespace std;
+
+template <typename Arch>
+static bool is_implicit_offset_syscall_arch(int syscallno) {
+  return syscallno == Arch::writev || syscallno == Arch::write;
+}
+
+static bool is_implict_offset_syscall(SupportedArch arch, int syscallno) {
+  RR_ARCH_FUNCTION(is_implicit_offset_syscall_arch, arch, syscallno);
+}
+
+template <typename Arch>
+static int64_t retrieve_offset_arch(Task* t, int syscallno,
+                                    const Registers& regs) {
+  switch (syscallno) {
+    case Arch::pwrite64:
+    case Arch::pwritev:
+    case Arch::pread64:
+    case Arch::preadv: {
+      if (sizeof(typename Arch::unsigned_word) == 4) {
+        return regs.arg4() | (uint64_t(regs.arg5_signed()) << 32);
+      }
+      return regs.arg4_signed();
+    }
+    case Arch::writev:
+    case Arch::write: {
+      ASSERT(t, t->session().is_recording())
+          << "Can only read a file descriptor's offset while recording";
+      int fd = regs.arg1_signed();
+      // Get the offset from /proc/*/fdinfo/*
+      char fdinfo_path[PATH_MAX];
+      sprintf(fdinfo_path, "/proc/%d/fdinfo/%d", t->tid, fd);
+      FILE* fdinfo_file;
+      if (!(fdinfo_file = fopen(fdinfo_path, "r"))) {
+        FATAL() << "Failed to open " << fdinfo_path;
+      }
+      int64_t offset = -1;
+      if (fscanf(fdinfo_file, "pos:\t%ld", &offset) != 1) {
+        FATAL() << "Failed to read position";
+      }
+      fclose(fdinfo_file);
+      // The pos we just read, was after the write completed. Luckily, we do
+      // know how many bytes were written.
+      return offset - regs.syscall_result();
+    }
+    default: {
+      ASSERT(t, false) << "Can not retrieve offset for this system call.";
+      return -1;
+    }
+  }
+}
+
+static int64_t retrieve_offset(Task* t, int syscallno, const Registers& regs) {
+  RR_ARCH_FUNCTION(retrieve_offset_arch, t->arch(), t, syscallno, regs);
+}
+
+int64_t FileMonitor::LazyOffset::retrieve(bool needed_for_replay) {
+  bool is_replay = t->session().is_replaying();
+  bool is_implicit_offset = is_implict_offset_syscall(t->arch(), syscallno);
+  ASSERT(t, needed_for_replay || !is_replay);
+  // There is no way we can figure out this information now, so retrieve it
+  // from the trace (we record it below under the same circumstance).
+  if (is_replay && is_implicit_offset) {
+    vector<uint8_t> buf;
+    static_cast<ReplayTask*>(t)->trace_reader().read_generic(buf);
+    return *reinterpret_cast<int64_t*>(buf.data());
+  }
+  int64_t offset = retrieve_offset(t, syscallno, regs);
+  if (needed_for_replay && is_implicit_offset) {
+    static_cast<RecordTask*>(t)->trace_writer().write_generic(&offset,
+                                                              sizeof(offset));
+  }
+  return offset;
+}
+}

--- a/src/MagicSaveDataMonitor.h
+++ b/src/MagicSaveDataMonitor.h
@@ -20,6 +20,7 @@ public:
    * During recording, record the written data.
    * During replay, check that the written data matches what was recorded.
    */
+  virtual bool needs_offset(Task*, bool) { return false; }
   virtual void did_write(Task* t, const std::vector<Range>& ranges,
                          int64_t offset);
 };

--- a/src/MmappedFileMonitor.h
+++ b/src/MmappedFileMonitor.h
@@ -32,7 +32,7 @@ public:
    * During recording, note writes to mapped segments.
    */
   virtual void did_write(Task* t, const std::vector<Range>& ranges,
-                         int64_t offset);
+                         LazyOffset& offset);
 
 private:
   // Whether this monitor is still actively monitoring

--- a/src/MmappedFileMonitor.h
+++ b/src/MmappedFileMonitor.h
@@ -21,6 +21,12 @@ public:
 
   virtual Type type() { return Mmapped; }
   void revive() { dead_ = false; }
+  // If this write could potentially affect memory we need to PREVENT_SWITCH,
+  // since the timing of the write is otherwise unpredictable from our
+  // perspective.
+  virtual Switchable will_write(Task*) {
+    return dead_ ? ALLOW_SWITCH : PREVENT_SWITCH;
+  }
 
   /**
    * During recording, note writes to mapped segments.

--- a/src/ProcMemMonitor.h
+++ b/src/ProcMemMonitor.h
@@ -25,8 +25,9 @@ public:
   /**
    * During replay, copy writes to tracee |tid|'s memory.
    */
+  virtual bool needs_offset(Task* t, bool);
   virtual void did_write(Task* t, const std::vector<Range>& ranges,
-                         int64_t offset);
+                         LazyOffset& lazy_offset);
 
 private:
   // 0 if this doesn't object doesn't refer to a tracee's proc-mem.

--- a/src/ProcMemMonitor.h
+++ b/src/ProcMemMonitor.h
@@ -18,6 +18,10 @@ public:
 
   virtual Type type() { return ProcMem; }
 
+  // We need to PREVENT_SWITCH, since the timing of the write is otherwise
+  // unpredictable from our perspective.
+  virtual Switchable will_write(Task*) { return PREVENT_SWITCH; }
+
   /**
    * During replay, copy writes to tracee |tid|'s memory.
    */

--- a/src/StdioMonitor.cc
+++ b/src/StdioMonitor.cc
@@ -24,7 +24,7 @@ Switchable StdioMonitor::will_write(Task* t) {
 }
 
 void StdioMonitor::did_write(Task* t, const std::vector<Range>& ranges,
-                             int64_t) {
+                             LazyOffset&) {
   if (!t->session().is_replaying()) {
     return;
   }

--- a/src/StdioMonitor.h
+++ b/src/StdioMonitor.h
@@ -41,7 +41,7 @@ public:
    * During replay, echo writes to stdout/stderr.
    */
   virtual void did_write(Task* t, const std::vector<Range>& ranges,
-                         int64_t offset);
+                         LazyOffset&) override;
 
 private:
   int original_fd;

--- a/src/Task.h
+++ b/src/Task.h
@@ -519,12 +519,6 @@ public:
   void reset_syscallbuf();
 
   /**
-   * Compute the offset used by a read/write syscall. Returns -1 if the
-   * syscall doesn't pass an offset.
-   */
-  int64_t get_io_offset(int syscallno, const Registers& regs);
-
-  /**
    * Return the virtual memory mapping (address space) of this
    * task.
    */

--- a/src/VirtualPerfCounterMonitor.cc
+++ b/src/VirtualPerfCounterMonitor.cc
@@ -109,7 +109,7 @@ static size_t write_ranges(RecordTask* t,
 
 bool VirtualPerfCounterMonitor::emulate_read(RecordTask* t,
                                              const vector<Range>& ranges,
-                                             int64_t, uint64_t* result) {
+                                             LazyOffset&, uint64_t* result) {
   RecordTask* target = t->session().find_task(target_tuid);
   if (target) {
     int64_t val = target->tick_count() - initial_ticks;

--- a/src/VirtualPerfCounterMonitor.h
+++ b/src/VirtualPerfCounterMonitor.h
@@ -20,12 +20,12 @@ public:
   VirtualPerfCounterMonitor(Task* t, Task* target,
                             const struct perf_event_attr& attr);
 
-  virtual Type type() { return VirtualPerfCounter; }
+  virtual Type type() override { return VirtualPerfCounter; }
 
-  virtual bool emulate_ioctl(RecordTask* t, uint64_t* result);
-  virtual bool emulate_fcntl(RecordTask* t, uint64_t* result);
+  virtual bool emulate_ioctl(RecordTask* t, uint64_t* result) override;
+  virtual bool emulate_fcntl(RecordTask* t, uint64_t* result) override;
   virtual bool emulate_read(RecordTask* t, const std::vector<Range>& ranges,
-                            int64_t offset, uint64_t* result);
+                            LazyOffset& offset, uint64_t* result) override;
 
 private:
   Ticks initial_ticks;

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2917,8 +2917,8 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
       uint64_t result;
       vector<FileMonitor::Range> ranges;
       ranges.push_back(FileMonitor::Range(t->regs().arg2(), t->regs().arg3()));
-      if (t->fd_table()->emulate_read(
-              fd, t, ranges, t->get_io_offset(syscallno, t->regs()), &result)) {
+      FileMonitor::LazyOffset offset(t, t->regs(), syscallno);
+      if (t->fd_table()->emulate_read(fd, t, ranges, offset, &result)) {
         // Don't perform this syscall.
         Registers r = t->regs();
         r.set_arg1(-1);
@@ -3011,8 +3011,8 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
         ranges.push_back(
             FileMonitor::Range(iovecs[i].iov_base, iovecs[i].iov_len));
       }
-      if (t->fd_table()->emulate_read(
-              fd, t, ranges, t->get_io_offset(syscallno, t->regs()), &result)) {
+      FileMonitor::LazyOffset offset(t, t->regs(), syscallno);
+      if (t->fd_table()->emulate_read(fd, t, ranges, offset, &result)) {
         // Don't perform this syscall.
         Registers r = t->regs();
         r.set_arg1(-1);

--- a/src/test/proc_mem.c
+++ b/src/test/proc_mem.c
@@ -4,6 +4,7 @@
 
 static int cookie1;
 static int cookie2;
+static int cookie3;
 
 static int COOKIE = 0x12345678;
 
@@ -86,6 +87,7 @@ static void do_test(int (*opener)(int)) {
     test_assert(1 == read(pipe_fds[0], &ch, 1));
     test_assert(COOKIE == cookie1);
     test_assert(COOKIE == cookie2);
+    test_assert(COOKIE == cookie3);
     exit(77);
   }
 
@@ -99,6 +101,9 @@ static void do_test(int (*opener)(int)) {
   iov[1].iov_base = (char*)&COOKIE + 2;
   iov[1].iov_len = 2;
   test_assert(sizeof(COOKIE) == pwritev(fd, iov, 2, (off_t)&cookie2));
+
+  lseek(fd, (off_t)&cookie3, SEEK_SET);
+  test_assert(sizeof(COOKIE) == write(fd, &COOKIE, sizeof(COOKIE)));
 
   test_assert(1 == write(pipe_fds[1], "x", 1));
   test_assert(child == waitpid(child, &status, 0));


### PR DESCRIPTION
We used to only support pwrite on `/proc/*/mem` and any fd, whose backing
file was mapped MAP_SHARED into a Task's address space. For a
regular `write` system call, we can't easily get the offset to write at
by just looking at the register state (which we need to know in order
to reflect these changes appropriately into memory). Luckily, the kernel
allows us to query a file descriptor's current position by reading
/proc/*/fdinfo. Use that to get the offset, but take care to only read
it when we're actually going to need it.

This time actually fixes the issue @yuyichao reported.
