### PR TITLE
Use syscall directly in another test.

### DIFF
--- a/src/test/seccomp_sigsys_sigtrap.c
+++ b/src/test/seccomp_sigsys_sigtrap.c
@@ -61,7 +61,8 @@ int main(void) {
   install_filter();
 
   /* Test SIGSYS for a buffered syscall */
-  test_assert(open("/dev/null", O_RDONLY) == 42);
+  /* Use syscall directly since glibc 2.26 uses SYS_openat to implement open. */
+  test_assert(syscall(SYS_open, "/dev/null", O_RDONLY) == 42);
 
   atomic_puts("EXIT-SUCCESS");
 


### PR DESCRIPTION
Starting with glibc 2.26, it uses SYS_openat to implement open.

This fixes a test failure on fedora 27.