### PR TITLE
Work around kernel bug pwriting to PROT_READ thp

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -2088,6 +2088,9 @@ void Task::read_bytes_helper(remote_ptr<void> addr, ssize_t buf_size, void* buf,
  * that's PROT_NONE.
  * Also, writing through MAP_SHARED readonly mappings fails (even if the
  * file was opened read-write originally), so we handle that here too.
+ * Lastly, on kernels that have the DirtyCOW exploit mitigation patch,
+ * writes to PROT_READ, MAP_PRIVATE that cause COW hang the kernel, if backed by
+ * transparent huge pages, so handle that as well.
  */
 static ssize_t safe_pwrite64(Task* t, const void* buf, ssize_t buf_size,
                              remote_ptr<void> addr) {
@@ -2099,7 +2102,8 @@ static ssize_t safe_pwrite64(Task* t, const void* buf, ssize_t buf_size,
     if (m.map.prot() & PROT_WRITE) {
       continue;
     }
-    if (!(m.map.prot() & PROT_READ) || (m.map.flags() & MAP_SHARED)) {
+    if (!(m.map.prot() & PROT_READ) || (m.map.flags() & MAP_SHARED) ||
+          m.map.size() >= 2*1024*1024 /* Could be backed by thp */) {
       mappings_to_fix.push_back(m.map);
     }
   };


### PR DESCRIPTION
Kernels that have the DirtyCOW exploit mitigation patch (i.e. 4.9
and most stable kernels by now) will hang when trying to write to
a PROT_READ page that is backed by a transparent huge page and causes
a COW (which happens rather frequently for rr when it first sets up
a new address space). A kernel patch to fix this is pending at
http://marc.info/?l=linux-kernel&m=148359462917379&w=2, but until
then, we should avoid trying to pwrite to PROT_READ pages that may
be backed by transparent huge pages.