### PR TITLE
Fix release build

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -323,7 +323,7 @@ static void check_for_xen_pmi_bug() {
     asm volatile(
 #if defined(__x86_64__)
         "mov %[_SYS_ioctl], %%rax;"
-        "mov %[raw_fd], %%rdi;"
+        "mov %[raw_fd], %%edi;"
         "xor %%rdx, %%rdx;"
         "mov %[_PERF_EVENT_IOC_ENABLE], %%rsi;"
         "syscall;"


### PR DESCRIPTION
`raw_fd` is 4bytes so the target register needs to be 4bytes too.

Triggered by https://github.com/mozilla/rr/commit/6b62b15f94ef975ea0f7efba95b2f7d4acc5a6fd#diff-af3b638bc2a3e6c650974192a53c7291L47 on GCC 7.1, not sure why. Maybe something got optimized out before?
