### PR TITLE
Use labs() in adjtimex.c to avoid clang warning

### DIFF
--- a/src/test/adjtimex.c
+++ b/src/test/adjtimex.c
@@ -15,7 +15,7 @@ int main(void) {
   test_assert(0 == clock_gettime(CLOCK_REALTIME, &ts));
 
   // Verify that adjtimex() and clock_gettime() return roughly the same time.
-  test_assert(abs(tx.time.tv_sec - ts.tv_sec) <= 1);
+  test_assert(labs(tx.time.tv_sec - ts.tv_sec) <= 1);
 
   atomic_puts("EXIT-SUCCESS");
   return 0;


### PR DESCRIPTION
This fixes #2038. On my 64-bit Ubuntu machine, clang trunk (version 5.0.0 from svn revision 304217) spams a `-Wabsolute-value`  warning for an abs() call in adjtimex.c (getting the absolute value of the difference between two time_t values).  Clang suggests using labs() instead, since on that compiler/platform, this time_t subtraction produces a 'long' rather than an 'int'.  This pull request accepts that suggestion from clang.