### PR TITLE
Detect misconfigured environment as a first test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1016,6 +1016,11 @@ set(TESTS_WITHOUT_PROGRAM
 )
 
 if(BUILD_TESTS)
+  add_test(check_environment
+      bash ${CMAKE_SOURCE_DIR}/src/test/check_environment_test.run)
+  set_tests_properties(check_environment
+      PROPERTIES FAIL_REGULAR_EXPRESSION "rr needs /proc/sys/kernel/perf_event_paranoid <= 1")
+
   foreach(test ${BASIC_TESTS} ${TESTS_WITH_PROGRAM})
     add_executable(${test} src/test/${test}.c)
     post_build_executable(${test})

--- a/src/test/check_environment_test.run
+++ b/src/test/check_environment_test.run
@@ -1,0 +1,5 @@
+paranoid=`cat /proc/sys/kernel/perf_event_paranoid`
+if [ $paranoid -gt 1 ]; then
+	echo "rr needs /proc/sys/kernel/perf_event_paranoid <= 1, but it is $paranoid."
+	exit 1
+fi


### PR DESCRIPTION
Without that all tests fail without clear indication what happened. I had to look at the source to find out what's going on.
