### PR TITLE
In async signal tests, wait for tracees to be ready

### DIFF
--- a/src/test/async_kill_with_threads.c
+++ b/src/test/async_kill_with_threads.c
@@ -3,6 +3,7 @@
 #include "rrutil.h"
 
 static void* start_thread(__attribute__((unused)) void* p) {
+  atomic_puts("ready");
   sleep(1000);
   return NULL;
 }

--- a/src/test/async_kill_with_threads_main_running.c
+++ b/src/test/async_kill_with_threads_main_running.c
@@ -10,6 +10,8 @@ static void* start_thread(__attribute__((unused)) void* p) {
 int main(void) {
   pthread_t thread;
 
+  atomic_puts("ready");
+
   pthread_create(&thread, NULL, start_thread, NULL);
   atomic_puts("EXIT-SUCCESS");
   while (1) {

--- a/src/test/async_kill_with_threads_thread_running.c
+++ b/src/test/async_kill_with_threads_thread_running.c
@@ -3,6 +3,7 @@
 #include "rrutil.h"
 
 static void* start_thread(__attribute__((unused)) void* p) {
+  atomic_puts("ready");
   while (1) {
   }
   return NULL;

--- a/src/test/async_segv.c
+++ b/src/test/async_segv.c
@@ -13,6 +13,8 @@ int main(void) {
 
   signal(SIGSEGV, handle_segv);
 
+  atomic_puts("ready");
+
   /* No syscalls after here!  (Up to the assert.) */
   for (i = 1; i < (1 << 30); ++i) {
     dummy += (dummy + i) % 9735;

--- a/src/test/async_signal_syscalls.c
+++ b/src/test/async_signal_syscalls.c
@@ -36,6 +36,8 @@ int main(int argc, char* argv[]) {
 
   signal(SIGUSR1, handle_usr1);
 
+  atomic_puts("ready\n");
+
   /* Driver scripts choose the number of iterations based on
    * their needs. */
   for (i = 0; i < 1 << num_its; ++i) {

--- a/src/test/async_usr1.c
+++ b/src/test/async_usr1.c
@@ -20,6 +20,8 @@ int main(void) {
 
   signal(SIGUSR1, handle_usr1);
 
+  atomic_puts("ready");
+
   breakpoint();
   /* NO SYSCALLS AFTER HERE!  (Up to the assert.) */
   for (i = 1; !caught_usr1 && i < (1 << 30); ++i) {

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -49,6 +49,12 @@ function delay_kill { sig=$1; delay_secs=$2; proc=$3
         exit 1
     fi
 
+    # Wait for the test to print "ready", indicating it has completed
+    # any required setup.
+    until grep -q ready record.out; do
+        sleep 0
+    done
+
     kill -s $sig $pid
     if [[ $? != 0 ]]; then
         # Sometimes we fail to deliver a signal to a process because


### PR DESCRIPTION
Some tracees need to set up signal handlers, etc. Fixes #1896