### PR TITLE
Check for seccomp dependency during configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,11 @@ foreach(required_lib ${REQUIRED_LIBS})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${${PKG}_CFLAGS}")
 endforeach(required_lib)
 
+find_path(SECCOMP NAMES "linux/seccomp.h")
+if(NOT SECCOMP)
+  message(FATAL_ERROR "Couldn't find linux/seccomp.h. You may need to upgrade your kernel.")
+endif()
+
 # Check for Python >=2.7 but not Python 3.
 find_package(PythonInterp 2.7 REQUIRED)
 if(PYTHON_VERSION_MAJOR GREATER 2)


### PR DESCRIPTION
Prior to this commit, target platforms with older, pre-seccomp kernels would
hit a compilation failure when their compiler failed to find linux/seccomp.h.
This change makes CMake check for the required header during configuration and
present an earlier, more friendly error.

Resolves #1920 

----

I don't have a complete array of kernels on hand to test but on the machines I do, this check correctly errors on Linux 3.0 and passes on 3.17 and 4.4. Please let me know if you want anything changed to make it acceptable. Thanks.