### PR TITLE
Some ioctls to get wireshark/dumpcap working

### DIFF
--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -16,6 +16,7 @@
 #include <linux/filter.h>
 #include <linux/futex.h>
 #include <linux/ipc.h>
+#include <linux/if_bonding.h>
 #include <linux/mqueue.h>
 #include <linux/msg.h>
 #include <linux/net.h>

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1367,6 +1367,57 @@ struct BaseArch : public wordsize,
     uint32_t permitted;
     uint32_t inheritable;
   };
+
+  struct hci_dev_req {
+    uint16_t dev_id;
+    uint32_t dev_opt;
+  };
+
+  struct hci_dev_list_req {
+    uint16_t dev_num;
+    struct hci_dev_req dev_req[0];
+  };
+
+  typedef struct {
+    uint8_t b[6];
+  } __attribute__((__packed__)) bdaddr_t;
+
+  struct hci_dev_stats {
+    uint32_t err_rx;
+    uint32_t err_tx;
+    uint32_t cmd_tx;
+    uint32_t evt_rx;
+    uint32_t acl_tx;
+    uint32_t acl_rx;
+    uint32_t sco_tx;
+    uint32_t sco_rx;
+    uint32_t byte_rx;
+    uint32_t byte_tx;
+  };
+
+  struct hci_dev_info {
+    uint16_t dev_id;
+    char  name[8];
+
+    bdaddr_t bdaddr;
+
+    uint32_t flags;
+    uint8_t  type;
+
+    uint8_t  features[8];
+
+    uint32_t pkt_type;
+    uint32_t link_policy;
+    uint32_t link_mode;
+
+    uint16_t acl_mtu;
+    uint16_t acl_pkts;
+    uint16_t sco_mtu;
+    uint16_t sco_pkts;
+
+    struct hci_dev_stats stat;
+  };
+
 };
 
 struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1418,6 +1418,12 @@ struct BaseArch : public wordsize,
     struct hci_dev_stats stat;
   };
 
+  typedef struct ifbond {
+    int32_t bond_mode;
+    int32_t num_slaves;
+    int32_t miimon;
+  } ifbond;
+  RR_VERIFY_TYPE(ifbond);
 };
 
 struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {

--- a/src/kernel_supplement.h
+++ b/src/kernel_supplement.h
@@ -170,6 +170,13 @@ struct usbdevfs_streams {
 #define SO_SET_REPLACE 64
 #endif
 
+#ifndef HCIGETDEVLIST
+#define HCIGETDEVLIST _IOR('H', 210, int)
+#endif
+#ifndef HCIGETDEVINFO
+#define HCIGETDEVINFO _IOR('H', 211, int)
+#endif
+
 // Unfortuantely the header that defines these is not C++ safe, we we'll
 // have to redefine them here
 #ifndef KEYCTL_GET_KEYRING_ID

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1420,6 +1420,14 @@ static Switchable prepare_ioctl(RecordTask* t,
     case SNDRV_CTL_IOCTL_CARD_INFO:
       syscall_state.reg_parameter<typename Arch::snd_ctl_card_info>(3);
       return PREVENT_SWITCH;
+
+    case HCIGETDEVINFO:
+      syscall_state.reg_parameter<typename Arch::hci_dev_info>(3);
+      return PREVENT_SWITCH;
+
+    case HCIGETDEVLIST:
+      syscall_state.reg_parameter<typename Arch::hci_dev_list_req>(3);
+      return PREVENT_SWITCH;
   }
 
   /* In ioctl language, "_IOC_READ" means "outparam".  Both

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1353,6 +1353,14 @@ static Switchable prepare_ioctl(RecordTask* t,
     case SIOCDELRT:
       return PREVENT_SWITCH;
 
+    case SIOCBONDINFOQUERY: {
+      auto ifrp = syscall_state.reg_parameter<typename Arch::ifreq>(3, IN);
+      syscall_state.mem_ptr_parameter<typename Arch::ifbond>(
+          REMOTE_PTR_FIELD(ifrp, ifr_ifru.ifru_data));
+      syscall_state.after_syscall_action(record_page_below_stack_ptr);
+      return PREVENT_SWITCH;
+    }
+
     case SIOCGIFADDR:
     case SIOCGIFDSTADDR:
     case SIOCGIFBRDADDR:

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -1397,6 +1397,14 @@ static Switchable prepare_ioctl(RecordTask* t,
       return PREVENT_SWITCH;
     }
 
+    case SIOCGSTAMP:
+      syscall_state.reg_parameter<typename Arch::timeval>(3);
+      return PREVENT_SWITCH;
+
+    case SIOCGSTAMPNS:
+      syscall_state.reg_parameter<typename Arch::timespec>(3);
+      return PREVENT_SWITCH;
+
     case TCGETS:
     case TIOCGLCKTRMIOS:
       syscall_state.reg_parameter<typename Arch::termios>(3);


### PR DESCRIPTION
That would be:
- HCIGETDEVLIST (dumpcap enumerates bluetooth devices)
- HCIGETDEVINFO (not actually needed but i felt like recording hciconfig)
- SIOCBONDINFOQUERY (pretty much the same as SIOCETHTOOL)
- SIOCGSTAMPNS
- SIOCGSTAMP (not actually needed but it's the same as the one above)

Known issues:
- No tests. Could write them if needed. HCIGETDEVINFO is likely not testable without a real bluetooth device plugged in, but the rest are probably good enough.
- HCI\* structures don't use RR_VERIFY_TYPE. I think that's unavoidable given how they are not normally included in kernel headers.
- Having a real bluetooth device plugged in breaks the recording of dumpcap because it decides to do the rest of the sniffing, and I don't care about bluetooth _that_ much. I just wanted to record wireshark.
- As the SIOCGSTAMPNS commit says, calling that ioctl during recording fails with ENOENT:

```
$ sudo ./bin/rr record dumpcap
rr: Saving execution to trace directory `/root/.local/share/rr/dumpcap-19'.
Capturing on 'eth0'
File: /tmp/wireshark_pcapng_eth0_20161030051341_fkFhHn
dumpcap: Error while capturing packets: SIOCGSTAMPNS: No such file or directory
Please report this to the Wireshark developers.
https://bugs.wireshark.org/
(This is not a crash; please do not report it as such.)
Packets captured: 0
Packets received/dropped on interface 'eth0': 0/0 (pcap:0/dumpcap:0/flushed:0/ps_ifdrop:0) (0.0%)
```

Quoting the socket(7) manpage (my emphasis)

> SIOCGSTAMP
> 
> > Return a struct timeval with the receive timestamp of the last packet passed to the user. This is useful for accurate round trip time measurements. See setitimer(2) for a description of struct timeval. This ioctl should only be used if the socket option SO_TIMESTAMP is not set on the socket. Otherwise, it returns the timestamp of the last packet that was received while SO_TIMESTAMP was not set, **or it fails if no such packet has been received, (i.e., ioctl(2) returns -1 with errno set to ENOENT)**

Weird, likely an issue bigger than the ioctl itself. But replaying doesn't die with assertion errors so good enough for me!
