### PR TITLE
Fix sigframe size for KNL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -911,6 +911,7 @@ set(TESTS_WITHOUT_PROGRAM
   checkpoint_mmap_shared
   checkpoint_prctl_name
   checkpoint_simple
+  checksum_sanity_noclone
   cont_signal
   cpuid
   dead_thread_target

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -952,6 +952,7 @@ set(TESTS_WITHOUT_PROGRAM
   sanity
   shm_checkpoint
   siginfo
+  sigreturn_checksum
   signal_stop
   signal_checkpoint
   simple_script

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1220,23 +1220,20 @@ void RecordSession::signal_state_changed(RecordTask* t, StepState* step_state) {
 
         // It's somewhat difficult engineering-wise to
         // compute the sigframe size at compile time,
-        // and it can vary across kernel versions.  So
-        // this size is an overestimate of the real
-        // size(s).  The estimate was made by
-        // comparing $sp before and after entering the
-        // sighandler, for a sighandler that used the
-        // main task stack.  On linux 3.11.2, that
-        // computed size was 1736 bytes, which is an
-        // upper bound on the sigframe size.  We don't
-        // want to mess with this code much, so we
-        // overapproximate the overapproximation and
-        // round off to 2048.
+        // and it can vary across kernel versions and CPU
+        // microarchitectures. So this size is an overestimate
+        // of the real size(s).
         //
         // If this size becomes too small in the
         // future, and unit tests that use sighandlers
         // are run with checksumming enabled, then
         // they can catch errors here.
-        sigframe_size = 2048;
+        sigframe_size = 1152 /* Overestimate of kernel sigframe */ +
+                         128 /* Redzone */ +
+                        /* If xsave is available, the kernel uses it for the
+                           sigframe, otherwise it falls back to legacy methods,
+                           for which 512 should be sufficient */
+                        (xsave_area_size() ? xsave_area_size() : 512);
 
         t->ev().transform(EV_SIGNAL_HANDLER);
         t->signal_delivered(sig);

--- a/src/test/checksum_sanity_noclone.run
+++ b/src/test/checksum_sanity_noclone.run
@@ -1,0 +1,6 @@
+source `dirname $0`/util.sh
+GLOBAL_OPTIONS="$GLOBAL_OPTIONS --checksum=on-all-events"
+RECORD_ARGS="--no-read-cloning --no-file-cloning"
+record checksum_sanity$bitness
+replay
+check EXIT-SUCCESS

--- a/src/test/sigreturn_checksum.run
+++ b/src/test/sigreturn_checksum.run
@@ -1,0 +1,5 @@
+source `dirname $0`/util.sh
+GLOBAL_OPTIONS="$GLOBAL_OPTIONS --checksum=on-all-events"
+record sigreturn$bitness
+replay
+check EXIT-SUCCESS

--- a/src/util.cc
+++ b/src/util.cc
@@ -862,4 +862,26 @@ bool has_effective_caps(uint64_t caps) {
   return true;
 }
 
+unsigned int xsave_area_size() {
+  // 0 means XSAVE not detected
+  static unsigned int detected_xsave_area_size = 0;
+  static bool xsave_initialized = false;
+  if (xsave_initialized) {
+    return detected_xsave_area_size;
+  }
+  xsave_initialized = true;
+
+  auto cpuid_data = cpuid(CPUID_GETFEATURES, 0);
+  if (!(cpuid_data.ecx & (1 << 26))) {
+    // XSAVE not present
+    return detected_xsave_area_size;
+  }
+
+  // We'll use the largest possible area all the time
+  // even when it might not be needed. Simpler that way.
+  cpuid_data = cpuid(CPUID_GETXSAVE, 0);
+  detected_xsave_area_size = cpuid_data.ecx;
+  return detected_xsave_area_size;
+}
+
 } // namespace rr

--- a/src/util.h
+++ b/src/util.h
@@ -282,6 +282,11 @@ void* xmalloc(size_t size);
  */
 bool has_effective_caps(uint64_t caps);
 
+/**
+ * Determine the size of the xsave area
+ */
+unsigned int xsave_area_size();
+
 } // namespace rr
 
 #endif /* RR_UTIL_H_ */


### PR DESCRIPTION
See first commit. 2048 bytes is not enough to hold the sigframe on KNL (or other microarchitectures with AVX512). 

Additionally, something I forgot to add to the last PR, which is checksum_sanity, but with cloning force-disabled, to make sure to cover the corner cases of both code paths.