### PR TITLE
Lock the syscallbuf during diversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -777,6 +777,7 @@ set(TESTS_WITH_PROGRAM
   daemon_read
   dconf_mock
   dev_tty
+  diversion_syscall
   dlopen
   execve_loop
   exit_codes

--- a/src/DiversionSession.cc
+++ b/src/DiversionSession.cc
@@ -115,11 +115,12 @@ DiversionSession::DiversionResult DiversionSession::diversion_step(
     return result;
   }
 
+  // Disable syscall buffering during diversions
   if (t->preload_globals) {
-    // Disable syscall buffering during diversions
     t->write_mem(REMOTE_PTR_FIELD(t->preload_globals, in_diversion),
                  (unsigned char)1);
   }
+  t->set_syscallbuf_locked(1);
 
   switch (command) {
     case RUN_CONTINUE:

--- a/src/test/diversion_syscall.c
+++ b/src/test/diversion_syscall.c
@@ -1,0 +1,27 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+static __attribute__((noinline)) void breakpoint(void) {
+  int break_here = 1;
+  (void)break_here;
+}
+
+int main(void) {
+  // We will make use of the fact that fd 3 is closed. Just to be sure the
+  // parent didn't leak anything, close it (in the normal case, this'll fail,
+  // but that's ok).
+  close(3);
+
+  // Do a bunch of bufferable system calls
+  int fd = open("/dev/null", O_WRONLY | O_CLOEXEC);
+  test_assert(fd == 3);
+
+  // At this breakpoint, we'll attempt to open a file during the diversion
+  breakpoint();
+
+  // More bufferable syscalls
+  for (int i = 1; i < 10; ++i) {
+    write(fd, "Hello", 5);
+  }
+}

--- a/src/test/diversion_syscall.py
+++ b/src/test/diversion_syscall.py
@@ -1,0 +1,18 @@
+from rrutil import *
+import re
+
+send_gdb('b breakpoint')
+expect_gdb('Breakpoint 1')
+
+send_gdb('c')
+expect_gdb('Breakpoint 1')
+
+send_gdb('p open("diversion_print.out",0102,0600)')
+expect_gdb('\$1 = 3')
+# This FD is confused with that during record. That's ok, just make sure
+# operations on this during the diversion actually go to our file.
+
+send_gdb('p write(3, "DIVERSION-SUCCESS", 17)')
+expect_gdb('\$2 = 17')
+
+ok()

--- a/src/test/diversion_syscall.run
+++ b/src/test/diversion_syscall.run
@@ -1,0 +1,9 @@
+source `dirname $0`/util.sh
+record $TESTNAME
+debug_test
+token=DIVERSION-SUCCESS
+if [[ "diversion_print.out" != $(grep -l $token diversion_print.out) ]]; then
+  failed ": token '$token' not written to file by diversion"
+else
+  passed
+fi


### PR DESCRIPTION
Otherwise a syscall that gets called during the diversion will try to interpret
the syscallbuf as its own data, wrecking all kinds of havok. Add a simple test
for this scenario.