### PR TITLE
[Chaosutil] Define linux-only headers under __linux__.

### DIFF
--- a/src/chaos-test/chaosutil.h
+++ b/src/chaos-test/chaosutil.h
@@ -14,7 +14,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
+
+#ifdef __linux__
 #include <sys/user.h>
+#endif
+
 #include <time.h>
 #include <unistd.h>
 


### PR DESCRIPTION
This is a nop for Linux builds, but improves portability to other
systems. In particular, on FreeBSD, sys/user is a kernel only header
that causes preprocessor time errors if used in userland.

cc: @rocallahan 
cc: @sfwhittaker
cc: @espindola 