### PR TITLE
Add explicit return value to `main()` in `ptrace_tls.c`

### DIFF
--- a/src/test/ptrace_tls.c
+++ b/src/test/ptrace_tls.c
@@ -173,4 +173,5 @@ int main(void) {
   test_assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
 
   atomic_puts("EXIT-SUCCESS");
+  return 0;
 }


### PR DESCRIPTION
Without an explicit return value, this function fails to compile if warnings are
treated as errors:

"error: control reaches end of non-void function [-Werror=return-type]"