### PR TITLE
Do not fail test if USER_NS is disabled in the kernel.

### DIFF
--- a/src/test/nsutils.h
+++ b/src/test/nsutils.h
@@ -89,7 +89,8 @@ static int try_setup_ns_internal(int ns_kind, int expect_to_be_root) {
     err = unshare(ns_kind | CLONE_NEWUSER);
 
     if (err == -1) {
-      test_assert(errno == EPERM);
+      // `EINVAL` is returned if the namespace is not supported/enabled.
+      test_assert(errno == EPERM || errno == EINVAL);
       atomic_puts("Skipping test because namespaces are\n"
                   "not available at this privilege level");
       return -1;


### PR DESCRIPTION
Thanks to @Keno . Supposedly this should fix most (all?) of the failing tests that I'm seeing.
Ref https://github.com/torvalds/linux/blob/99378fd26803328cbab64ae60fa98e1394d07a6d/include/linux/user_namespace.h#L123-L129
