### PR TITLE
Fix compilation error on GCC 7

### DIFF
--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -14,6 +14,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <functional>
 
 #include "preload/preload_interface.h"
 

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -1269,6 +1269,7 @@ static void rep_process_syscall_arch(ReplayTask* t, ReplayTraceStep* step,
         }
       }
     }
+      RR_FALLTHROUGH;
 
     case Arch::recvmsg:
     case Arch::recvmmsg:

--- a/src/test/overflow_branch_counter.c
+++ b/src/test/overflow_branch_counter.c
@@ -14,8 +14,8 @@ void catcher(__attribute__((unused)) int signum,
 
 int main(void) {
   struct sigaction sact;
-  long long counter = 0;
-  long long counter2 = 0;
+  long counter = 0;
+  long counter2 = 0;
 
   sigemptyset(&sact.sa_mask);
   sact.sa_flags = SA_SIGINFO;
@@ -45,7 +45,7 @@ int main(void) {
 #endif
 
   atomic_printf("Signal %d caught, Counter is %lld\n", caught_sig,
-                counter + (counter2 << 32));
+                counter + (((long long)counter2) << 32));
   test_assert(SIGALRM == caught_sig);
 
   breakpoint();

--- a/src/util.h
+++ b/src/util.h
@@ -17,6 +17,24 @@
 #ifndef __has_attribute
 #define __has_attribute(x) 0
 #endif
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(x) 0
+#endif
+
+/// RR_FALLTHROUGH - Mark fallthrough cases in switch statements.
+#if defined(__cplusplus) && __cplusplus > 201402L && __has_cpp_attribute(fallthrough)
+#define RR_FALLTHROUGH [[fallthrough]]
+#elif !__cplusplus
+// Workaround for llvm.org/PR23435, since clang 3.6 and below emit a spurious
+// error when __has_cpp_attribute is given a scoped attribute in C mode.
+#define RR_FALLTHROUGH
+#elif __has_cpp_attribute(clang::fallthrough)
+#define RR_FALLTHROUGH [[clang::fallthrough]]
+#elif defined(__GNUC__) && __GNUC__ >= 7
+#define RR_FALLTHROUGH __attribute__((fallthrough))
+#else
+#define RR_FALLTHROUGH
+#endif
 
 namespace rr {
 


### PR DESCRIPTION
* `#include <functional>` explicitly for `std::function`
* Use correctly sized variable in assembly
* Suppress fallthrough warnings