### PR TITLE
added tracee getauxval

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -33,6 +33,12 @@ class TraceFrame;
 enum Completion { COMPLETE, INCOMPLETE };
 
 /**
+ * Get access to the the tracee's getauxval()
+ * Returns a value from the tracee's auxiliary vector
+*/
+unsigned long tracee_getauxval(Task* t, unsigned long type);
+
+/**
  * Returns a vector containing the raw data you can get from getauxval.
  */
 std::vector<uint8_t> read_auxv(Task* t);


### PR DESCRIPTION
This commit adds the ability to get all the values seperataly from the auxiliary vector of the tracee, we don't need it at now, but maybe it helps in further development. 
This patch is added on the changes to #2208. There was added the functionality to get the AT_ENTRY value, of the auxiliary vector