### PR TITLE
Drop loop initial declarations in `timer.c`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,12 @@ set(rr_VERSION_PATCH 0)
 
 add_definitions(-DRR_VERSION="${rr_VERSION_MAJOR}.${rr_VERSION_MINOR}.${rr_VERSION_PATCH}")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread -g3 -Wall -Wextra -Wstrict-prototypes")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread -g3 -Wall -Wextra -Wstrict-prototypes -std=gnu11")
 set(CMAKE_C_FLAGS_DEBUG "-O0 -Werror -DDEBUG")
 set(CMAKE_C_FLAGS_RELEASE "-O2")
 # Define __STDC_LIMIT_MACROS so |#include <stdint.h>| works as expected.
 # Define __STDC_FORMAT_MACROS so |#include <inttypes.h>| works as expected.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__USE_LARGEFILE64 -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++0x -pthread -g3 -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__USE_LARGEFILE64 -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++11 -pthread -g3 -Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG "-O0 -Werror -DDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2")
 set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -g3")

--- a/src/test/timer.c
+++ b/src/test/timer.c
@@ -52,7 +52,8 @@ int main(void) {
   ALLOCATE_GUARD(id, 'a');
   ALLOCATE_GUARD(timeout_id, 'b');
   clockid_t clocks[2] = { CLOCK_REALTIME, CLOCK_MONOTONIC };
-  for (unsigned int i = 0; i < sizeof(clocks) / sizeof(clockid_t); ++i) {
+  unsigned int i;
+  for (i = 0; i < sizeof(clocks) / sizeof(clockid_t); ++i) {
     test_assert(0 == timer_create(clocks[i], NULL, id));
     VERIFY_GUARD(id);
 
@@ -74,7 +75,8 @@ int main(void) {
      * between test runtime and reproducability.
      */
     test_assert(0 == timer_settime(*id, 0, &its3, NULL));
-    for (int i = 0; i < 5000 && !caught_limit_sig; ++i) {
+    int j;
+    for (j = 0; j < 5000 && !caught_limit_sig; ++j) {
       caught_sig = 0;
       for (counter = 0; counter >= 0 && !caught_sig; counter++) {
         (void)sys_gettid();

--- a/src/test/timer.c
+++ b/src/test/timer.c
@@ -52,8 +52,7 @@ int main(void) {
   ALLOCATE_GUARD(id, 'a');
   ALLOCATE_GUARD(timeout_id, 'b');
   clockid_t clocks[2] = { CLOCK_REALTIME, CLOCK_MONOTONIC };
-  unsigned int i;
-  for (i = 0; i < sizeof(clocks) / sizeof(clockid_t); ++i) {
+  for (unsigned int i = 0; i < sizeof(clocks) / sizeof(clockid_t); ++i) {
     test_assert(0 == timer_create(clocks[i], NULL, id));
     VERIFY_GUARD(id);
 
@@ -75,8 +74,7 @@ int main(void) {
      * between test runtime and reproducability.
      */
     test_assert(0 == timer_settime(*id, 0, &its3, NULL));
-    int j;
-    for (j = 0; j < 5000 && !caught_limit_sig; ++j) {
+    for (int i = 0; i < 5000 && !caught_limit_sig; ++i) {
       caught_sig = 0;
       for (counter = 0; counter >= 0 && !caught_sig; counter++) {
         (void)sys_gettid();


### PR DESCRIPTION
The current code throws "error: ‘for’ loop initial declarations are only allowed in C99 mode" for these
two loops. Adding `-std=c99` to `CMakeLists.txt` causes "error: implicit declaration of function ‘asm’
[-Werror=implicit-function-declaration]" for `asm()` in `src/test/blocked_sigill.c:20`. Changing these
loops to out-of-line the declaration seems like the simplest solution.