### PR TITLE
Drop unnecessary "move()" from await_connection()

### DIFF
--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1366,7 +1366,7 @@ static unique_ptr<GdbConnection> await_connection(
   auto dbg = unique_ptr<GdbConnection>(new GdbConnection(t->tgid(), features));
   dbg->set_cpu_features(get_cpu_features(t->arch()));
   dbg->await_debugger(listen_fd);
-  return move(dbg);
+  return dbg;
 }
 
 static void print_debugger_launch_command(Task* t, unsigned short port,


### PR DESCRIPTION
I'm building rr on Linux using Clang trunk from ~last week, and I'm getting this build warning (treated as an error):
````
rr/src/GdbServer.cc:1369:10: error: moving a local object in a return statement prevents copy elision [-Werror,-Wpessimizing-move]
  return move(dbg);
         ^
rr/rr/src/GdbServer.cc:1369:10: note: remove std::move call here
  return move(dbg);
         ^~~~~   ~
````

Source link:
https://github.com/mozilla/rr/blob/2e4fd448052aec5592871c82e1de500a3925aaeb/src/GdbServer.cc#L1364-L1369

Turns out the "move" wrapper here is unnecessary (and somewhat problematic for optimizations, as noted in the warning).  Easy fix: just drop the "move", as the compiler suggests.  It's fine to return unique_ptr by value -- see the sample function "pass_through" on http://en.cppreference.com/w/cpp/memory/unique_ptr