### PR TITLE
tests: include sys/sysmacros.h for minor/major funcs

### DIFF
--- a/src/test/rrutil.h
+++ b/src/test/rrutil.h
@@ -76,6 +76,7 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/sysinfo.h>
+#include <sys/sysmacros.h>
 #include <sys/time.h>
 #include <sys/timerfd.h>
 #include <sys/times.h>


### PR DESCRIPTION
Newer versions of glibc are deprecating the implicit sys/sysmacros.h
include via sys/types.h, so include it explicitly.