### PR TITLE
Usability improvements for pid namespaces/setuid binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -828,6 +828,7 @@ set(TESTS_WITH_PROGRAM
   ptrace_remote_unmap
   # Not called ps, because that interferes with using real 'ps' in tests
   rr_ps
+  rr_ps_ns
   read_big_struct
   restart_abnormal_exit
   reverse_continue_breakpoint
@@ -1048,9 +1049,11 @@ if(BUILD_TESTS)
   # This sucks but I can't find a better way to get CMake to build
   # the same source file in two different ways.
   if(rr_32BIT AND rr_64BIT)
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/test/rrutil.h"
-                   "${CMAKE_CURRENT_BINARY_DIR}/32/rrutil.h"
-                   COPYONLY)
+    foreach(header rrutil.h nsutils.h)
+      configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/test/${header}"
+                    "${CMAKE_CURRENT_BINARY_DIR}/32/${header}"
+                    COPYONLY)
+    endforeach(header)
 
     foreach(test ${BASIC_TESTS} ${TESTS_WITH_PROGRAM} cpuid test_lib)
       configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/test/${test}.c"

--- a/src/PsCommand.cc
+++ b/src/PsCommand.cc
@@ -126,7 +126,11 @@ static int ps(const string& trace_dir, FILE* out) {
     if (e.type() == TraceTaskEvent::CLONE &&
         !(e.clone_flags() & CLONE_THREAD)) {
       pid_t pid = tid_to_pid[e.tid()];
-      fprintf(out, "%d\t%d\t%d\t", e.tid(), tid_to_pid[e.parent_tid()],
+      fprintf(out, "%d", e.tid());
+      if (e.own_ns_tid() != e.tid()) {
+        fprintf(out, " (%d)", e.own_ns_tid());
+      }
+      fprintf(out, "\t%d\t%d\t", tid_to_pid[e.parent_tid()],
               find_exit_code(pid, events, i, tid_to_pid));
 
       ssize_t cmd_line_index = find_cmd_line(pid, events, i, tid_to_pid);

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1002,8 +1002,9 @@ RecordTask* RecordSession::revive_task_for_exec(pid_t rec_tid) {
 
   // Pretend the old task cloned a new task with the right tid, and then exited
   trace_writer().write_task_event(TraceTaskEvent::for_clone(
-      rec_tid, t->tid, CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND |
-                           CLONE_THREAD | CLONE_SYSVSEM));
+      rec_tid, t->tid, t->own_namespace_rec_tid,
+      CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD |
+          CLONE_SYSVSEM));
   trace_writer().write_task_event(
       TraceTaskEvent::for_exit(t->tid, WaitStatus::for_exit_code(0)));
 

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1652,6 +1652,12 @@ void RecordTask::set_tid_addr(remote_ptr<int> tid_addr) {
   tid_futex = tid_addr;
 }
 
+void RecordTask::update_own_namespace_tid() {
+  AutoRemoteSyscalls remote(this);
+  own_namespace_rec_tid =
+      remote.infallible_syscall(syscall_number_for_gettid(arch()));
+}
+
 void RecordTask::tgkill(int sig) {
   LOG(debug) << "Sending " << sig << " to tid " << tid;
   ASSERT(this, 0 == syscall(SYS_tgkill, real_tgid(), tid, sig));

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -487,6 +487,9 @@ public:
   void restore_sigmask_if_saved();
   void clear_saved_sigmask();
 
+  /* Retrieve the tid of this task from the tracee and store it */
+  void update_own_namespace_tid();
+
 private:
   ~RecordTask();
 

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -32,7 +32,7 @@ namespace rr {
 // MUST increment this version number.  Otherwise users' old traces
 // will become unreplayable and they won't know why.
 //
-#define TRACE_VERSION 68
+#define TRACE_VERSION 69
 
 struct SubstreamData {
   const char* name;
@@ -294,7 +294,7 @@ void TraceWriter::write_task_event(const TraceTaskEvent& event) {
   tasks << global_time << (char)event.type() << event.tid();
   switch (event.type()) {
     case TraceTaskEvent::CLONE:
-      tasks << event.parent_tid() << event.clone_flags();
+      tasks << event.parent_tid() << event.own_ns_tid() << event.clone_flags();
       break;
     case TraceTaskEvent::EXEC:
       tasks << event.file_name() << event.cmd_line() << event.fds_to_close();
@@ -317,7 +317,7 @@ TraceTaskEvent TraceReader::read_task_event() {
   r.type_ = (TraceTaskEvent::Type)type;
   switch (r.type()) {
     case TraceTaskEvent::CLONE:
-      tasks >> r.parent_tid_ >> r.clone_flags_;
+      tasks >> r.parent_tid_ >> r.own_ns_tid_ >> r.clone_flags_;
       break;
     case TraceTaskEvent::EXEC:
       tasks >> r.file_name_ >> r.cmd_line_ >> r.fds_to_close_;

--- a/src/TraceTaskEvent.h
+++ b/src/TraceTaskEvent.h
@@ -30,10 +30,11 @@ public:
 
   TraceTaskEvent(Type type = NONE, pid_t tid = 0) : type_(type), tid_(tid) {}
 
-  static TraceTaskEvent for_clone(pid_t tid, pid_t parent_tid,
+  static TraceTaskEvent for_clone(pid_t tid, pid_t parent_tid, pid_t own_ns_tid,
                                   uint64_t clone_flags) {
     TraceTaskEvent result(CLONE, tid);
     result.parent_tid_ = parent_tid;
+    result.own_ns_tid_ = own_ns_tid;
     result.clone_flags_ = clone_flags;
     return result;
   }
@@ -55,6 +56,10 @@ public:
   pid_t parent_tid() const {
     assert(type() == CLONE);
     return parent_tid_;
+  }
+  pid_t own_ns_tid() const {
+    assert(type() == CLONE);
+    return own_ns_tid_;
   }
   uint64_t clone_flags() const {
     assert(type() == CLONE);
@@ -89,6 +94,7 @@ private:
   Type type_;
   pid_t tid_;
   pid_t parent_tid_;                  // CLONE only
+  pid_t own_ns_tid_;                  // CLONE only
   uint64_t clone_flags_;              // CLONE only
   std::string file_name_;             // EXEC only
   std::vector<std::string> cmd_line_; // EXEC only

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1356,6 +1356,17 @@ struct BaseArch : public wordsize,
   // The corresponding header requires -fpermissive, which we don't pass. Skip
   // this check.
   // RR_VERIFY_TYPE(ipt_replace);
+
+  struct cap_header {
+    uint32_t version;
+    int pid;
+  };
+
+  struct cap_data {
+    uint32_t effective;
+    uint32_t permitted;
+    uint32_t inheritable;
+  };
 };
 
 struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {

--- a/src/test/netfilter.c
+++ b/src/test/netfilter.c
@@ -3,78 +3,12 @@
 #include "rrutil.h"
 #include <linux/netfilter_ipv4/ip_tables.h>
 
-static int open_proc_file(pid_t pid, const char* file, int mode) {
-  char path[100];
-  ssize_t n = snprintf(path, sizeof(path), "/proc/%d/%s", pid, file);
-  test_assert(n >= 0 && n < (ssize_t)sizeof(path));
-  int fd = open(path, mode);
-  test_assert(fd != -1);
-  return fd;
-}
+#include "nsutils.h"
 
 int main(void) {
-  int err = unshare(CLONE_NEWNET);
-  if (err == -1) {
-    // Try again using user namespace functionality
-    test_assert(errno == EPERM);
-
-    int child_block[2], parent_block[2];
-    pipe(child_block);
-    pipe(parent_block);
-
-    pid_t pid = getpid();
-    if (fork() == 0) {
-      close(child_block[1]);
-      close(parent_block[0]);
-
-      // This will block until the parent closes fds[1]
-      test_assert(0 == read(child_block[0], NULL, 1));
-      close(child_block[0]);
-
-      // Deny setgroups
-      int setgroups_fd = open_proc_file(pid, "setgroups", O_WRONLY);
-      char deny[] = "deny";
-      test_assert(write(setgroups_fd, deny, sizeof(deny)) == sizeof(deny));
-      close(setgroups_fd);
-
-      // Make us root
-      ssize_t nbytes;
-      int uidmap_fd = open_proc_file(pid, "uid_map", O_WRONLY);
-      test_assert(uidmap_fd != -1);
-      char uidmap[100];
-      nbytes = snprintf(uidmap, (ssize_t)sizeof(uidmap), "0\t%d\t1", getuid());
-      test_assert(nbytes > 0 && nbytes <= (ssize_t)sizeof(uidmap));
-      test_assert(write(uidmap_fd, uidmap, nbytes) == nbytes);
-      test_assert(uidmap_fd);
-
-      int gidmap_fd = open_proc_file(pid, "gid_map", O_WRONLY);
-      test_assert(gidmap_fd != -1);
-      char gidmap[100];
-      nbytes = snprintf(gidmap, (ssize_t)sizeof(gidmap), "0\t%d\t1", getgid());
-      test_assert(nbytes > 0 && nbytes <= (ssize_t)sizeof(gidmap));
-      test_assert(write(gidmap_fd, gidmap, nbytes) == nbytes);
-
-      close(parent_block[1]);
-
-      return 0;
-    }
-    close(child_block[0]);
-    close(parent_block[1]);
-
-    err = unshare(CLONE_NEWNET | CLONE_NEWUSER);
-
-    if (err == -1) {
-      test_assert(errno == EPERM);
-      atomic_printf("Skipping test because network namespaces are\n"
-                    "not available at this privilege level");
-      atomic_printf("EXIT-SUCCESS");
-      return 0;
-    }
-
-    close(child_block[1]);
-    // Wait until our child has made us root in this namespace;
-    test_assert(0 == read(parent_block[0], NULL, 1));
-    close(parent_block[0]);
+  if (!try_setup_ns(CLONE_NEWNET)) {
+    atomic_printf("EXIT-SUCCESS");
+    return 0;
   }
 
   /*

--- a/src/test/nsutils.h
+++ b/src/test/nsutils.h
@@ -1,0 +1,84 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#ifndef NSUTILS_H
+#define NSUTILS_H
+
+#include "rrutil.h"
+
+static int open_proc_file(pid_t pid, const char* file, int mode) {
+  char path[100];
+  ssize_t n = snprintf(path, sizeof(path), "/proc/%d/%s", pid, file);
+  test_assert(n >= 0 && n < (ssize_t)sizeof(path));
+  int fd = open(path, mode);
+  test_assert(fd != -1);
+  return fd;
+}
+
+static int try_setup_ns(int ns_kind) {
+  int err = unshare(ns_kind);
+  if (err == -1) {
+    // Try again using user namespace functionality
+    test_assert(errno == EPERM);
+
+    int child_block[2], parent_block[2];
+    pipe(child_block);
+    pipe(parent_block);
+
+    pid_t pid = getpid();
+    if (fork() == 0) {
+      close(child_block[1]);
+      close(parent_block[0]);
+
+      // This will block until the parent closes fds[1]
+      test_assert(0 == read(child_block[0], NULL, 1));
+      close(child_block[0]);
+
+      // Deny setgroups
+      int setgroups_fd = open_proc_file(pid, "setgroups", O_WRONLY);
+      char deny[] = "deny";
+      test_assert(write(setgroups_fd, deny, sizeof(deny)) == sizeof(deny));
+      close(setgroups_fd);
+
+      // Make us root
+      ssize_t nbytes;
+      int uidmap_fd = open_proc_file(pid, "uid_map", O_WRONLY);
+      test_assert(uidmap_fd != -1);
+      char uidmap[100];
+      nbytes = snprintf(uidmap, (ssize_t)sizeof(uidmap), "0\t%d\t1", getuid());
+      test_assert(nbytes > 0 && nbytes <= (ssize_t)sizeof(uidmap));
+      test_assert(write(uidmap_fd, uidmap, nbytes) == nbytes);
+      test_assert(uidmap_fd);
+
+      int gidmap_fd = open_proc_file(pid, "gid_map", O_WRONLY);
+      test_assert(gidmap_fd != -1);
+      char gidmap[100];
+      nbytes = snprintf(gidmap, (ssize_t)sizeof(gidmap), "0\t%d\t1", getgid());
+      test_assert(nbytes > 0 && nbytes <= (ssize_t)sizeof(gidmap));
+      test_assert(write(gidmap_fd, gidmap, nbytes) == nbytes);
+
+      close(parent_block[1]);
+
+      _exit(0);
+    }
+    close(child_block[0]);
+    close(parent_block[1]);
+
+    err = unshare(ns_kind | CLONE_NEWUSER);
+
+    if (err == -1) {
+      test_assert(errno == EPERM);
+      atomic_printf("Skipping test because namespaces are\n"
+                    "not available at this privilege level");
+      return -1;
+    }
+
+    close(child_block[1]);
+    // Wait until our child has made us root in this namespace;
+    test_assert(0 == read(parent_block[0], NULL, 1));
+    close(parent_block[0]);
+  }
+
+  return 0;
+}
+
+#endif // NSUTILS_H

--- a/src/test/rr_ps_ns.c
+++ b/src/test/rr_ps_ns.c
@@ -1,0 +1,23 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "nsutils.h"
+#include "rrutil.h"
+
+int main(void) {
+  pid_t pid;
+  if (try_setup_ns(CLONE_NEWPID)) {
+    atomic_printf("EXIT-SUCCESS");
+    // 77 will indicate to driver script that this test was skipped
+    return 77;
+  }
+
+  // This is the first child, therefore PID 1 in it's PID namespace
+  if ((pid = fork()) == 0) {
+    // We will check that rr ps includes `(1)` here
+    return 78;
+  }
+
+  test_assert(pid == waitpid(pid, NULL, 0));
+  atomic_printf("EXIT-SUCCESS");
+  return 79;
+}

--- a/src/test/rr_ps_ns.run
+++ b/src/test/rr_ps_ns.run
@@ -1,0 +1,15 @@
+source `dirname $0`/util.sh
+compare_test EXIT-SUCCESS
+
+if !(do_ps | grep -q $'\t77'); then
+    # If 77 shows up, the test was skipped. Since we're here, we should expect
+    # the parent exiting with 79, and the child (PID 1 in its namespace) exiting
+    # with 78
+    if !(do_ps | grep -q $'\t79'); then
+      failed "Can't find return value 79"
+    fi
+    
+    if !(do_ps | grep $'\t78' | cut -f 1 | grep -q $'(1)'); then
+      failed "Can't find child namespace init"
+    fi    
+fi

--- a/src/util.h
+++ b/src/util.h
@@ -276,6 +276,12 @@ inline void msan_unpoison(void* ptr, size_t n) {
  */
 void* xmalloc(size_t size);
 
+/**
+ * Determine if the given capabilities are a subset of the process' current
+ * active capabilities.
+ */
+bool has_effective_caps(uint64_t caps);
+
 } // namespace rr
 
 #endif /* RR_UTIL_H_ */


### PR DESCRIPTION
The first commit is fairly straightforward, just a bit big due to reorganization in the test code. It records new threads' pids with respect to their own PID namespace in the trace stream and prints those during `rr ps`.

The second commit makes working with privileged executables easier. I played with a couple of variants, but in the end came up with this, which is fairly simple and seems to work quite nicely. See commit message for details.