### PR TITLE
Best effort support for cross-architecture syscalls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,7 @@ set(BASIC_TESTS
   cloned_sigmask
   constructor
   creat_address_not_truncated
+  cross_arch
   cwd_inaccessible
   daemon
   desched_blocking_poll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,6 +551,7 @@ set(BASIC_TESTS
   mmap_short_file
   mmap_tmpfs
   mmap_zero_size_fd
+  modify_ldt
   mprotect
   mprotect_heterogenous
   mprotect_none

--- a/src/AutoRemoteSyscalls.cc
+++ b/src/AutoRemoteSyscalls.cc
@@ -192,6 +192,8 @@ void AutoRemoteSyscalls::wait_syscall(int syscallno) {
   ASSERT(t, t->regs().original_syscallno() == syscallno || syscallno < 0)
       << "Should be entering " << t->syscall_name(syscallno)
       << ", but instead at " << t->syscall_name(t->regs().original_syscallno());
+
+  t->canonicalize_and_set_regs(t->regs(), t->arch());
 }
 
 SupportedArch AutoRemoteSyscalls::arch() const { return t->arch(); }

--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -355,6 +355,14 @@ bool Monkeypatcher::try_patch_syscall(RecordTask* t) {
 
   tried_to_patch_syscall_addresses.insert(r.ip());
 
+  SupportedArch arch;
+  if (!get_syscall_instruction_arch(
+          t, r.ip().decrement_by_syscall_insn_length(t->arch()), &arch) ||
+      arch != t->arch()) {
+    LOG(debug) << "Declining to patch cross-architecture syscall at " << r.ip();
+    return false;
+  }
+
   uint8_t following_bytes[256];
   size_t bytes_count = t->read_bytes_fallible(
       r.ip().to_data_ptr<uint8_t>(), sizeof(following_bytes), following_bytes);

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -358,6 +358,8 @@ public:
     record_remote_even_if_null(addr, sizeof(T));
   }
 
+  SupportedArch detect_syscall_arch();
+
   /**
    * Manage pending events.  |push_event()| pushes the given
    * event onto the top of the event stack.  The |pop_*()|
@@ -365,6 +367,7 @@ public:
    * the specified type.
    */
   void push_event(const Event& ev) { pending_events.push_back(ev); }
+  void push_syscall_event(int syscallno);
   void pop_event(EventType expected_type);
   void pop_noop() { pop_event(EV_NOOP); }
   void pop_desched() { pop_event(EV_DESCHED); }

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -270,6 +270,21 @@ public:
     RR_SET_REG(edx, rdx, value >> 32);
   }
 
+  void set_r8(uintptr_t value) {
+    assert(arch() == x86_64);
+    u.x64regs.r8 = value;
+  }
+
+  void set_r9(uintptr_t value) {
+    assert(arch() == x86_64);
+    u.x64regs.r9 = value;
+  }
+
+  void set_r10(uintptr_t value) {
+    assert(arch() == x86_64);
+    u.x64regs.r10 = value;
+  }
+
   void set_r11(uintptr_t value) {
     assert(arch() == x86_64);
     u.x64regs.r11 = value;
@@ -418,6 +433,19 @@ private:
     rr::X64Arch::user_regs_struct x64regs;
   } u;
 };
+
+template <typename ret, typename callback>
+ret with_converted_registers(const Registers& regs, SupportedArch arch,
+                             callback f) {
+  if (regs.arch() != arch) {
+    // If this is a cross architecture syscall, first convert the registers.
+    Registers converted_regs(arch);
+    std::vector<uint8_t> data = regs.get_ptrace_for_arch(arch);
+    converted_regs.set_from_ptrace_for_arch(arch, data.data(), data.size());
+    return f(converted_regs);
+  }
+  return f(regs);
+}
 
 std::ostream& operator<<(std::ostream& stream, const Registers& r);
 

--- a/src/ReplaySession.h
+++ b/src/ReplaySession.h
@@ -74,6 +74,8 @@ struct ReplayTraceStep {
 
   union {
     struct {
+      /* The architecture of the syscall */
+      SupportedArch arch;
       /* The syscall number we expect to
        * enter/exit. */
       int number;

--- a/src/Task.h
+++ b/src/Task.h
@@ -112,6 +112,8 @@ struct TrapReasons {
   bool breakpoint;
 };
 
+void fixup_syscall_registers(Registers& registers, SupportedArch arch);
+
 /**
  * A "task" is a task in the linux usage: the unit of scheduling.  (OS
  * people sometimes call this a "thread control block".)  Multiple
@@ -196,7 +198,8 @@ public:
    * Perform those side effects on |regs| and do set_regs() on that to make it
    * look like a syscall happened.
    */
-  void emulate_syscall_entry(const Registers& regs);
+  void canonicalize_and_set_regs(const Registers& regs,
+                                 SupportedArch syscall_arch);
 
   /**
    * Return the ptrace message pid associated with the current ptrace
@@ -286,7 +289,8 @@ public:
    * Use 'regs' instead of this->regs() because some registers may not be
    * set properly in the task yet.
    */
-  virtual void on_syscall_exit(int syscallno, const Registers& regs);
+  virtual void on_syscall_exit(int syscallno, SupportedArch arch,
+                               const Registers& regs);
 
   /**
    * Assuming ip() is just past a breakpoint instruction, adjust

--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -86,23 +86,36 @@ static const uint8_t int80_insn[] = { 0xcd, 0x80 };
 static const uint8_t sysenter_insn[] = { 0x0f, 0x34 };
 static const uint8_t syscall_insn[] = { 0x0f, 0x05 };
 
-bool is_at_syscall_instruction(Task* t, remote_code_ptr ptr) {
+bool get_syscall_instruction_arch(Task* t, remote_code_ptr ptr,
+                                  SupportedArch* arch) {
   bool ok = true;
   vector<uint8_t> code = t->read_mem(ptr.to_data_ptr<uint8_t>(), 2, &ok);
   if (!ok) {
     return false;
   }
   switch (t->arch()) {
+    // Compatibility mode switch can happen in user space (but even without
+    // such tricks, int80, which uses the 32bit syscall table, can be invoked
+    // from 64bit processes).
     case x86:
-      return memcmp(code.data(), int80_insn, sizeof(int80_insn)) == 0 ||
-             memcmp(code.data(), sysenter_insn, sizeof(sysenter_insn)) == 0;
     case x86_64:
-      return memcmp(code.data(), syscall_insn, sizeof(syscall_insn)) == 0 ||
-             memcmp(code.data(), sysenter_insn, sizeof(sysenter_insn)) == 0;
+      if (memcmp(code.data(), int80_insn, sizeof(int80_insn)) == 0 ||
+          memcmp(code.data(), sysenter_insn, sizeof(sysenter_insn) == 0)) {
+        *arch = x86;
+      } else if (memcmp(code.data(), syscall_insn, sizeof(syscall_insn)) == 0) {
+        *arch = x86_64;
+      } else {
+        return false;
+      }
+      return true;
     default:
-      assert(0 && "Need to define syscall instructions");
       return false;
   }
+}
+
+bool is_at_syscall_instruction(Task* t, remote_code_ptr ptr) {
+  SupportedArch arch;
+  return get_syscall_instruction_arch(t, ptr, &arch);
 }
 
 vector<uint8_t> syscall_instruction(SupportedArch arch) {

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1741,6 +1741,13 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
 #include "SyscallHelperFunctions.generated"
 
 /**
+ * Return true if |ptr| in task |t| points to an invoke-syscall instruction,
+ * and if so, return the architecture for which this is a syscall in *arch.
+ */
+bool get_syscall_instruction_arch(Task* t, remote_code_ptr ptr,
+                                  SupportedArch* arch);
+
+/**
  * Return true if |ptr| in task |t| points to an invoke-syscall instruction.
  */
 bool is_at_syscall_instruction(Task* t, remote_code_ptr ptr);

--- a/src/preload/raw_syscall.S
+++ b/src/preload/raw_syscall.S
@@ -85,7 +85,7 @@ _raw_syscall:
            to hide these effects when we get a ptrace trap from system calls
            in the kernel: it clears TF from %r11, forces %rcx to -1, and sets
            flags to fixed values (ZF+PF+IF+reserved, same as for "xor reg,reg").
-           Task::emulate_syscall_entry is responsible for fixing up registers
+           Task::canonicalize_and_set_regs is responsible for fixing up registers
            when we emulate a system call that was traced during recording (by
            running to a breakpoint at that system call). It does the above
            effects after setting %r11 to %rflags.

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3749,6 +3749,17 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
       return ALLOW_SWITCH;
     }
 
+    case Arch::modify_ldt: {
+      int func = regs.arg1();
+      if (func == 0 || func == 2) {
+        syscall_state.reg_parameter(
+            2, ParamSize::from_syscall_result<int>((size_t)regs.arg3()));
+      }
+      // N.B. Unlike set_thread_area, the entry number is not written
+      // for (func == 1 || func == 0x11)
+      return ALLOW_SWITCH;
+    }
+
     default:
       // Invalid syscalls return -ENOSYS. Assume any such
       // result means the syscall was completely ignored by the

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -1206,6 +1206,7 @@ static void rep_process_syscall_arch(ReplayTask* t, ReplayTraceStep* step,
     case Arch::munmap:
     case Arch::mprotect:
     case Arch::arch_prctl:
+    case Arch::modify_ldt:
     case Arch::set_thread_area: {
       // Using AutoRemoteSyscalls here fails for arch_prctl, not sure why.
       Registers r = t->regs();

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -638,7 +638,7 @@ setdomainname = EmulatedSyscall(x86=121, x64=171)
 # buf. The utsname struct is defined in <sys/utsname.h>:
 uname = EmulatedSyscall(x86=122, x64=63, arg1="typename Arch::utsname")
 
-modify_ldt = UnsupportedSyscall(x86=123, x64=154)
+modify_ldt = IrregularEmulatedSyscall(x86=123, x64=154)
 adjtimex = UnsupportedSyscall(x86=124, x64=159)
 
 #  int mprotect(const void *addr, size_t len, int prot)

--- a/src/test/cross_arch.c
+++ b/src/test/cross_arch.c
@@ -1,0 +1,37 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+#if !defined(__i386__) && !defined(__x86_64__)
+#error "Adjust or disable this test for your architecture"
+#else
+static int32_t my_syscall(uint32_t syscallno, uint32_t arg1, uint32_t arg2,
+                          uint32_t arg3) {
+  int32_t ret;
+  /* Use int $0x80 to do the syscall. This will use the i386 syscall table
+     regardless of whether or not this is a 64bit process or not */
+  asm("int $0x80\n\t"
+      "nop\n\t"
+      "nop\n\t"
+      "nop\n\t"
+      : "=a"(ret)
+      : "a"(syscallno), "b"(arg1), "c"(arg2), "d"(arg3));
+  return ret;
+}
+#define SYS32_exit 1  /* write on x64 */
+#define SYS32_write 4 /* stat on x64 */
+#endif
+
+char token[] = "EXIT-SUCCESS";
+int main(void) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  void* low_buffer = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+                          MAP_ANONYMOUS | MAP_PRIVATE | MAP_32BIT, 0, 0);
+  memcpy(low_buffer, token, sizeof(token));
+  test_assert(sizeof(token) == my_syscall(SYS32_write, STDOUT_FILENO,
+                                          (uintptr_t)low_buffer,
+                                          sizeof(token)));
+  my_syscall(SYS32_exit, 0, 0, 0);
+  test_assert(0 && "Should have exited");
+  return 0;
+}

--- a/src/test/mmap_replace_most_mappings.c
+++ b/src/test/mmap_replace_most_mappings.c
@@ -12,9 +12,11 @@ static int contains_symbol(map_properties_t* props, void* symbol) {
   return (props->start <= (uintptr_t)symbol && (uintptr_t)symbol < props->end);
 }
 void callback(uint64_t env, char* name, map_properties_t* props) {
-  (void)env;
   if (contains_symbol(props, &main) || contains_symbol(props, unmappings) ||
-      props->start == RR_PAGE_ADDR || strcmp(name, "[stack]") == 0) {
+      /* env is on the stack - this prevents it from being unmapped if
+         the kernel gets confused by syscallbuf's stack switching */
+      contains_symbol(props, &env) || props->start == RR_PAGE_ADDR ||
+      strcmp(name, "[stack]") == 0) {
     return;
   }
 

--- a/src/test/modify_ldt.c
+++ b/src/test/modify_ldt.c
@@ -1,0 +1,26 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+#include <asm/ldt.h>
+
+int main(void) {
+  uint32_t limit = 0x1234;
+  struct user_desc desc = {.entry_number = 0,
+                           .base_addr = 0x0,
+                           .limit = limit,
+                           .seg_32bit = 1,
+                           .contents = 2,
+                           .read_exec_only = 0,
+                           .seg_not_present = 0,
+                           .useable = 1 };
+  test_assert(0 == syscall(SYS_modify_ldt, 0x11, &desc, sizeof(desc)));
+  uint32_t new_limit = 0, has_limit = 0;
+  uint32_t selector = (desc.entry_number << 3) | 0x4 /* LDT */ | 0x3 /* RPL */;
+  asm("lsl %[selector], %[the_limit]\n\t"
+      "jnz 1f\n\tmovl $1, %[has_limit]\n\t1:"
+      : [the_limit] "=r"(new_limit), [has_limit] "+rm"(has_limit)
+      : [selector] "r"(selector));
+  test_assert(has_limit && new_limit == limit);
+  atomic_printf("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/set_tid_address.c
+++ b/src/test/set_tid_address.c
@@ -28,7 +28,13 @@ int main(void) {
   v = 1;
   pthread_create(&thread, NULL, run_thread, NULL);
   test_assert(1 == write(pipe_fds[1], "x", 1));
-  test_assert(0 == syscall(SYS_futex, &v, FUTEX_WAIT, 1, NULL, NULL, 0));
+  int ret = syscall(SYS_futex, &v, FUTEX_WAIT, 1, NULL, NULL, 0);
+  // The above is slightly racy. If the thread finishes before we enter
+  // the syscall we will exit with EAGAIN. This is unfortunate, but there
+  // is no much we can do. Luckily this failure mode is different from
+  // the one we really care about (the FUTEX_WAKE not happening), which
+  // would manifest itself as a hang in the call above.
+  test_assert(0 == ret || (-1 == ret && errno == EAGAIN));
   test_assert(0 == v);
 
   size_t page_size = sysconf(_SC_PAGESIZE);


### PR DESCRIPTION
As mentioned on IRC, when using `int $0x80`, the kernel behaves as if the process were 32bit, contrary to rr's expectation, which is that it's just a different spelling of `syscall`. This adds some best-effort code to handle this. In my testing this works surprisingly well, and runs a couple of
the test cases I had tried, but I made no effort or attempt at rigorous testing of this functionality. There's a new warning message that gets printed in the log when a cross-arch syscall is detected though, so we should be able to figure out what's going on if we come across any real applications we care about that do this.

While I'm at it (it being weird corners of the x86 architecture), also clean up the modify_ldt support commit I had lying around locally. With both of these commits, I was also able to successfully record&replay the [ldt_gdt kernel selftest](https://github.com/torvalds/linux/blob/master/tools/testing/selftests/x86/ldt_gdt.c), which uses both of these features.