### PR TITLE
Rename verify_not_option to improve clarity

### DIFF
--- a/src/Command.cc
+++ b/src/Command.cc
@@ -160,16 +160,16 @@ bool Command::parse_option(std::vector<std::string>& args,
   return false;
 }
 
-bool Command::verify_not_option(std::vector<std::string>& args) {
+bool Command::check_if_option(std::vector<std::string>& args) {
   if (args.size() > 0 && args[0][0] == '-') {
-    fprintf(stderr, "Invalid option %s\n", args[0].c_str());
-    return false;
+    return true;
   }
-  return true;
+  fprintf(stderr, "Invalid option %s\n", args[0].c_str());
+  return false;
 }
 
 bool Command::parse_optional_trace_dir(vector<string>& args, string* out) {
-  if (!verify_not_option(args)) {
+  if (check_if_option(args)) {
     return false;
   }
   if (args.size() > 0) {

--- a/src/Command.h
+++ b/src/Command.h
@@ -46,7 +46,7 @@ public:
   virtual int run(std::vector<std::string>& args) = 0;
   void print_help(FILE* out);
 
-  static bool verify_not_option(std::vector<std::string>& args);
+  static bool check_if_option(std::vector<std::string>& args);
   static bool parse_optional_trace_dir(std::vector<std::string>& args,
                                        std::string* out);
   static bool parse_option(std::vector<std::string>& args,

--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -440,7 +440,7 @@ int RecordCommand::run(vector<string>& args) {
     return 1;
   }
 
-  if (!verify_not_option(args) || args.size() == 0) {
+  if (check_if_option(args) || args.size() == 0) {
     print_help(stderr);
     return 1;
   }

--- a/src/main.cc
+++ b/src/main.cc
@@ -260,7 +260,7 @@ int main(int argc, char* argv[]) {
   if (command) {
     args.erase(args.begin());
   } else {
-    if (!Command::verify_not_option(args)) {
+    if (Command::check_if_option(args)) {
       print_usage(stderr);
       return 1;
     }


### PR DESCRIPTION
Renaming `verify_not_option` to `check_if_option` improves clarity
because we get to avoid double negative if-statements.