### PR TITLE
Fix incorrect use of recreate_shared_mmap

### DIFF
--- a/src/MonitoredSharedMemory.cc
+++ b/src/MonitoredSharedMemory.cc
@@ -39,7 +39,7 @@ void MonitoredSharedMemory::maybe_monitor(RecordTask* t,
       new MonitoredSharedMemory(real_mem, m.map.size()));
 
   const AddressSpace::Mapping& shared =
-      Session::recreate_shared_mmap(remote, m, move(result));
+      Session::steal_mapping(remote, m, move(result));
   // m may be invalid now
   memcpy(shared.local_addr, real_mem, shared.map.size());
 }

--- a/src/Session.h
+++ b/src/Session.h
@@ -242,6 +242,13 @@ public:
       AutoRemoteSyscalls& remote, const AddressSpace::Mapping& m,
       MonitoredSharedMemory::shr_ptr&& monitored = nullptr);
 
+  /* Takes a mapping and replaces it by one that is shared between rr and
+     the tracee. The caller is responsible for filling the contents of the
+      new mapping. */
+  static const AddressSpace::Mapping& steal_mapping(
+      AutoRemoteSyscalls& remote, const AddressSpace::Mapping& m,
+      MonitoredSharedMemory::shr_ptr&& monitored = nullptr);
+
   enum PtraceSyscallBeforeSeccomp {
     PTRACE_SYSCALL_BEFORE_SECCOMP,
     SECCOMP_BEFORE_PTRACE_SYSCALL,


### PR DESCRIPTION
This function is only supposed to be used with mappings that were previously
created using create_shared_mmap. MonitorSharedMemory tried to use it on an
outside MAP_SHARED mapping, which happened to work if you got lucky and
extract_name came up with a name that was valid. However, since the name
in general doesn't have to follow any particular scheme, it was easy to come
up with one that wasn't (e.g. that contained slashes). Add a new function
(steal_mapping) that does what was intended here: replace an arbitrary mapping
with one shared with rr.