### PR TITLE
Fixes rare case where continue_or_step() could overshoot a tick_target

### DIFF
--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -552,6 +552,7 @@ void ReplaySession::continue_or_step(ReplayTask* t,
   } else {
     while (true) {
       t->resume_execution(resume_how, RESUME_WAIT, tick_request);
+      Ticks ticks_left = constraints.ticks_target - t->tick_count();
       if (t->stop_sig() == 0) {
         auto type = AddressSpace::rr_page_syscall_from_exit_point(t->ip());
         if (type && type->traced == AddressSpace::UNTRACED) {
@@ -571,6 +572,8 @@ void ReplaySession::continue_or_step(ReplayTask* t,
           // is not fast anyway.)
           perform_interrupted_syscall(t);
         }
+      } else if (ticks_left <= PerfCounters::skid_size()) {
+        break;
       } else if (handle_unrecorded_cpuid_fault(t, constraints)) {
         // Just continue
       } else {


### PR DESCRIPTION
## Overview
This pull request fixes a rare case where `continue_or_step()` was overshooting its given `constraints.ticks_target`. This issue was identified as result of the following stack trace during `reverse-continue`:

```
(rr) reverse-continue
Continuing.
[FATAL /home/doom/rr_dev/rr/src/ReplayTimeline.cc:438:replay_step_to_mark()]
 (task 117349 (rec:1693) at time 32)
 -> Assertion `t->tick_count() < mark.ptr->proto.key.ticks' failed to hold.
=== Start rr backtrace:
./bin/rr(_ZN2rr13dump_rr_stackEv+0x2d)[0x5400ed]
./bin/rr(_ZN2rr9GdbServer15emergency_debugEPNS_4TaskE+0x1cd)[0x47d6ed]
./bin/rr(_ZN2rr21EmergencyDebugOstreamD1Ev+0x18a)[0x4894ea]
./bin/rr(_ZN2rr14ReplayTimeline19replay_step_to_markERKNS0_4MarkERNS0_24ReplayStepToMarkStrategyE+0x517)[0x4ff7c7]
./bin/rr(_ZN2rr14ReplayTimeline16reverse_continueERKSt8functionIFbPNS_10ReplayTaskEEERKS1_IFbvEE+0xb60)[0x503880]
./bin/rr(_ZN2rr9GdbServer14debug_one_stepERNS_10GdbRequestE+0xa70)[0x479ed0]
./bin/rr(_ZN2rr9GdbServer12serve_replayERKNS0_15ConnectionFlagsE+0x64b)[0x47b48b]
./bin/rr(_ZN2rr13ReplayCommand3runERSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EE+0x1ae2)[0x4e4202]
./bin/rr(main+0x2ee)[0x54626e]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7fedbd1de830]
./bin/rr(_start+0x29)[0x439d79]
=== End rr backtrace
```

Specifically, the assert can be seen in the snippet of code below:
https://github.com/mozilla/rr/blob/67c9d90dc28dd5c8da8dff91563e5b227cee8af4/src/ReplayTimeline.cc#L432-L438

The testcase failed the assert due to the fact that `t->tick_count()` == `mark.ptr->proto.key.ticks`. This means the given task (`t`) was replayed to the same point as the given time `mark`, when it should have stopped 1 tick prior.

## Root Cause

The root cause can be attributed to the loop below as found in `ReplaySession::continue_or_step()`

https://github.com/mozilla/rr/blob/67c9d90dc28dd5c8da8dff91563e5b227cee8af4/src/ReplaySession.cc#L553-L580

During replay, it appears that we can get stuck in this loop without paying any respect to the given `constraints.ticks_target` as we should be.

There needs to be an additional break condition of some sort in this loop.

## Suggested Fix

The suggested fix adds a condition to the loop that will break when the task is approaching the target tick count, allowing the task to be walked in for the remainder of the replay event.

## Testcase

I am not sure how practical it would be to create a testcase that reliably produces this behavior. But for posterity, I have uploaded a copy of the binary + trace I took that manifests this condition: [tetstcase.zip](https://github.com/mozilla/rr/files/1425240/tetstcase.zip)

Load the trace and use the commands below:

```start
b * 0x80595E4
continue
reverse-continue
```

This asciinema demonstrates example usage: https://asciinema.org/a/lFCeRCI8naVlqyuRlZKBnAXxJ




