### PR TITLE
[kernel-abi] Don't use a reserved keyword.

### DIFF
--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1036,7 +1036,7 @@ struct BaseArch : public wordsize,
     ptr<size_t> oldlenp;
     ptr<void> newval;
     ptr<size_t> newlen;
-    unsigned_long __unused[4];
+    unsigned_long __rr_unused[4];
   };
   RR_VERIFY_TYPE(__sysctl_args);
 
@@ -1830,7 +1830,7 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
     struct timespec st_atim;
     struct timespec st_mtim;
     struct timespec st_ctim;
-    syscall_slong_t __unused[3];
+    syscall_slong_t __rr_unused[3];
   };
   RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, struct ::stat, struct stat);
 
@@ -1849,7 +1849,7 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
     struct timespec st_atim;
     struct timespec st_mtim;
     struct timespec st_ctim;
-    syscall_slong_t __unused[3];
+    syscall_slong_t __rr_unused[3];
   };
   RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, struct ::stat64, struct stat64);
 };


### PR DESCRIPTION
__unused is reserved by compilers somehow (even though it's an
extension) so compiling this code with clang on FreeBSD results
in an error, i.e.

```
/home/davide/rr/src/kernel_abi.h:1046:27: error: expected member
name or ';' after declaration specifiers
    unsigned_long __unused[4];
    ~~~~~~~~~~~~~         ^
```

Rename to avoid the clash.