### PR TITLE
[build] Use env to improve portability on other systems.

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Helper to make |./configure && make| do what you expect.
 cmake .


### PR DESCRIPTION
FreeBSD, for example, has no bash in the default installation,
and when it's installed, it resides in /usr/local/bin.

This is the first of a series of patches to port `rr` to FreeBSD.