### PR TITLE
[chaos-test] Use sysconf(_SC_PAGE_SIZE) instead of PAGE_SIZE.

### DIFF
--- a/src/chaos-test/chaosutil.h
+++ b/src/chaos-test/chaosutil.h
@@ -80,4 +80,8 @@ inline static double now_double(void) {
   return ts.tv_sec + ts.tv_nsec / 1000000000.0;
 }
 
+inline static long get_page_size(void) {
+  return sysconf(_SC_PAGE_SIZE);
+}
+
 #endif

--- a/src/chaos-test/mmap_adjacent.c
+++ b/src/chaos-test/mmap_adjacent.c
@@ -7,21 +7,21 @@
 
 int main(__attribute__((unused)) int argc, char** argv) {
   int page_count = atoi(argv[1]);
-  char* p1 = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  char* p1 = mmap(NULL, get_page_size(), PROT_READ | PROT_WRITE,
                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   char* p2;
   int i;
 
   for (i = 0; i < page_count - 2; ++i) {
-    char* p = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+    char* p = mmap(NULL, get_page_size(), PROT_READ | PROT_WRITE,
                    MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
     test_assert(p != MAP_FAILED);
   }
 
-  p2 = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  p2 = mmap(NULL, get_page_size(), PROT_READ | PROT_WRITE,
             MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
 
-  if (p2 + PAGE_SIZE == p1) {
+  if (p2 + get_page_size() == p1) {
     caught_test_failure("maps are adjacent: %p %p", p2, p1);
   }
 

--- a/src/chaos-test/mmap_bits.c
+++ b/src/chaos-test/mmap_bits.c
@@ -8,14 +8,14 @@
 
 int main(__attribute__((unused)) int argc, char** argv) {
   int bits_match = atoi(argv[1]);
-  char* p1 = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  char* p1 = mmap(NULL, get_page_size(), PROT_READ | PROT_WRITE,
                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
-  char* p2 = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  char* p2 = mmap(NULL, get_page_size(), PROT_READ | PROT_WRITE,
                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   intptr_t delta = p2 - p1;
   intptr_t mask = ((1 << bits_match) - 1) << 12;
 
-  test_assert(PAGE_SIZE == (1 << 12));
+  test_assert(get_page_size() == (1 << 12));
   test_assert(p1 != MAP_FAILED);
   test_assert(p2 != MAP_FAILED);
 


### PR DESCRIPTION
The former is the POSIX way of handling this.

cc: @rocallahan 
cc: @sfwhittaker
cc: @espindola 