### PR TITLE
Fix replay of syscall instructions on MAP_SHARED pages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -601,6 +601,7 @@ set(BASIC_TESTS
   ptrace_syscall
   ptrace_syscall_clone_untraced
   ptrace_sysemu
+  ptrace_sysemu_syscall
   ptrace_trace_clone
   ptrace_trace_exit
   ptrace_traceme

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,6 +530,7 @@ set(BASIC_TESTS
   madvise
   madvise_free
   map_fixed
+  map_shared_syscall
   membarrier
   memfd_create
   mincore

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -239,8 +239,6 @@ template <typename Arch> static void prepare_clone(ReplayTask* t) {
   r.set_syscall_result(-ENOSYS);
   r.set_original_syscallno(trace_frame.regs().original_syscallno());
   t->set_regs(r);
-  // Get out of the kernel
-  t->finish_emulated_syscall();
 
   // Dig the recorded tid out out of the trace. The tid value returned in
   // the recorded registers could be in a different pid namespace from rr's,

--- a/src/test/map_shared_syscall.c
+++ b/src/test/map_shared_syscall.c
@@ -1,0 +1,45 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+/* Tests that we can do a syscall from a syscall instruction located on a
+   MAP_SHARED page */
+
+static uintptr_t my_syscall(uintptr_t syscall, uintptr_t arg1) {
+  uintptr_t ret;
+#ifdef __x86_64__
+  __asm__ volatile("syscall\n\t" : "=a"(ret) : "a"(syscall), "D"(arg1));
+#elif defined(__i386__)
+  __asm__ volatile("int $0x80\n\t" : "=a"(ret) : "a"(syscall), "b"(arg1));
+#else
+#error define syscall here
+#endif
+  return ret;
+}
+
+extern char __executable_start;
+void my_brk(uintptr_t brk) { my_syscall(SYS_brk, brk); }
+
+int main(void) {
+  /* map another copy of this executable (but MAP_SHARED this time) */
+  int fd = open("/proc/self/exe", O_RDONLY);
+  test_assert(fd != -1);
+
+  /* Get the size of this executable */
+  struct stat stat_buf;
+  test_assert(fstat(fd, &stat_buf) == 0);
+
+  /* Map the executable */
+  void* map_addr =
+      mmap(NULL, stat_buf.st_size, PROT_READ | PROT_EXEC, MAP_SHARED, fd, 0);
+  test_assert(map_addr != MAP_FAILED);
+
+  /* Call my_sbrk in the new copy */
+  void (*fptr)(uintptr_t) = (void (*)(uintptr_t))(
+      (uintptr_t)map_addr +
+      ((uintptr_t)&my_brk - (uintptr_t)&__executable_start));
+  fptr((uintptr_t)sbrk(0) + sysconf(_SC_PAGESIZE));
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/ptrace_sysemu_syscall.c
+++ b/src/test/ptrace_sysemu_syscall.c
@@ -1,0 +1,89 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+/* This test tests the interaction between PTRACE_SYSEMU and PTRACE_SYSCALL.
+ * In addition, it also tests the behavior of PTRACE_SYSEMU when the entering
+ * syscall number is invalid (it will be -ENOSYS for the second syscall).
+ */
+
+#ifndef PTRACE_SYSEMU
+#define PTRACE_SYSEMU 31
+#endif
+
+#if defined(__i386__)
+#define SYSCALL_RESULT eax
+#define SYSCALL_GETEUID SYS_geteuid32
+#define IP eip
+#elif defined(__x86_64__)
+#define SYSCALL_RESULT rax
+#define SYSCALL_GETEUID SYS_geteuid
+#define IP rip
+#else
+#error unknown architecture
+#endif
+
+extern char syscall1_addr;
+int main(void) {
+  pid_t child;
+  int status;
+  struct user_regs_struct regs;
+
+  if (0 == (child = fork())) {
+    ptrace(PTRACE_TRACEME, 0, 0, 0);
+#ifdef __i386__
+    __asm__ __volatile__("int $3\n\t"
+                         "syscall1_addr: int $0x80\n\t"
+                         "nop\n\t"
+                         "int $0x80\n\t"
+                         "nop\n\t"
+                         "int $3\n\t" ::"a"(SYSCALL_GETEUID));
+#elif defined(__x86_64__)
+    __asm__ __volatile__("int $3\n\t"
+                         "syscall1_addr: syscall\n\t"
+                         "nop\n\t"
+                         "syscall\n\t"
+                         "nop\n\t"
+                         "int $3\n\t" ::"a"(SYSCALL_GETEUID));
+#else
+#error Add support for new architecture here
+#endif
+    test_assert(0 && "Should not reach here");
+  }
+
+  /* Wait until the tracee stops */
+  test_assert(child == waitpid(child, &status, 0));
+  test_assert(WIFSTOPPED(status) && WSTOPSIG(status) == SIGTRAP);
+  test_assert(0 == ptrace(PTRACE_SETOPTIONS, child, 0, PTRACE_O_TRACESYSGOOD));
+
+  /* Should step to syscall entry */
+  test_assert(0 == ptrace(PTRACE_SYSEMU, child, 0, 0));
+  test_assert(child == waitpid(child, &status, 0));
+  test_assert(WIFSTOPPED(status) && WSTOPSIG(status) == (SIGTRAP | 0x80));
+
+  /* Should step to syscall exit, but have skipped the syscall */
+  test_assert(0 == ptrace(PTRACE_SYSCALL, child, 0, 0));
+  test_assert(child == waitpid(child, &status, 0));
+  test_assert(WIFSTOPPED(status) && WSTOPSIG(status) == (SIGTRAP | 0x80));
+
+  /* If we hadn't skipped the syscall the register would now contain the result
+   */
+  test_assert(0 == ptrace(PTRACE_GETREGS, child, NULL, &regs));
+  test_assert((uintptr_t)regs.SYSCALL_RESULT == (uintptr_t)-ENOSYS);
+  test_assert((uintptr_t)regs.IP == (uintptr_t)&syscall1_addr + 2);
+
+  /* Should step to syscall entry */
+  test_assert(0 == ptrace(PTRACE_SYSEMU, child, 0, 0));
+  test_assert(child == waitpid(child, &status, 0));
+  test_assert(WIFSTOPPED(status) && WSTOPSIG(status) == (SIGTRAP | 0x80));
+
+  /* Should hit the interrupt (i.e. not step to syscall exit) */
+  test_assert(0 == ptrace(PTRACE_SYSEMU, child, 0, 0));
+  test_assert(child == waitpid(child, &status, 0));
+  test_assert(WIFSTOPPED(status) && WSTOPSIG(status) == SIGTRAP);
+
+  kill(child, SIGKILL);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
This fixes a bug when replaying a syscall instruction that's on a MAP_SHARED page
(see second commit). While attempting to understand this issue, I wrote a test, which
encountered a small different bug (fixed in the first commit).