### PR TITLE
Fix deadlock when a ptracee gets killed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,7 @@ set(BASIC_TESTS
   ioctl_tty
   kcmp
   kill_newborn
+  kill_ptracee
   legacy_ugid
   madvise
   madvise_free

--- a/src/Scheduler.cc
+++ b/src/Scheduler.cc
@@ -173,7 +173,11 @@ bool Scheduler::is_task_runnable(RecordTask* t, bool* by_waitpid) {
       // We have no way to detect a SIGCONT coming from outside the tracees.
       // We just have to poll SigPnd in /proc/<pid>/status.
       enable_poll = true;
-      return false;
+      // We also need to check if the task got killed.
+      t->try_wait();
+      // N.B.: If we supported ptrace exit notifications for killed tracee's
+      // that would need handling here, but we don't at the moment.
+      return t->is_dying();
     }
   }
 

--- a/src/Task.h
+++ b/src/Task.h
@@ -771,6 +771,10 @@ public:
    */
   bool ptrace_if_alive(int request, remote_ptr<void> addr, void* data);
 
+  bool is_dying() const {
+    return seen_ptrace_exit_event || detected_unexpected_exit;
+  }
+
 protected:
   Task(Session& session, pid_t tid, pid_t rec_tid, uint32_t serial,
        SupportedArch a);

--- a/src/test/kill_ptracee.c
+++ b/src/test/kill_ptracee.c
@@ -1,0 +1,58 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+int main(void) {
+  pid_t child;
+  int status;
+
+  /* Just an always runnable task */
+  if (0 == fork()) {
+    for (;;) {
+      sched_yield();
+    }
+  }
+
+  if (0 == (child = fork())) {
+    ptrace(PTRACE_TRACEME, 0, 0, 0);
+    raise(SIGSTOP);
+    for (;;) {
+      __asm__("pause");
+    }
+    test_assert(0 && "Should have died");
+  }
+
+  /* Wait until the tracee stops */
+  test_assert(child == waitpid(child, &status, 0));
+  test_assert(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP);
+
+  /* Continue the tracee */
+  test_assert(0 == ptrace(PTRACE_CONT, child, 0, 0));
+
+  sched_yield();
+
+  kill(child, SIGKILL);
+
+  /* Wait until the tracee exits */
+  test_assert(child == waitpid(child, &status, 0));
+  test_assert(WIFSIGNALED(status) && WTERMSIG(status) == SIGKILL);
+
+  /* Same thing again but will while the tracee is still in the ptrace stop */
+  if (0 == (child = fork())) {
+    ptrace(PTRACE_TRACEME, 0, 0, 0);
+    raise(SIGSTOP);
+    test_assert(0 && "Should have died");
+  }
+
+  /* Wait until the tracee stops */
+  test_assert(child == waitpid(child, &status, 0));
+  test_assert(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP);
+
+  kill(child, SIGKILL);
+
+  test_assert(child == waitpid(child, &status, 0));
+  test_assert(WIFSIGNALED(status) && WTERMSIG(status) == SIGKILL);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
When an emulated ptracee gets killed while in a ptrace/signal stop,
we would fail to notice the PTRACE_EXIT_EVENT for that task, since
we never waited on it, instead looking only for SIGCONT. If the parent
is waiting for the child to die, this causes a deadlock under rr.