### PR TITLE
Handle sigmask=NULL in pselect

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -546,8 +546,9 @@ void RecordTask::on_syscall_exit_arch(int syscallno, const Registers& regs) {
       return;
     }
     case Arch::pselect6: {
-      remote_ptr<sig_set_t> setp = regs.arg6();
-      if (!setp.is_null()) {
+      remote_ptr<typename Arch::pselect6_arg6> setp = regs.arg6();
+      auto ss = REMOTE_PTR_FIELD(setp, ss);
+      if (!setp.is_null() && read_mem(ss)) {
         restore_sigmask();
       }
       return;

--- a/src/test/intr_pselect.c
+++ b/src/test/intr_pselect.c
@@ -31,6 +31,10 @@ int main(void) {
   atomic_puts("ignoring SIGALRM, going into pselect ...");
   test_assert(0 == pselect_pipe(2, &sigmask) && 0 == errno);
 
+  alarm(1);
+  atomic_puts("ignoring SIGALRM (sigmask=NULL), going into pselect ...");
+  test_assert(0 == pselect_pipe(2, NULL) && 0 == errno);
+
   /* Test that the signal mask is correct in rr when the SIGALRM is delivered */
   sigaddset(&sigmask, SIGCHLD);
 


### PR DESCRIPTION
After `pselect` returns, avoid restoring the sigmask if `sigmask=NULL`.
```
[FATAL /home/ted/Downloads/rr/rr/src/RecordTask.cc:1083:restore_sigmask() errno: SUCCESS] 
 (task 16743 (rec:16743) at time 5157)
 -> Assertion `has_previously_blocked_sigs' failed to hold. 
```
https://github.com/mozilla/rr/issues/1912
https://github.com/mozilla/rr/pull/1913