### PR TITLE
Use syscall directly in test.

### DIFF
--- a/src/test/seccomp.c
+++ b/src/test/seccomp.c
@@ -168,7 +168,8 @@ int main(void) {
   test_assert(1 == read(pipe_fds[0], &ch, 1));
 
   test_assert(syscall(SYS_geteuid) == 42);
-  open("/dev/null", O_RDONLY);
+  /* Use syscall directly since glibc 2.26 uses SYS_openat to implement open. */
+  syscall(SYS_open, "/dev/null", O_RDONLY);
   test_assert(count_SIGSYS == 2);
 
   atomic_puts("SUCCESS");


### PR DESCRIPTION
Starting with glibc 2.26, it uses SYS_openat to implement open.

This fixes a test failure on fedora 27.