### PR TITLE
Fix typo in GdbConnection.cc

### DIFF
--- a/src/GdbConnection.cc
+++ b/src/GdbConnection.cc
@@ -316,7 +316,7 @@ void GdbConnection::read_packet() {
     }
     checkedlen = inbuf.size();
     read_data_once();
-    if (connection_alive_) {
+    if (!connection_alive_) {
       return;
     }
   }


### PR DESCRIPTION
I was taking a look at my commits from some time ago and discovered this mistake.
We should bail if the connection is not alive anymore, not the other way around.

I am amazed that this typo did not break anything :-)