### PR TITLE
Sleep before gdb_rr.close.

### DIFF
--- a/src/test/util.py
+++ b/src/test/util.py
@@ -69,6 +69,9 @@ def clean_up():
     iterations = 0
     while gdb_rr:
         try:
+            # FIXME: without this sleep python freezes instead of exiting.
+            # The sleep has to be before BufferedRWPair.close()
+            time.sleep(0.1)
             gdb_rr.close(force=1)
             gdb_rr = None
         except Exception, e:


### PR DESCRIPTION
It is not clear why, but we have to sleep before
BufferedRWPair.close() (which is called from gdb_rr.close). If we
don't, python freezes instead of exiting.