### PR TITLE
Miscellaneous bugfixes/syscall coverage improvement + small new feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,6 +500,7 @@ set(BASIC_TESTS
   fd_tracking_across_threads
   fds_clean
   flock
+  flock_ofd
   flock2
   fork_brk
   fork_child_crash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -581,6 +581,7 @@ set(BASIC_TESTS
   munmap_segv
   munmap_discontinuous
   nanosleep
+  netfilter
   no_mask_timeslice
   numa
   old_fork

--- a/src/DumpCommand.cc
+++ b/src/DumpCommand.cc
@@ -40,7 +40,8 @@ DumpCommand DumpCommand::singleton(
     "  -r, --raw                  dump trace frames in a more easily\n"
     "                             machine-parseable format instead of the\n"
     "                             default human-readable format\n"
-    "  -s, --statistics           dump statistics about the trace\n");
+    "  -s, --statistics           dump statistics about the trace\n"
+    "  -t, --tid=<pid>            dump events only for the specified tid\n");
 
 struct DumpFlags {
   bool dump_syscallbuf;
@@ -49,6 +50,7 @@ struct DumpFlags {
   bool dump_mmaps;
   bool raw_dump;
   bool dump_statistics;
+  int only_tid;
 
   DumpFlags()
       : dump_syscallbuf(false),
@@ -56,7 +58,8 @@ struct DumpFlags {
         dump_recorded_data_metadata(false),
         dump_mmaps(false),
         raw_dump(false),
-        dump_statistics(false) {}
+        dump_statistics(false),
+        only_tid(0) {}
 };
 
 static bool parse_dump_arg(vector<string>& args, DumpFlags& flags) {
@@ -70,7 +73,8 @@ static bool parse_dump_arg(vector<string>& args, DumpFlags& flags) {
     { 'm', "recorded-metadata", NO_PARAMETER },
     { 'p', "mmaps", NO_PARAMETER },
     { 'r', "raw", NO_PARAMETER },
-    { 's', "statistics", NO_PARAMETER }
+    { 's', "statistics", NO_PARAMETER },
+    { 't', "tid", HAS_PARAMETER },
   };
   ParsedOption opt;
   if (!Command::parse_option(args, options, &opt)) {
@@ -95,6 +99,12 @@ static bool parse_dump_arg(vector<string>& args, DumpFlags& flags) {
       break;
     case 's':
       flags.dump_statistics = true;
+      break;
+    case 't':
+      if (!opt.verify_valid_int(1, INT32_MAX)) {
+        return false;
+      }
+      flags.only_tid = opt.int_value;
       break;
     default:
       assert(0 && "Unknown option");
@@ -162,7 +172,8 @@ static void dump_events_matching(TraceReader& trace, const DumpFlags& flags,
     if (end < frame.time()) {
       return;
     }
-    if (start <= frame.time() && frame.time() <= end) {
+    if (start <= frame.time() && frame.time() <= end &&
+        (!flags.only_tid || flags.only_tid == frame.tid())) {
       if (flags.raw_dump) {
         frame.dump_raw(out);
       } else {

--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -19,6 +19,7 @@
 #include <linux/mqueue.h>
 #include <linux/msg.h>
 #include <linux/net.h>
+#include <linux/netfilter/x_tables.h>
 #include <linux/sem.h>
 #include <linux/shm.h>
 #include <linux/sockios.h>

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -910,12 +910,11 @@ struct BaseArch : public wordsize,
   };
 
   struct setsockopt_args {
-    signed_int sockfd;
-    signed_int level;
-    signed_int optname;
-    char __pad[sizeof(ptr<void>) - sizeof(int)];
+    signed_long sockfd;
+    signed_long level;
+    signed_long optname;
     ptr<void> optval;
-    ptr<socklen_t> optlen;
+    signed_long optlen;
   };
 
   struct recv_args {
@@ -1337,6 +1336,26 @@ struct BaseArch : public wordsize,
     signed_long __reserved[4];
   };
   RR_VERIFY_TYPE(mq_attr);
+
+  struct xt_counters {
+    uint64_t pcnt, bcnt;
+  };
+  RR_VERIFY_TYPE(xt_counters);
+
+  struct ipt_replace {
+    uint8_t name[32];
+    uint32_t valid_hook;
+    uint32_t num_entries;
+    uint32_t size;
+    uint32_t hook_entry[5];
+    uint32_t underflow[5];
+    uint32_t num_counters;
+    ptr<xt_counters> counters; // ptr<xt_counters>
+    // Plus hangoff here
+  };
+  // The corresponding header requires -fpermissive, which we don't pass. Skip
+  // this check.
+  // RR_VERIFY_TYPE(ipt_replace);
 };
 
 struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -91,7 +91,11 @@ struct FcntlConstants {
     SETLKW64 = 14,
     SETOWN_EX = 15,
     GETOWN_EX = 16,
-    // Linux-specific operations
+    // Open File descriptor locks (Linux specific)
+    OFD_GETLK = 36,
+    OFD_SETLK = 37,
+    OFD_SETLKW = 38,
+    // Other Linux-specific operations
     DUPFD_CLOEXEC = 0x400 + 6,
     ADD_SEALS = 0x400 + 9
   };

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1054,7 +1054,7 @@ struct BaseArch : public wordsize,
   RR_VERIFY_TYPE(sigset_t);
 
   typedef struct {
-    ptr<const sigset_t> ss;
+    ptr<const kernel_sigset_t> ss;
     size_t ss_len;
   } pselect6_arg6;
 

--- a/src/kernel_supplement.h
+++ b/src/kernel_supplement.h
@@ -164,6 +164,12 @@ struct usbdevfs_streams {
 #define BUS_MCEERR_AO 5
 #endif
 
+// Defined in the ip_tables header for each protocol, but always to the same,
+// value, so it should be fine to set this here
+#ifndef SO_SET_REPLACE
+#define SO_SET_REPLACE 64
+#endif
+
 } // namespace rr
 
 #endif /* RR_KERNEL_SUPPLEMENT_H_ */

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2780,6 +2780,7 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
         case Arch::SETFL:
         case Arch::SETLK:
         case Arch::SETLK64:
+        case Arch::OFD_SETLK:
         case Arch::SETOWN:
         case Arch::SETOWN_EX:
         case Arch::GETSIG:
@@ -2802,6 +2803,7 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
           syscall_state.reg_parameter<typename Arch::_flock>(3, IN_OUT);
           break;
 
+        case Arch::OFD_GETLK:
         case Arch::GETLK64:
           // flock and flock64 better be different on 32-bit architectures,
           // but on 64-bit architectures, it's OK if they're the same.
@@ -2818,6 +2820,7 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
 
         case Arch::SETLKW:
         case Arch::SETLKW64:
+        case Arch::OFD_SETLKW:
           // SETLKW blocks, but doesn't write any
           // outparam data to the |struct flock|
           // argument, so no need for scratch.

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -682,7 +682,8 @@ Switchable TaskSyscallState::done_preparing(Switchable sw) {
         saved_data.resize(prev_size + param.num_bytes.incoming_size);
         saved_data_loc = saved_data.data() + prev_size;
       }
-      if (!(*param.mutator)(t, param.dest, saved_data_loc)) {
+      if (!(*param.mutator)(t, scratch_enabled ? param.scratch : param.dest,
+                            saved_data_loc)) {
         // Nothing was modified, no need to clean up when we unwind.
         param.mutator = nullptr;
         if (!scratch_enabled) {
@@ -3579,9 +3580,9 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
 
     case Arch::rt_sigprocmask:
     case Arch::sigprocmask: {
-      syscall_state.reg_parameter<typename Arch::sigset_t>(3);
-      syscall_state.reg_parameter<typename Arch::sigset_t>(2, IN,
-                                                           protect_rr_sigs);
+      syscall_state.reg_parameter<typename Arch::kernel_sigset_t>(3);
+      syscall_state.reg_parameter<typename Arch::kernel_sigset_t>(
+          2, IN, protect_rr_sigs);
       return PREVENT_SWITCH;
     }
 

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3367,6 +3367,7 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
      * long arg4, unsigned long arg5); */
     case Arch::prctl:
       switch ((int)regs.arg1_signed()) {
+        case PR_GET_CHILD_SUBREAPER:
         case PR_GET_ENDIAN:
         case PR_GET_FPEMU:
         case PR_GET_FPEXC:
@@ -3380,6 +3381,7 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
         case PR_GET_TIMERSLACK:
         case PR_MCE_KILL:
         case PR_MCE_KILL_GET:
+        case PR_SET_CHILD_SUBREAPER:
         case PR_SET_KEEPCAPS:
         case PR_SET_NAME:
         case PR_SET_PDEATHSIG:

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3287,8 +3287,11 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
      *           const struct timespec *timeout_ts,
      *           const sigset_t *sigmask); */
     case Arch::ppoll:
-      syscall_state.reg_parameter<typename Arch::sigset_t>(4, IN,
-                                                           protect_rr_sigs);
+      /* The raw syscall modifies this with the time remaining. The libc
+         does not expose this functionality however */
+      syscall_state.reg_parameter<typename Arch::timespec>(3, IN_OUT);
+      syscall_state.reg_parameter<typename Arch::kernel_sigset_t>(
+          4, IN, protect_rr_sigs);
     /* fall through */
     case Arch::poll: {
       auto nfds = (nfds_t)regs.arg2();

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -1149,7 +1149,7 @@ flistxattr = IrregularEmulatedSyscall(x86=234, x64=196)
 removexattr = EmulatedSyscall(x86=235, x64=197)
 lremovexattr = EmulatedSyscall(x86=236, x64=198)
 fremovexattr = EmulatedSyscall(x86=237, x64=199)
-tkill = UnsupportedSyscall(x86=238, x64=200)
+tkill = EmulatedSyscall(x86=238, x64=200)
 
 # ssize_t sendfile64 (int __out_fd, int __in_fd, __off64_t *__offset, size_t
 #__count);

--- a/src/test/flock_ofd.c
+++ b/src/test/flock_ofd.c
@@ -1,0 +1,86 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+#define FILENAME "foo.txt"
+
+static void verify_lock(int fd, struct flock64* lock) {
+  ssize_t pagesize = sysconf(_SC_PAGESIZE);
+  lock->l_type = F_WRLCK;
+  test_assert(0 == fcntl(fd, F_OFD_GETLK, lock));
+
+  test_assert(F_RDLCK == lock->l_type && pagesize / 2 == lock->l_start &&
+              pagesize / 2 == lock->l_len);
+}
+
+int main(void) {
+  ssize_t pagesize = sysconf(_SC_PAGESIZE);
+  int fd, fd2;
+  size_t i;
+  int err;
+  pid_t pid;
+  int status;
+
+  fd = open(FILENAME, O_CREAT | O_EXCL | O_RDWR, 0600);
+  fd2 = open(FILENAME, O_EXCL | O_RDWR, 0600);
+  test_assert(fd >= 0 && fd2 >= 0);
+
+  unlink(FILENAME);
+
+  /* Write a page's worth of data. */
+  for (i = 0; i < pagesize / sizeof(i); ++i) {
+    ssize_t nwritten = write(fd, &i, sizeof(i));
+    test_assert(nwritten == sizeof(i));
+  }
+
+  struct flock64 lock = {.l_type = F_RDLCK,
+                         .l_whence = SEEK_SET,
+                         .l_start = pagesize,
+                         .l_len = -pagesize / 2 };
+
+  /* It should currently be unlocked. */
+  err = fcntl(fd2, F_OFD_GETLK, &lock);
+  test_assert(0 == err);
+
+  test_assert(F_UNLCK == lock.l_type);
+
+  if (0 == (pid = fork())) {
+    lock.l_type = F_RDLCK;
+    fcntl(fd, F_OFD_SETLK, &lock);
+    test_assert(0 == err);
+
+    /* Close a dup of the file descriptor. This should not release the lock */
+    test_assert(0 == close(dup(fd)));
+
+    /* Make sure our lock "took". */
+    if (0 == (pid = fork())) {
+      verify_lock(fd2, &lock);
+      exit(0);
+    }
+
+    waitpid(pid, &status, 0);
+    test_assert(WIFEXITED(status) && 0 == WEXITSTATUS(status));
+    return 0;
+  }
+
+  waitpid(pid, &status, 0);
+  test_assert(WIFEXITED(status) && 0 == WEXITSTATUS(status));
+
+  /* Should still be locked, since the lock is associated with the file
+     descriptor, not the process */
+  verify_lock(fd2, &lock);
+
+  /* This should release the lock */
+  close(fd);
+
+  lock.l_type = F_RDLCK;
+  lock.l_whence = SEEK_SET;
+  lock.l_start = pagesize;
+  lock.l_len = -pagesize / 2;
+  lock.l_pid = 0;
+  test_assert(0 == fcntl(fd2, F_OFD_GETLK, &lock));
+  test_assert(F_UNLCK == lock.l_type);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/netfilter.c
+++ b/src/test/netfilter.c
@@ -1,0 +1,176 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+#include <linux/netfilter_ipv4/ip_tables.h>
+
+static int open_proc_file(pid_t pid, const char* file, int mode) {
+  char path[100];
+  ssize_t n = snprintf(path, sizeof(path), "/proc/%d/%s", pid, file);
+  test_assert(n >= 0 && n < (ssize_t)sizeof(path));
+  int fd = open(path, mode);
+  test_assert(fd != -1);
+  return fd;
+}
+
+int main(void) {
+  int err = unshare(CLONE_NEWNET);
+  if (err == -1) {
+    // Try again using user namespace functionality
+    test_assert(errno == EPERM);
+
+    int child_block[2], parent_block[2];
+    pipe(child_block);
+    pipe(parent_block);
+
+    pid_t pid = getpid();
+    if (fork() == 0) {
+      close(child_block[1]);
+      close(parent_block[0]);
+
+      // This will block until the parent closes fds[1]
+      test_assert(0 == read(child_block[0], NULL, 1));
+      close(child_block[0]);
+
+      // Deny setgroups
+      int setgroups_fd = open_proc_file(pid, "setgroups", O_WRONLY);
+      char deny[] = "deny";
+      test_assert(write(setgroups_fd, deny, sizeof(deny)) == sizeof(deny));
+      close(setgroups_fd);
+
+      // Make us root
+      ssize_t nbytes;
+      int uidmap_fd = open_proc_file(pid, "uid_map", O_WRONLY);
+      test_assert(uidmap_fd != -1);
+      char uidmap[100];
+      nbytes = snprintf(uidmap, (ssize_t)sizeof(uidmap), "0\t%d\t1", getuid());
+      test_assert(nbytes > 0 && nbytes <= (ssize_t)sizeof(uidmap));
+      test_assert(write(uidmap_fd, uidmap, nbytes) == nbytes);
+      test_assert(uidmap_fd);
+
+      int gidmap_fd = open_proc_file(pid, "gid_map", O_WRONLY);
+      test_assert(gidmap_fd != -1);
+      char gidmap[100];
+      nbytes = snprintf(gidmap, (ssize_t)sizeof(gidmap), "0\t%d\t1", getgid());
+      test_assert(nbytes > 0 && nbytes <= (ssize_t)sizeof(gidmap));
+      test_assert(write(gidmap_fd, gidmap, nbytes) == nbytes);
+
+      close(parent_block[1]);
+
+      return 0;
+    }
+    close(child_block[0]);
+    close(parent_block[1]);
+
+    err = unshare(CLONE_NEWNET | CLONE_NEWUSER);
+
+    if (err == -1) {
+      test_assert(errno == EPERM);
+      atomic_printf("Skipping test because network namespaces are\n"
+                    "not available at this privilege level");
+      atomic_printf("EXIT-SUCCESS");
+      return 0;
+    }
+
+    close(child_block[1]);
+    // Wait until our child has made us root in this namespace;
+    test_assert(0 == read(parent_block[0], NULL, 1));
+    close(parent_block[0]);
+  }
+
+  /*
+   * For this test, we'll be manually doing the following:
+   * iptables -t nat -A POSTROUTING -s 10.0.0.0/24 -j MASQUERADE
+   */
+
+  int sock_fd = socket(AF_INET, SOCK_RAW, IPPROTO_RAW);
+  struct ipt_getinfo info;
+  memset(&info, 0, sizeof(info));
+  strcpy(info.name, "nat");
+  uint32_t getinfo_size = sizeof(info);
+  test_assert(
+      0 == getsockopt(sock_fd, SOL_IP, IPT_SO_GET_INFO, &info, &getinfo_size));
+  test_assert(getinfo_size == sizeof(info));
+
+  atomic_printf("%d existing entries in nat table\n", info.num_entries);
+
+  struct ipt_get_entries* entries =
+      malloc(sizeof(struct ipt_get_entries) + info.size);
+  strcpy(entries->name, "nat");
+  entries->size = info.size;
+  uint32_t getentries_size = sizeof(struct ipt_get_entries) + entries->size;
+  test_assert(0 == getsockopt(sock_fd, SOL_IP, IPT_SO_GET_ENTRIES, entries,
+                              &getentries_size));
+  test_assert(getentries_size == sizeof(struct ipt_get_entries) + info.size);
+
+  // matches will be empty
+  struct xt_entry_target target;
+  const char* target_name = "MASQUERADE";
+  target.u.user.target_size = strlen(target_name) - 1;
+  memcpy(target.u.user.name, target_name, strlen(target_name) - 1);
+
+  struct ipt_entry entry;
+  memset(&entry, 0, sizeof(struct ipt_entry));
+  entry.ip.src.s_addr = 0x10;
+  entry.ip.smsk.s_addr = 0xffffff;
+  entry.target_offset = 0x70;
+  entry.next_offset = 0x98;
+
+  // Allocate space to receive counters
+  struct xt_counters* counters =
+      malloc(sizeof(struct xt_counters) * info.num_entries);
+  // We will check for at least some of these bytes being replaced by the kernel
+  memset(counters, 0xff, sizeof(struct xt_counters) * info.num_entries);
+
+  struct ipt_replace repl;
+  strcpy(repl.name, "nat");
+  repl.num_entries = info.num_entries + 1;
+  repl.size = info.size + entry.next_offset;
+  memcpy(repl.hook_entry, info.hook_entry, sizeof(repl.hook_entry));
+  memcpy(repl.underflow, info.underflow, sizeof(repl.underflow));
+  repl.num_counters = info.num_entries;
+  repl.counters = counters;
+
+  size_t final_size = sizeof(struct ipt_replace) + repl.size;
+  char* final = malloc(final_size);
+
+  // Assemble structure
+  memcpy(final, &repl, sizeof(struct ipt_replace));
+
+  // Copy over original entries and insert our new one as the second-to-last one
+  char* src_ptr = (char*)entries->entrytable;
+  char* dest_ptr = (char*)((struct ipt_replace*)final)->entries;
+  for (size_t i = 0; i < info.num_entries; ++i) {
+    if (i == info.num_entries - 2) {
+      memcpy(dest_ptr, &entry, sizeof(struct ipt_entry));
+      dest_ptr += sizeof(struct ipt_entry);
+      memcpy(dest_ptr, &target, sizeof(struct xt_entry_target));
+      dest_ptr += sizeof(struct xt_entry_target);
+      size_t npad = entry.next_offset - sizeof(struct xt_entry_target);
+      memset(dest_ptr, 0, npad);
+      dest_ptr += npad;
+    }
+    struct ipt_entry* cur_entry = (struct ipt_entry*)src_ptr;
+    memcpy(dest_ptr, src_ptr, cur_entry->next_offset);
+    dest_ptr += cur_entry->next_offset;
+    src_ptr += cur_entry->next_offset;
+  }
+
+  // Finally pass this off to the kernel
+  test_assert(
+      setsockopt(sock_fd, SOL_IP, IPT_SO_SET_REPLACE, final, final_size));
+
+  // Verify that the counters array was overwritten. Since we don't know the
+  // exact value here, just make sure some bytes were written. After every byte
+  // comparison we also call getuid if they were not the same, which should
+  // catch any replay divergence, just from tick mismatch.
+  int any_changed = 0;
+  for (size_t i = 0; i < sizeof(struct xt_counters) * info.num_entries; ++i) {
+    if (((uint8_t*)entries)[i] != 0xff) {
+      any_changed = 1;
+      (void)getuid();
+    }
+  }
+
+  test_assert(any_changed);
+  atomic_printf("EXIT-SUCCESS");
+}

--- a/src/test/ppoll.c
+++ b/src/test/ppoll.c
@@ -26,13 +26,18 @@ int main(void) {
   test_assert(0 == sigemptyset(&sigset));
   test_assert(0 == sigaddset(&sigset, SIGCHLD));
 
+  uint64_t fake_sigset[10];
+  fake_sigset[0] =
+      (((uint64_t)1) << (SIGCHLD - 1)) | (((uint64_t)1) << (SIGPWR - 1));
+  memset(&fake_sigset[1], 0xab, 9 * sizeof(uint64_t));
+
   signal(SIGALRM, &handle_sig);
 
   pipe2(fds, O_NONBLOCK);
 
   pfd.fd = fds[0];
   pfd.events = POLLIN;
-  for (i = 0; i < NUM_ITERATIONS; ++i) {
+  for (i = 0; i < NUM_ITERATIONS; i++) {
     int ret;
 
     atomic_printf("iteration %d\n", i);
@@ -43,13 +48,27 @@ int main(void) {
       return 0;
     }
 
-    ret = ppoll(&pfd, 1, &t, &sigset);
+    sigset_t before_sigset;
+    ret = sigprocmask(SIG_BLOCK, NULL, &before_sigset);
+    test_assert(ret == 0);
+    test_assert(!sigismember(&before_sigset, SIGALRM));
+
+    t.tv_sec = 1;
+    t.tv_nsec = 0;
+
+    ret = syscall(SYS_ppoll, &pfd, 1, &t, &fake_sigset[0], sizeof(uint64_t));
     if (i % 2 == 0) {
       test_assert(ret == -1 && errno == EINTR);
     } else {
       test_assert(ret == 0);
     }
 
+    /* Validate that we did not clobber fake_sigset memory */
+    for (size_t i = 0; i < 9 * sizeof(uint64_t); ++i) {
+      test_assert(((uint8_t*)(&fake_sigset[1]))[i] == 0xab);
+    }
+
+    /* Validate that the signal mask got reset */
     sigset_t after_sigset;
     ret = sigprocmask(SIG_BLOCK, NULL, &after_sigset);
     test_assert(ret == 0);

--- a/src/test/prctl.c
+++ b/src/test/prctl.c
@@ -53,6 +53,11 @@ int main(void) {
 
   test_assert(0 == prctl(PR_GET_SECCOMP));
 
+  int reaper;
+  test_assert(0 == prctl(PR_SET_CHILD_SUBREAPER, 1));
+  test_assert(0 == prctl(PR_GET_CHILD_SUBREAPER, &reaper));
+  test_assert(reaper == 1);
+
   atomic_puts("EXIT-SUCCESS");
   return 0;
 }

--- a/src/test/tgkill.c
+++ b/src/test/tgkill.c
@@ -21,6 +21,11 @@ int main(void) {
 
   test_assert(2 == num_signals_caught);
 
+  syscall(SYS_tkill, sys_gettid(), SIGUSR1);
+  syscall(SYS_tkill, sys_gettid(), SIGUSR2);
+
+  test_assert(4 == num_signals_caught);
+
   atomic_puts("EXIT-SUCCESS");
   return 0;
 }

--- a/src/test/timer.c
+++ b/src/test/timer.c
@@ -88,10 +88,13 @@ int main(void) {
     // tests that no overruns occur, so we delete and recreate the timer.
     test_assert(0 == timer_delete(*id));
 
+    // Reset this before restarting the counter, to avoid causing a race
+    // condition.
+    caught_sig = 0;
+
     test_assert(0 == timer_create(clocks[i], NULL, id));
     test_assert(0 == timer_settime(*id, 0, &its, NULL));
 
-    caught_sig = 0;
     for (counter = 0; counter >= 0 && !caught_sig; counter++) {
       if (counter % 100000 == 0) {
         write(STDOUT_FILENO, ".", 1);


### PR DESCRIPTION
As always, see commit messages for details. The first one `dump -t` is a small feature to filter dump entries by tid. The others are various bug fixes and missing syscall coverage I ran into recently. I probably have a few more of those coming, but wanted to get these in to avoid diverging too much from upstream. It's already a little large. If you want me to split up the PR, let me know.