### PR TITLE
[test-monitor] Include headers used explicitly.

### DIFF
--- a/src/test-monitor/test-monitor.cc
+++ b/src/test-monitor/test-monitor.cc
@@ -1,4 +1,5 @@
 #include <dirent.h>
+#include <errno.h>
 #include <limits.h>
 #include <signal.h>
 #include <stdint.h>
@@ -9,6 +10,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
On FreeBSD, this fails because the file uses std::string and
errno without including the correct header. On Linux, it happens
to work because those headers are transitively included by some
other header. Let's bee more explicit here.