### PR TITLE
More Kabylake CPUID

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -157,6 +157,7 @@ static CpuMicroarch get_cpu_microarch() {
     case 0x50670:
       return IntelSilvermont;
     case 0x806e0:
+    case 0x906e0:
       return IntelKabylake;
     default:
       FATAL() << "CPU " << HEX(cpu_type) << " unknown.";


### PR DESCRIPTION
This is the CPUID returned by the new Xeon mobile processor.

Not all tests passes on this (most do) trying to get a list of failing tests now...
