### PR TITLE
Run clang-tidy's readability-braces-around-statements over the codebase

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -67,8 +67,9 @@ private:
   void init() {
     char maps_path[PATH_MAX];
     sprintf(maps_path, "/proc/%d/maps", tid);
-    if (!(maps_file = fopen(maps_path, "r")))
+    if (!(maps_file = fopen(maps_path, "r"))) {
       FATAL() << "Failed to open " << maps_path;
+    }
     ++*this;
   }
 
@@ -1522,8 +1523,9 @@ void AddressSpace::coalesce_around(Task* t, MemoryMap::iterator it) {
 }
 
 void AddressSpace::destroy_breakpoint(BreakpointMap::const_iterator it) {
-  if (task_set().empty())
+  if (task_set().empty()) {
     return;
+  }
   Task* t = *task_set().begin();
   LOG(debug) << "Writing back " << std::hex << (int)it->second.overwritten_data;
   t->write_mem(it->first.to_data_ptr<uint8_t>(), it->second.overwritten_data);

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1325,8 +1325,9 @@ void RecordTask::record_remote(remote_ptr<void> addr, ssize_t num_bytes) {
     return;
   }
 
-  if (record_remote_by_local_map(addr, num_bytes) != 0)
+  if (record_remote_by_local_map(addr, num_bytes) != 0) {
     return;
+  }
 
   auto buf = read_mem(addr.cast<uint8_t>(), num_bytes);
   trace_writer().write_raw(rec_tid, buf.data(), num_bytes, addr);
@@ -1338,8 +1339,9 @@ void RecordTask::record_remote_fallible(remote_ptr<void> addr,
 
   ASSERT(this, num_bytes >= 0);
 
-  if (record_remote_by_local_map(addr, num_bytes) != 0)
+  if (record_remote_by_local_map(addr, num_bytes) != 0) {
     return;
+  }
 
   vector<uint8_t> buf;
   if (!addr.is_null()) {
@@ -1361,8 +1363,9 @@ void RecordTask::record_remote_even_if_null(remote_ptr<void> addr,
     return;
   }
 
-  if (record_remote_by_local_map(addr, num_bytes) != 0)
+  if (record_remote_by_local_map(addr, num_bytes) != 0) {
     return;
+  }
 
   auto buf = read_mem(addr.cast<uint8_t>(), num_bytes);
   trace_writer().write_raw(rec_tid, buf.data(), num_bytes, addr);

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -562,8 +562,9 @@ bool Session::make_private_shared(AutoRemoteSyscalls& remote,
   strncpy(name, m.map.fsname().c_str(), sizeof(name));
   name[sizeof(name) - 1] = '\0';
   for (char* ptr = name; *ptr != '\0'; ++ptr) {
-    if (*ptr == '/')
+    if (*ptr == '/') {
       *ptr = '-';
+    }
   }
 
   // Now create the new mapping in its place

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1841,8 +1841,9 @@ KernelMapping Task::init_syscall_buffer(AutoRemoteSyscalls& remote,
 }
 
 void Task::reset_syscallbuf() {
-  if (!syscallbuf_child)
+  if (!syscallbuf_child) {
     return;
+  }
 
   ASSERT(this, !is_in_untraced_syscall() ||
                    !read_mem(REMOTE_PTR_FIELD(syscallbuf_child, locked)));

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3908,8 +3908,9 @@ static void process_mmap(RecordTask* t, size_t length, int prot, int flags,
   // We don't want to patch MAP_SHARED files. In the best case we'd end crashing
   // at an assertion, in the worst case, we'd end up modifying the underlying
   // file.
-  if (!(flags & MAP_SHARED))
+  if (!(flags & MAP_SHARED)) {
     t->vm()->monkeypatcher().patch_after_mmap(t, addr, size, offset_pages, fd);
+  }
 
   if ((prot & (PROT_WRITE | PROT_READ)) == PROT_READ && (flags & MAP_SHARED) &&
       !(flags & MAP_ANONYMOUS)) {

--- a/src/test/mmap_replace_most_mappings.c
+++ b/src/test/mmap_replace_most_mappings.c
@@ -14,8 +14,9 @@ static int contains_symbol(map_properties_t* props, void* symbol) {
 void callback(uint64_t env, char* name, map_properties_t* props) {
   (void)env;
   if (contains_symbol(props, &main) || contains_symbol(props, unmappings) ||
-      props->start == RR_PAGE_ADDR || strcmp(name, "[stack]") == 0)
+      props->start == RR_PAGE_ADDR || strcmp(name, "[stack]") == 0) {
     return;
+  }
 
   unmappings[2 * nunmappings] = (uintptr_t)props->start;
   unmappings[2 * nunmappings + 1] = (uintptr_t)(props->end - props->start);

--- a/src/test/mmap_self_maps_shared.c
+++ b/src/test/mmap_self_maps_shared.c
@@ -4,8 +4,9 @@
 
 void callback(uint64_t env, char* name, map_properties_t* props) {
   (void)env;
-  if (name[0] != '/')
+  if (name[0] != '/') {
     return;
+  }
   int fd = open(name, O_RDONLY);
   void* addr =
       mmap(NULL, props->end - props->start, PROT_READ, MAP_SHARED, fd, 0);

--- a/src/test/no_mask_timeslice.c
+++ b/src/test/no_mask_timeslice.c
@@ -26,8 +26,9 @@ int main(void) {
   pthread_sigmask(SIG_BLOCK, &mask, &old);
 
   pthread_barrier_wait(&bar);
-  while (!pseudospinlock)
+  while (!pseudospinlock) {
     ;
+  }
 
   pthread_sigmask(SIG_SETMASK, &old, NULL);
 

--- a/src/test/ptrace_remote_unmap.c
+++ b/src/test/ptrace_remote_unmap.c
@@ -70,8 +70,9 @@ void munmap_remote(pid_t child, uintptr_t start, size_t size) {
 static void remote_unmap_callback(uint64_t child, char* name,
                                   map_properties_t* props) {
   if ((props->start <= child_syscall_addr && child_syscall_addr < props->end) ||
-      props->start == RR_PAGE_ADDR || strcmp(name, "[vsyscall]") == 0)
+      props->start == RR_PAGE_ADDR || strcmp(name, "[vsyscall]") == 0) {
     return;
+  }
 
   munmap_remote(child, props->start, props->end - props->start);
 }


### PR DESCRIPTION
Came up in the review of #1867 as a desirable stylistic property.