### PR TITLE
Support adjtimex syscall.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,6 +464,7 @@ set(BASIC_TESTS
   64bit_child
   _llseek
   accept
+  adjtimex
   alarm
   alarm2
   alsa_ioctl

--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -42,6 +42,7 @@
 #include <sys/sysinfo.h>
 #include <sys/time.h>
 #include <sys/times.h>
+#include <sys/timex.h>
 #include <sys/un.h>
 #include <sys/user.h>
 #include <sys/utsname.h>

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1422,6 +1422,43 @@ struct BaseArch : public wordsize,
     int32_t miimon;
   } ifbond;
   RR_VERIFY_TYPE(ifbond);
+
+  typedef struct timex {
+    int modes;
+    long offset;
+    long freq;
+    long maxerror;
+    long esterror;
+    int status;
+    long constant;
+    long precision;
+    long tolerance;
+    timeval time;
+    long tick;
+    long ppsfreq;
+    long jitter;
+    int shift;
+    long stabil;
+    long jitcnt;
+    long calcnt;
+    long errcnt;
+    long stbcnt;
+    int tai;
+
+    // Further padding bytes to allow for future expansion.
+    int : 32;
+    int : 32;
+    int : 32;
+    int : 32;
+    int : 32;
+    int : 32;
+    int : 32;
+    int : 32;
+    int : 32;
+    int : 32;
+    int : 32;
+  } timex;
+  RR_VERIFY_TYPE(timex);
 };
 
 struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1424,25 +1424,25 @@ struct BaseArch : public wordsize,
   RR_VERIFY_TYPE(ifbond);
 
   typedef struct timex {
-    int modes;
-    long offset;
-    long freq;
-    long maxerror;
-    long esterror;
+    unsigned int modes;
+    signed_long offset;
+    signed_long freq;
+    signed_long maxerror;
+    signed_long esterror;
     int status;
-    long constant;
-    long precision;
-    long tolerance;
+    signed_long constant;
+    signed_long precision;
+    signed_long tolerance;
     timeval time;
-    long tick;
-    long ppsfreq;
-    long jitter;
+    signed_long tick;
+    signed_long ppsfreq;
+    signed_long jitter;
     int shift;
-    long stabil;
-    long jitcnt;
-    long calcnt;
-    long errcnt;
-    long stbcnt;
+    signed_long stabil;
+    signed_long jitcnt;
+    signed_long calcnt;
+    signed_long errcnt;
+    signed_long stbcnt;
     int tai;
 
     // Further padding bytes to allow for future expansion.

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -639,7 +639,12 @@ setdomainname = EmulatedSyscall(x86=121, x64=171)
 uname = EmulatedSyscall(x86=122, x64=63, arg1="typename Arch::utsname")
 
 modify_ldt = IrregularEmulatedSyscall(x86=123, x64=154)
-adjtimex = UnsupportedSyscall(x86=124, x64=159)
+
+#  int adjtimex(struct timex *buf);
+#
+# adjtimex() takes a pointer to a timex structure, reads it, and returns
+# the same structure updated with the current kernel values.
+adjtimex = EmulatedSyscall(x86=124, x64=159, arg1="typename Arch::timex")
 
 #  int mprotect(const void *addr, size_t len, int prot)
 #

--- a/src/test/adjtimex.c
+++ b/src/test/adjtimex.c
@@ -1,0 +1,22 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "rrutil.h"
+#include <sys/timex.h>
+#include <time.h>
+
+int main(void) {
+  struct timex tx;
+  memset(&tx, 0, sizeof(tx));
+  test_assert(-1 != adjtimex(&tx));
+
+  struct timespec ts;
+  memset(&ts, 0, sizeof(ts));
+
+  test_assert(0 == clock_gettime(CLOCK_REALTIME, &ts));
+
+  // Verify that adjtimex() and clock_gettime() return roughly the same time.
+  test_assert(abs(tx.time.tv_sec - ts.tv_sec) <= 1);
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
This pull request adds support of [adjtimer syscall](http://man7.org/linux/man-pages/man2/adjtimex.2.html). It is fairly trivial since it only requires updating `adjtimex` to be `EmulatedSyscall` in syscalls.py and defining `timex` structure this syscall uses.

Related to #1053.