### PR TITLE
[RFC] Test for get_mempolicy outparams

### DIFF
--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -1336,7 +1336,7 @@ fadvise64_64 = EmulatedSyscall(x86=272)
 
 vserver = InvalidSyscall(x86=273, x64=236)
 mbind = EmulatedSyscall(x86=274, x64=237)
-get_mempolicy = EmulatedSyscall(x86=275, x64=239)
+get_mempolicy = EmulatedSyscall(x86=275, x64=239, arg1="signed int", arg2="typename Arch::unsigned_long")
 set_mempolicy = EmulatedSyscall(x86=276, x64=238)
 
 mq_open = EmulatedSyscall(x86=277, x64=240)

--- a/src/test/numa.c
+++ b/src/test/numa.c
@@ -39,11 +39,21 @@ int main(void) {
   ret = mbind(p, 16 * page_size, MPOL_PREFERRED, NULL, 0, MPOL_MF_MOVE);
   test_assert(ret == 0 || (ret == -1 && errno == ENOSYS));
 
+  // sanity check
   ret = set_mempolicy(0, NULL, 0);
   test_assert(ret == 0);
-
   ret = get_mempolicy(NULL, NULL, 0, NULL, 0);
   test_assert(ret == 0);
+
+  // test in and out params
+  unsigned long nodemask = 0x1;
+  ret = set_mempolicy(MPOL_BIND, &nodemask, 8 * sizeof(nodemask));
+  test_assert(ret == 0);
+  int mode;
+  nodemask = 0xABCD;
+  ret = get_mempolicy(&mode, &nodemask, 8 * sizeof(nodemask), NULL, 0);
+  test_assert(mode == MPOL_BIND);
+  test_assert(nodemask == 0x1);
 
   atomic_puts("EXIT-SUCCESS");
   return 0;


### PR DESCRIPTION
Follow up to #2030. Running this test alone (ie `./obj/bin/numa`) works just fine. Inside the test harness, however, it fails with the following error. I'm not sure what to make of it. Could some more experienced comment?

```
$  bash basic_test.run numa
./util.sh: line 236: 23261 Aborted                 (core dumped) _RR_TRACE_DIR="$workdir" test-monitor $TIMEOUT replay.err rr $GLOBAL_OPTIONS replay -a $replayflags > replay.out 2> replay.err
Test 'numa' FAILED: : error during replay:
--------------------------------------------------
process 23262 sent SIGURG
====== /proc/23262/status
Name:   rr
Umask:  0022
State:  S (sleeping)
Tgid:   23262
Ngid:   0
Pid:    23262
PPid:   23261
TracerPid:      0
Uid:    1000    1000    1000    1000
Gid:    100     100     100     100
FDSize: 64
Groups: 10 100
NStgid: 23262
NSpid:  23262
NSpwarning: unable to open /proc file '/proc/23260/task/23260/maps'
warning: remote target does not support file transfer, attempting to access files from local filesystem.
warning: Could not load shared library symbols for linux-vdso.so.1.
Do you need "set solib-search-path" or "set sysroot"?
[FATAL /home/dxu/dev/rr/rr/src/log.cc:339:emergency_debug() errno: SUCCESS] Can't resume execution from invalid state
000
ShdPnd: 0000000000000000
SigBlk: 0000000000000000
SigIgn: 0000000000000000
SigCgt: 0000000180002000
CapInh: 0000000000000000
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapBnd: 0000003fffffffff
CapAmb: 0000000000000000
NoNewPrivs:     0
Seccomp:        0
Cpus_allowed:   8
Cpus_allowed_list:      3
Mems_allowed:   00000000,00000001
Mems_allowed_list:      0
voluntary_ctxt_switches:        2
nonvoluntary_ctxt_switches:     350
====== /proc/23262/stack
[<ffffffff815647e0>] inet_csk_accept+0x310/0x350
[<ffffffff8159665c>] inet_accept+0x3c/0x150
[<ffffffff814f72e9>] SyS_accept4+0xf9/0x200
[<ffffffff814f7400>] SyS_accept+0x10/0x20
[<ffffffff81631d37>] entry_SYSCALL_64_fastpath+0x1a/0xa9
[<ffffffffffffffff>] 0xffffffffffffffff
====== /proc/23263/status
Name:   rr:numa-zYB6Lk0
Umask:  0022
State:  t (tracing stop)
Tgid:   23263
Ngid:   0
Pid:    23263
PPid:   23262
TracerPid:      23262
Uid:    1000    1000    1000    1000
Gid:    100     100     100     100
FDSize: 1024
Groups: 10 100
NStgid: 23263
NSpid:  23263
NSpgid: 23263
NSsid:  23263
VmPeak:    15744 kB
VmSize:    15744 kB
VmLck:         0 kB
VmPin:         0 kB
VmHWM:      3176 kB
VmRSS:      3176 kB
RssAnon:            2340 kB
RssFile:             832 kB
RssShmem:              4 kB
VmData:     2356 kB
VmStk:         0 kB
VmExe:         4 kB
VmLib:      2096 kB
VmPTE:        52 kB
VmPMD:        16 kB
VmSwap:        0 kB
HugetlbPages:          0 kB
Threads:        1
SigQ:   0/31109
SigPnd: 0000000000000000
ShdPnd: 0000000000000000
SigBlk: 0000000000000000
SigIgn: 0000000000010000
SigCgt: 0000000000000000
CapInh: 0000000000000000
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapBnd: 0000003fffffffff
CapAmb: 0000000000000000
NoNewPrivs:     1
Seccomp:        0
Cpus_allowed:   8
Cpus_allowed_list:      3
Mems_allowed:   00000000,00000001
Mems_allowed_list:      0
voluntary_ctxt_switches:        350
nonvoluntary_ctxt_switches:     0
====== /proc/23263/stack
[<ffffffff81090f16>] ptrace_stop+0x166/0x290
[<ffffffff810910d6>] ptrace_do_notify+0x96/0xc0
[<ffffffff8109221b>] ptrace_notify+0x5b/0x80
[<ffffffff810036d4>] syscall_slow_exit_work+0x74/0x170
[<ffffffff81003bc6>] do_syscall_64+0xb6/0xc0
[<ffffffff81631deb>] entry_SYSCALL64_slow_path+0x25/0x25
[<ffffffffffffffff>] 0xffffffffffffffff
====== gdb -p 23262 -ex 'set confirm off' -ex 'set height 0' -ex 'thread apply all bt' -ex q 2>&1
GNU gdb (GDB) 7.12.1
Copyright (C) 2017 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word".
Attaching to process 23262
ptrace: Operation not permitted.
====== gdb '-l' '10000' '-ex' 'target extended-remote :23263' -ex 'set confirm off' -ex 'set height 0' -ex 'info registers' -ex 'thread apply all bt' -ex q /tmp/rr-test-numa-zYB6Lk0GD/numa-zYB6Lk0GD-0/mmap_hardlink_3_numa-zYB6Lk0GD
 2>&1
GNU gdb (GDB) 7.12.1
Copyright (C) 2017 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
and "show warranty" for details.
This GDB was configured as "x86_64-pc-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
<http://www.gnu.org/software/gdb/documentation/>.
For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /tmp/rr-test-numa-zYB6Lk0GD/numa-zYB6Lk0GD-0/mmap_hardlink_3_numa-zYB6Lk0GD...done.
Remote debugging using :23263
Reading symbols from /home/dxu/dev/rr/obj/bin/../lib/rr/librrpreload.so...done.
Reading symbols from /usr/lib/librt.so.1...(no debugging symbols found)...done.
Reading symbols from /usr/lib/libdl.so.2...(no debugging symbols found)...done.
Reading symbols from /usr/lib/libpthread.so.0...(no debugging symbols found)...done.
Reading symbols from /usr/lib/libc.so.6...(no debugging symbols found)...done.
Reading symbols from /lib64/ld-linux-x86-64.so.2...(no debugging symbols found)...done.
0x00007f929418fefe in __write_nocancel () from /usr/lib/libpthread.so.0
rax            0x1      1
rbx            0x7f9293f431b4   140267524207028
rcx            0xffffffffffffffff       -1
rdx            0x1a     26
rsi            0x7ffc9d70d9c0   140722949904832
rdi            0x1      1
rbp            0x7ffc9d70de90   0x7ffc9d70de90
rsp            0x7ffc9d70d9a8   0x7ffc9d70d9a8
r8             0x7f9293f431b4   140267524207028
r9             0x1a     26
r10            0x5b     91
r11            0x246    582
r12            0x4006d0 4196048
r13            0x7ffc9d70dfe0   140722949906400
r14            0x0      0
r15            0x0      0
rip            0x7f929418fefe   0x7f929418fefe <__write_nocancel+5>
eflags         0x246    [ PF ZF IF ]
cs             0x33     51
ss             0x2b     43
ds             0x0      0
es             0x0      0
fs             0x0      0
gs             0x0      0
fs_base        0x7f9294bcce80   0x7f9294bcce80
gs_base        0x0      0x0

Thread 1 (Thread 23260.23260):
#0  0x00007f929418fefe in __write_nocancel () from /usr/lib/libpthread.so.0
#1  0x0000000000400891 in atomic_printf (fmt=0x400d0c "FAILED: errno=%d (%s)\n")
    at /home/dxu/dev/rr/rr/src/test/rrutil.h:140
#2  0x00000000004008f5 in check_cond (cond=0) at /home/dxu/dev/rr/rr/src/test/rrutil.h:158
#3  0x0000000000400c1f in main () at /home/dxu/dev/rr/rr/src/test/numa.c:55
Detaching from program: /tmp/rr-test-numa-zYB6Lk0GD/numa-zYB6Lk0GD-0/mmap_hardlink_3_numa-zYB6Lk0GD, process 23260
--------------------------------------------------
replay.out:
--------------------------------------------------
--------------------------------------------------
Test numa failed, leaving behind /tmp/rr-test-numa-zYB6Lk0GD
To replay the failed test, run
  _RR_TRACE_DIR=/tmp/rr-test-numa-zYB6Lk0GD rr replay
```