### PR TITLE
Make rr gdbinit use 'python' correctly.

### DIFF
--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -106,7 +106,7 @@ static const string& gdb_rr_macros() {
        << GdbCommandHandler::gdb_macros()
        // Try both "set target-async" and "maint set target-async" since
        // that changed recently.
-       << "python-interactive\n"
+       << "python\n"
        << "import re\n"
        << "m = re.compile("
        << "'.* ([0-9]+)\\.([0-9]+)(\\.([0-9]+))?.*'"
@@ -122,7 +122,8 @@ static const string& gdb_rr_macros() {
        << "\n"
        << "if ver < 71101:\n"
        << "    gdb.execute('set target-async 0')\n"
-       << "    gdb.execute('maint set target-async 0')\n";
+       << "    gdb.execute('maint set target-async 0')\n"
+       << "end\n";
     s = ss.str();
   }
   return s;


### PR DESCRIPTION
'python-interactive' is for interactive shells. You need to put 'end' at
the end.

This was messing up a script I use that uses rr in an automated way. Let me know if there was a reason the gdbinit was this way and I can figure out something else.