### PR TITLE
Save and restore Task::wait_status when performing a remote syscall.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -869,6 +869,7 @@ set(TESTS_WITH_PROGRAM
   step_thread
   string_instructions
   string_instructions_async_signals
+  string_instructions_async_signals_shared
   string_instructions_multiwatch
   string_instructions_replay
   string_instructions_watch

--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -242,6 +242,7 @@ private:
 
   Task* t;
   Registers initial_regs;
+  WaitStatus initial_wait_status;
   remote_code_ptr initial_ip;
   remote_ptr<void> initial_sp;
   remote_ptr<void> fixed_sp;

--- a/src/Task.h
+++ b/src/Task.h
@@ -486,6 +486,8 @@ public:
     return thread_areas_;
   }
 
+  void set_status(WaitStatus status) { wait_status = status; }
+
   /**
    * Return true when the task is running, false if it's stopped.
    */

--- a/src/test/string_instructions_async_signals_shared.c
+++ b/src/test/string_instructions_async_signals_shared.c
@@ -1,0 +1,80 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+
+/* This test is designed to trigger the following:
+   -- SCHED event targets the start of a string instruction
+   -- ReplaySession::advance_to sets an internal breakpoint at that string
+   instruction and runs to it, stopping at an execution of that instruction
+   before the SCHED point
+   -- advance_to does a fast_forward over the string instruction
+   -- because the string instruction is in a MAP_SHARED mapping, rr has to
+   inject an mprotect call to insert a breakpoint
+   -- AutoRemoteSyscalls clobbers Task::wait_status with the result of
+   waiting on the injected syscall
+   -- rr asserts because we're at an unexpected syscall stop */
+#define SIZE 256
+#define COUNT 8 * 256 * 256
+
+static char* p;
+static int ctr;
+static void* mapping;
+
+const uint8_t string_code[] = {
+  0xfc,       // CLD
+  0xf2, 0xae, // REPNZ SCAS %ES:(%RDI),%AL
+  0xc3,       // RET
+};
+
+static void* do_thread(__attribute__((unused)) void* p) {
+  while (1) {
+    sched_yield();
+  }
+  return NULL;
+}
+
+int main(void) {
+  int v;
+  pthread_t thread;
+
+  mapping = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+		 MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+  test_assert(mapping != NULL);
+
+  memcpy(mapping, string_code, sizeof(string_code));
+
+  v = mprotect(mapping, 4096, PROT_READ | PROT_EXEC);
+  test_assert(v == 0);
+
+  p = xmalloc(SIZE);
+
+  pthread_create(&thread, NULL, do_thread, NULL);
+
+  memset(p, 0, SIZE);
+  p[1] = 'a';
+
+  for (v = 0; v < COUNT; ++v) {
+    int ret;
+#if defined(__i386__) || defined(__x86_64__)
+    char* end;
+    __asm__("call *%5\n\t"
+            : "=D"(end)
+            : "a"('a'), "D"(p), "c"(SIZE), "b"(ctr), "m"(mapping));
+    ret = end - p - 1;
+#else
+    int i;
+    for (i = 0; i < SIZE; ++i) {
+      if (p[i] == 'a') {
+        ret = i;
+        break;
+      }
+    }
+#endif
+    ++ctr;
+    test_assert(ret == 1);
+  }
+
+  atomic_puts("EXIT-SUCCESS");
+
+  return 0;
+}

--- a/src/test/string_instructions_async_signals_shared.run
+++ b/src/test/string_instructions_async_signals_shared.run
@@ -1,0 +1,6 @@
+source `dirname $0`/util.sh
+
+RECORD_ARGS="-c1000"
+TIMEOUT=600
+compare_test EXIT-SUCCESS
+


### PR DESCRIPTION
But be careful not to restore it if the new wait_status is meaningful.
The call_exit tests will fail if we restore it unconditionally, because
the ptrace exit notification from the diversion session will be lost.
More generally, if a remote syscall were to trigger a signal or similar
we shouldn't squash that.

David Baron has a recording where a SCHED is being delivered to an ip
that contains a repeating string instruction (strlen). We fast forward
through the string instruction, but the remote syscalls triggered
by a kernel bug workaround (see #2005) clobber the expected SIGTRAP, and
when we continue searching for the context switch point rr asserts
because the tracee appears to be in an unexpected syscall (because its
wait_status is the remnant of a remote syscall).

Issue #2005 is going to remove the workaround, so this specific case will not
trigger this bug anymore, but lets not leave the footgun lying around.