### PR TITLE
Add support for CPU 0x40670 (Intel Core i5-5675C)

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -164,6 +164,7 @@ static CpuMicroarch get_cpu_microarch() {
     case 0x40660:
       return IntelHaswell;
     case 0x306D0:
+    case 0x40670:
     case 0x406F0:
     case 0x50660:
       return IntelBroadwell;


### PR DESCRIPTION
lscpu:

```
Architecture:          x86_64
CPU op-mode(s):        32-bit, 64-bit
Byte Order:            Little Endian
CPU(s):                4
On-line CPU(s) list:   0-3
Thread(s) per core:    1
Core(s) per socket:    4
Socket(s):             1
NUMA node(s):          1
Vendor ID:             GenuineIntel
CPU family:            6
Model:                 71
Model name:            Intel(R) Core(TM) i5-5675C CPU @ 3.10GHz
Stepping:              1
CPU MHz:               3093.052
CPU max MHz:           3600.0000
CPU min MHz:           800.0000
BogoMIPS:              6186.10
Virtualization:        VT-x
L1d cache:             32K
L1i cache:             32K
L2 cache:              256K
L3 cache:              4096K
L4 cache:              131072K
NUMA node0 CPU(s):     0-3
Flags:                 fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single pti retpoline intel_pt tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 hle avx2 smep bmi2 erms invpcid rtm rdseed adx smap xsaveopt dtherm ida arat pln pts
```

Tests:
First run was done with `make test`, and *one* test failed: 

```
The following tests FAILED:
  1786 - checkpoint_dying_threads-32 (Failed)
```

Later, a second run was done with `ctest -j4 --verbose` and all tests passed correctly.