### PR TITLE
Fix -C for mmap entirely beyond its backing file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,6 +549,7 @@ set(BASIC_TESTS
   mmap_shared_write
   mmap_short_file
   mmap_tmpfs
+  mmap_zero_size_fd
   mprotect
   mprotect_heterogenous
   mprotect_none

--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -1501,7 +1501,9 @@ static inline void assert_coalesceable(Task* t,
 
 static bool is_coalescable(const AddressSpace::Mapping& mleft,
                            const AddressSpace::Mapping& mright) {
-  if (!is_adjacent_mapping(mleft.map, mright.map, RESPECT_HEAP)) {
+  if (!is_adjacent_mapping(mleft.map, mright.map, RESPECT_HEAP) ||
+      !is_adjacent_mapping(mleft.recorded_map, mright.recorded_map,
+                           RESPECT_HEAP)) {
     return false;
   }
   return mleft.flags == mright.flags;

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -271,6 +271,9 @@ public:
       IS_THREAD_LOCALS = 0x2,
       // This mapping is used for syscallbuf patch stubs
       IS_PATCH_STUBS = 0x4,
+      // This mapping has been created by the replayer to guarantee SIGBUS
+      // in a region whose backing file was too short during recording.
+      IS_SIGBUS_REGION = 0x8
     };
     uint32_t flags;
   };

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -720,6 +720,8 @@ static void create_sigbus_region(AutoRemoteSyscalls& remote, int prot,
   remote.task()->vm()->map(remote.task(), start, length, prot,
                            MAP_FIXED | MAP_PRIVATE, 0, file_name, fstat.st_dev,
                            fstat.st_ino, nullptr, &km_slice);
+  remote.task()->vm()->mapping_flags_of(start) |=
+      AddressSpace::Mapping::IS_SIGBUS_REGION;
 }
 
 static void finish_private_mmap(ReplayTask* t, AutoRemoteSyscalls& remote,

--- a/src/test/mmap_zero_size_fd.c
+++ b/src/test/mmap_zero_size_fd.c
@@ -1,0 +1,17 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+int main(void) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  char name[] = "/tmp/rr-mmap-zero-size-XXXXXX";
+  int fd = mkstemp(name);
+  ftruncate(fd, 0);
+  void* mmap_addr =
+      mmap(NULL, 2 * page_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+  test_assert(mmap_addr != MAP_FAILED);
+
+  test_assert(0 == unlink(name));
+
+  atomic_puts("EXIT-SUCCESS");
+}


### PR DESCRIPTION
This was problematic both during record and during replay. During record,
we'd get -1 back from read_bytes_fallible since we can't read any bytes
from the mapping, and during replay, we'd run into problems, because
the memory map looks differently due to us creating special SIGBUS
regions. Address both and add a test to checksum_sanity that always
covers this case.