### PR TITLE
Various changes having to do with unwinding

### DIFF
--- a/src/preload/breakpoint_table.S
+++ b/src/preload/breakpoint_table.S
@@ -3,6 +3,7 @@
         .global _breakpoint_table_entry_start
         .hidden _breakpoint_table_entry_start
 _breakpoint_table_entry_start:
+        .cfi_startproc
         ret
         .global _breakpoint_table_entry_end
         .hidden _breakpoint_table_entry_end
@@ -10,6 +11,7 @@ _breakpoint_table_entry_end:
         .rept 131071 /* SYSCALLBUF_BUFFER_SIZE/8 - 1 */
         ret
         .endr
+        .cfi_endproc
 
 
 #else

--- a/src/preload/preload.c
+++ b/src/preload/preload.c
@@ -611,7 +611,7 @@ static void __attribute__((constructor)) init_process(void) {
     { 1,
       3,
       { 0x90, 0x90, 0x90 },
-      (uintptr_t)_syscall_hook_trampoline_ba_01_00_00_00 },
+      (uintptr_t)_syscall_hook_trampoline_90_90_90 },
     /* glibc-2.22-17.fc23.x86_64 has 'syscall' followed by 'mov $1,%rdx'
      * in
      * pthread_barrier_wait.

--- a/src/preload/syscall_hook.S
+++ b/src/preload/syscall_hook.S
@@ -141,12 +141,22 @@ name:                           \
        .cfi_offset %eip, 0;     \
        .cfi_offset %esp, 4
 
-#define SYSCALLHOOK_END(name)         \
-        pop (stub_scratch_1);         \
-        .cfi_adjust_cfa_offset -4;    \
-        pop %esp;                     \
-        jmp *(stub_scratch_1);        \
-       .cfi_endproc;                  \
+#define SYSCALLHOOK_END(name)                                   \
+        pop (stub_scratch_1);                                   \
+        .cfi_adjust_cfa_offset -4;                              \
+        pop %esp;                                               \
+        .cfi_same_value %esp;                                   \
+        .cfi_escape 0x10, /* DW_CFA_expression */               \
+                    0x08, /* %eip */                            \
+                    0x05, /* 5 byte expression follows */       \
+                    0x03, /* DW_OP_addr */                      \
+                    /* Individually place bytes */              \
+                    stub_scratch_1 & 0xFF,                      \
+                    (stub_scratch_1 & (0xFF <<  0x8)) >>  0x8,  \
+                    (stub_scratch_1 & (0xFF << 0x10)) >> 0x10,  \
+                    (stub_scratch_1 & (0xFF << 0x18)) >> 0x18;  \
+        jmp *(stub_scratch_1);                                  \
+       .cfi_endproc;                                            \
        .size name, .-name
 
 SYSCALLHOOK_START(_syscall_hook_trampoline_3d_01_f0_ff_ff)
@@ -261,12 +271,26 @@ name:                           \
         .cfi_offset %rip, 0;    \
         .cfi_offset %rsp, 8;
 
-#define SYSCALLHOOK_END(name)          \
-        pop (stub_scratch_1);          \
-        .cfi_adjust_cfa_offset -8;     \
-        pop %rsp;                      \
-        jmp *(stub_scratch_1);         \
-        .cfi_endproc;                  \
+#define SYSCALLHOOK_END(name)                                   \
+        pop (stub_scratch_1);                                   \
+        .cfi_adjust_cfa_offset -8;                              \
+        pop %rsp;                                               \
+        .cfi_same_value %rsp;                                   \
+        .cfi_escape 0x10, /* DW_CFA_expression */               \
+                    0x10, /* %rip */                            \
+                    0x09, /* 9 byte expression follows */       \
+                    0x03, /* DW_OP_addr */                      \
+                    /* Individually place bytes */              \
+                    stub_scratch_1 & 0xFF,                      \
+                    (stub_scratch_1 & (0xFF <<  0x8)) >>  0x8,  \
+                    (stub_scratch_1 & (0xFF << 0x10)) >> 0x10,  \
+                    (stub_scratch_1 & (0xFF << 0x18)) >> 0x18,  \
+                    (stub_scratch_1 & (0xFF << 0x20)) >> 0x20,  \
+                    (stub_scratch_1 & (0xFF << 0x28)) >> 0x28,  \
+                    (stub_scratch_1 & (0xFF << 0x30)) >> 0x30,  \
+                    (stub_scratch_1 & (0xFF << 0x38)) >> 0x38;  \
+        jmp *(stub_scratch_1);                                  \
+        .cfi_endproc;                                           \
         .size name, .-name
 
 

--- a/src/preload/syscall_hook.S
+++ b/src/preload/syscall_hook.S
@@ -258,24 +258,52 @@ _syscall_hook_trampoline:
         .size _syscall_hook_trampoline, . - _syscall_hook_trampoline
 
 /**
+ * Ok, bear with me here. When gdb sees our stack switch, it gets suspicious and if
+ * we're unlucky may decide that our unwind info is broken and abort the unwind. However,
+ * it decides to allow the unwind to proceed anyway if we happen to be in a function called
+ * __morestack (because that's what gcc calls its stack switching mechanism). Now,
+ * GDB does the stack switching comparison based on the CFA. What we thus need to do is keep the
+ * CFA pointing to the old stack until we get to a function named __morestack. We set the CFA for every
+ * syscallhook to what it will be at the end of the function (which, well, is an ok definition
+ * of the CFA). Then, we insert a __morestack function (still with the old CFA) that just jumps
+ * through to the trampoline. This way, we can force gdb's stack switch detection to think the
+ * stack switch happens between the hook and the common trampoline code (and add a __morestack
+ * local symbol to the trampoline code to avoid GDB messing with out stack trace).
+ */
+#define CFA_AT_RSP_OFFSET(offset) \
+.cfi_escape 0x0f, /* DW_CFA_def_cfa_expression */\
+        0x03, /* 3 bytes follow */\
+        0x77, offset, /* DW_OP_breg7, offset */\
+        0x06; /* DW_OP_deref */
+
+#define RSP_IS_CFA \
+.cfi_escape 0x16, /* DW_CFA_val_expression */\
+            0x7,  /* %rsp */\
+            0;     /* 0 bytes follow */
+
+#define RIP_IS_DEREF_RSP \
+.cfi_escape 0x10, /* DW_CFA_expression */\
+            0x10, /* %rip */\
+            0x02, /* 2 bytes follow */\
+            0x77, 0; /* DW_OP_breg7, 0 */
+
+/**
  * On syscallhook entry, the stack has been switched to the end of per-task
  * scratch space, then the old RSP and the return address have been pushed.
  */
-#define SYSCALLHOOK_START(name) \
-        .global name;           \
-        .hidden name;           \
-        .type name, @function;  \
-name:                           \
-        .cfi_startproc;         \
-        .cfi_def_cfa_offset 0;  \
-        .cfi_offset %rip, 0;    \
-        .cfi_offset %rsp, 8;
+#define SYSCALLHOOK_START(name)    \
+        .global name;              \
+        .hidden name;              \
+        .type name, @function;     \
+name:                              \
+        .cfi_startproc;            \
+        CFA_AT_RSP_OFFSET(8)      \
+        RSP_IS_CFA                 \
+        RIP_IS_DEREF_RSP
 
 #define SYSCALLHOOK_END(name)                                   \
         pop (stub_scratch_1);                                   \
-        .cfi_adjust_cfa_offset -8;                              \
-        pop %rsp;                                               \
-        .cfi_same_value %rsp;                                   \
+        CFA_AT_RSP_OFFSET(0)                                    \
         .cfi_escape 0x10, /* DW_CFA_expression */               \
                     0x10, /* %rip */                            \
                     0x09, /* 9 byte expression follows */       \
@@ -289,30 +317,48 @@ name:                           \
                     (stub_scratch_1 & (0xFF << 0x28)) >> 0x28,  \
                     (stub_scratch_1 & (0xFF << 0x30)) >> 0x30,  \
                     (stub_scratch_1 & (0xFF << 0x38)) >> 0x38;  \
+        pop %rsp;                                               \
+        .cfi_def_cfa %rsp, 0;                                   \
         jmp *(stub_scratch_1);                                  \
         .cfi_endproc;                                           \
         .size name, .-name
 
+/* See note above on what __morestack is for */
+.global __morestack
+.hidden __morestack
+.type __morestack, @function
+__morestack:
+.cfi_startproc
+CFA_AT_RSP_OFFSET(16)
+.cfi_escape 0x16, /* DW_CFA_val_expression */\
+            0x07, /* %rsp */\
+            0x02, /* 2 bytes follow */\
+            0x77, 8; /* DW_OP_breg7, 8 */
+RIP_IS_DEREF_RSP
+callq _syscall_hook_trampoline
+retq
+.cfi_endproc
+.size __morestack, .-__morestack
 
 SYSCALLHOOK_START(_syscall_hook_trampoline_48_3d_01_f0_ff_ff)
-        callq _syscall_hook_trampoline
+        callq __morestack
         cmpq $0xfffffffffffff001,%rax
 SYSCALLHOOK_END(_syscall_hook_trampoline_48_3d_01_f0_ff_ff)
 
 SYSCALLHOOK_START(_syscall_hook_trampoline_48_3d_00_f0_ff_ff)
-        callq _syscall_hook_trampoline
+        callq __morestack
         cmpq $0xfffffffffffff000,%rax
 SYSCALLHOOK_END(_syscall_hook_trampoline_48_3d_00_f0_ff_ff)
 
 SYSCALLHOOK_START(_syscall_hook_trampoline_48_8b_3c_24)
-         callq _syscall_hook_trampoline
+         callq __morestack
          /* The original instruction after the syscall is movq (%rsp),%rdi. */
          movq 8(%rsp),%rdi
          movq (%rdi),%rdi
 SYSCALLHOOK_END(_syscall_hook_trampoline_48_8b_3c_24)
 
 SYSCALLHOOK_START(_syscall_hook_trampoline_5a_5e_c3)
-        callq _syscall_hook_trampoline
+        callq __morestack
         /* The original instructions after the syscall are
            pop %rdx; pop %rsi; retq. */
         /* We're not returning to the dynamically generated stub, so
@@ -328,22 +374,22 @@ SYSCALLHOOK_START(_syscall_hook_trampoline_5a_5e_c3)
         .size _syscall_hook_trampoline_5a_5e_c3, .-_syscall_hook_trampoline_5a_5e_c3
 
 SYSCALLHOOK_START(_syscall_hook_trampoline_89_c2_f7_da)
-        call _syscall_hook_trampoline
+        call __morestack
         mov %eax,%edx
         neg %edx
 SYSCALLHOOK_END(_syscall_hook_trampoline_89_c2_f7_da)
 
 SYSCALLHOOK_START(_syscall_hook_trampoline_90_90_90)
-        call _syscall_hook_trampoline
+        call __morestack
 SYSCALLHOOK_END(_syscall_hook_trampoline_90_90_90)
 
 SYSCALLHOOK_START(_syscall_hook_trampoline_ba_01_00_00_00)
-        call _syscall_hook_trampoline
+        call __morestack
         mov $1,%edx
 SYSCALLHOOK_END(_syscall_hook_trampoline_ba_01_00_00_00)
 
 SYSCALLHOOK_START(_syscall_hook_trampoline_89_c1_31_d2)
-        call _syscall_hook_trampoline
+        call __morestack
         mov %eax,%ecx
         xor %edx,%edx
 SYSCALLHOOK_END(_syscall_hook_trampoline_89_c1_31_d2)


### PR DESCRIPTION
The first three changes are general improvements to the unwind info in our preload library. They should be fairly uncontroversial, and in fact, with these changes (and manually telling the unwinder about our jump stubs), in a simple program I was able to determine that we have complete and correct unwind info at every instruction exercised in that program (it of course didn't go through all the paths in the preload library, but still something).

Unfortunately, gdb does not just use CFI to unwind, but relies on CFI coupled with a very large number of heuristics, which can override the CFI. It doesn't happen all that often, but sometimes gdb gets very angry at our stack switching scheme and aborts unwinding. The last commit implements an ugly workaround for this (x86_64 only, for now). The other option we have is to mark our syscall hooks as signal trampoline, in which case gdb is more forgiving (because signals are generally allowed to run on different stack), but it also inserts a `<signal handler called>` into the backtrace, which I feared is confusing to the user.