### PR TITLE
Add option for persisting the debug server after detaching

### DIFF
--- a/src/GdbConnection.h
+++ b/src/GdbConnection.h
@@ -508,6 +508,11 @@ public:
    */
   void await_debugger(ScopedFd& listen_fd);
 
+  /**
+   *  Returns false if the connection has been closed
+  */
+  bool is_connection_alive();
+
 private:
   /**
    * read() incoming data exactly one time, successfully.  May block.
@@ -596,6 +601,7 @@ private:
   size_t packetend;            /* index of '#' character */
   std::vector<uint8_t> outbuf; /* buffered output for gdb */
   Features features_;
+  bool connection_alive_;
 };
 
 } // namespace rr

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1434,6 +1434,8 @@ void GdbServer::serve_replay(const ConnectionFlags& flags) {
     GdbRequest last_resume_request;
     while (debug_one_step(last_resume_request) == CONTINUE_DEBUGGING) {
     }
+
+    timeline.remove_breakpoints_and_watchpoints();
   } while (flags.keep_listening);
 
   LOG(debug) << "debugger server exiting ...";

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1046,7 +1046,9 @@ GdbServer::ContinueOrStop GdbServer::debug_one_step(
         return handle_exited_state(last_resume_request);
       }
     } else {
-      in_debuggee_end_state = false;
+      if (req.type != DREQ_DETACH) {
+        in_debuggee_end_state = false;
+      }
     }
     // Otherwise (e.g. detach, restart, interrupt or reverse-exec) process
     // the request as normal.

--- a/src/GdbServer.h
+++ b/src/GdbServer.h
@@ -38,8 +38,10 @@ public:
 
   struct ConnectionFlags {
     // -1 to let GdbServer choose the port, a positive integer to select a
-    // specific port to listen on.
+    // specific port to listen on. If keep_listening is on, wait for another
+    // debugger connection after the first one is terminated.
     int dbg_port;
+    bool keep_listening;
     // If non-null, then when the gdbserver is set up, we write its connection
     // parameters through this pipe. GdbServer::launch_gdb is passed the
     // other end of this pipe to exec gdb with the parameters.
@@ -48,7 +50,10 @@ public:
     // is null.
     std::string debugger_name;
 
-    ConnectionFlags() : dbg_port(-1), debugger_params_write_pipe(nullptr) {}
+    ConnectionFlags()
+        : dbg_port(-1),
+          keep_listening(false),
+          debugger_params_write_pipe(nullptr) {}
   };
 
   /**

--- a/src/ReplayCommand.cc
+++ b/src/ReplayCommand.cc
@@ -59,9 +59,10 @@ ReplayCommand ReplayCommand::singleton(
     "Emacs\n"
     "  -d, --debugger=<FILE>      use <FILE> as the gdb command\n"
     "  -q, --no-redirect-output   don't replay writes to stdout/stderr\n"
-    "  -s, --dbgport=<PORT>       only start a debug server on <PORT>;\n"
+    "  -s, --dbgport=<PORT>       only start a debug server on <PORT>,\n"
     "                             don't automatically launch the debugger\n"
-    "                             client too.\n"
+    "                             client; set PORT to 0 to automatically\n"
+    "                             probe a port\n"
     "  -k, --keep-listening       keep listening after detaching when using \n"
     "                             --dbgport (-s) mode\n"
     "  -t, --trace=<EVENT>        singlestep instructions and dump register\n"
@@ -193,7 +194,7 @@ static bool parse_replay_arg(vector<string>& args, ReplayFlags& flags) {
       flags.redirect = false;
       break;
     case 's':
-      if (!opt.verify_valid_int(1, INT32_MAX)) {
+      if (!opt.verify_valid_int(0, INT32_MAX)) {
         return false;
       }
       flags.dbg_port = opt.int_value;


### PR DESCRIPTION
I am opening a pull request for the progress made in #1990. I still haven't gotten around to writing tests for this, but I will very soon :-) I am mostly creating this pull request to be able use CI for my fork. In the mean time, this option has received a couple of weeks of actual testing "in the field" from me and I am happy to report that it has been really useful so far. I will let you know when I commit the tests.