### PR TITLE
Add ability to set a temporary trace directory

### DIFF
--- a/src/Flags.h
+++ b/src/Flags.h
@@ -61,6 +61,8 @@ struct Flags {
   // under valgrind.
   std::string forced_uarch;
 
+  std::string output_trace_dir;
+
   Flags()
       : checksum(CHECKSUM_NONE),
         dump_on(DUMP_ON_NONE),

--- a/src/Flags.h
+++ b/src/Flags.h
@@ -61,8 +61,6 @@ struct Flags {
   // under valgrind.
   std::string forced_uarch;
 
-  std::string output_trace_dir;
-
   Flags()
       : checksum(CHECKSUM_NONE),
         dump_on(DUMP_ON_NONE),

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1775,7 +1775,8 @@ static string lookup_by_path(const string& name) {
 /*static*/ RecordSession::shr_ptr RecordSession::create(
     const vector<string>& argv, const vector<string>& extra_env,
     const DisableCPUIDFeatures& disable_cpuid_features,
-    SyscallBuffering syscallbuf, BindCPU bind_cpu) {
+    SyscallBuffering syscallbuf, BindCPU bind_cpu, 
+	const std::string& output_trace_dir) {
   // The syscallbuf library interposes some critical
   // external symbols like XShmQueryExtension(), so we
   // preload it whether or not syscallbuf is enabled. Indicate here whether
@@ -1860,7 +1861,7 @@ static string lookup_by_path(const string& name) {
 
   shr_ptr session(
       new RecordSession(full_path, argv, env, disable_cpuid_features,
-                        syscallbuf, bind_cpu));
+                        syscallbuf, bind_cpu, output_trace_dir));
   return session;
 }
 
@@ -1868,9 +1869,10 @@ RecordSession::RecordSession(const std::string& exe_path,
                              const std::vector<std::string>& argv,
                              const std::vector<std::string>& envp,
                              const DisableCPUIDFeatures& disable_cpuid_features,
-                             SyscallBuffering syscallbuf, BindCPU bind_cpu)
+                             SyscallBuffering syscallbuf, BindCPU bind_cpu, 
+							 const std::string& output_trace_dir)
     : trace_out(argv[0], choose_cpu(bind_cpu), has_cpuid_faulting_,
-                disable_cpuid_features),
+                disable_cpuid_features, output_trace_dir),
       scheduler_(*this),
       disable_cpuid_features_(disable_cpuid_features),
       ignore_sig(0),

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -60,7 +60,8 @@ public:
       const std::vector<std::string>& extra_env,
       const DisableCPUIDFeatures& features,
       SyscallBuffering syscallbuf = ENABLE_SYSCALL_BUF,
-      BindCPU bind_cpu = BIND_CPU);
+      BindCPU bind_cpu = BIND_CPU,
+	  const std::string& output_trace_dir = "");
 
   const DisableCPUIDFeatures& disable_cpuid_features() const {
     return disable_cpuid_features_;
@@ -73,6 +74,7 @@ public:
   int get_ignore_sig() const { return ignore_sig; }
   void set_continue_through_sig(int sig) { continue_through_sig = sig; }
   int get_continue_through_sig() const { return continue_through_sig; }
+  void set_output_trace_dir(std::string dir) { output_trace_dir = dir; }
 
   enum RecordStatus {
     // Some execution was recorded. record_step() can be called again.
@@ -166,7 +168,8 @@ private:
                 const std::vector<std::string>& argv,
                 const std::vector<std::string>& envp,
                 const DisableCPUIDFeatures& features,
-                SyscallBuffering syscallbuf, BindCPU bind_cpu);
+                SyscallBuffering syscallbuf, BindCPU bind_cpu,
+				const std::string& output_trace_dir);
 
   virtual void on_create(Task* t) override;
 
@@ -214,6 +217,8 @@ private:
    * When true, wait for all tracees to exit before finishing recording.
    */
   bool wait_for_all_;
+
+  std::string output_trace_dir;
 };
 
 } // namespace rr

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -199,7 +199,8 @@ public:
    */
   TraceWriter(const std::string& file_name, int bind_to_cpu,
               bool has_cpuid_faulting,
-              const DisableCPUIDFeatures& disable_cpuid_features);
+              const DisableCPUIDFeatures& disable_cpuid_features, 
+			  const std::string& m);
 
   /**
    * We got far enough into recording that we should set this as the latest


### PR DESCRIPTION
This commit adds the ability to set a trace-directory with `-o=<DIR>`
The `<DIR>` path is then the trace directory. The name of the directory can be choosen by the user and doesn't need to be `<application>-<x>`.
Latest Trace is not updated, because I think it's not a good way to add a latest-trace symlink to this "temporary" trace-dir.
Replay is only possible by given the path name.

I wanted to add this feature, to store traces in more than one directory, by not changing the environment variable `_RR_TRACE_DIR` every time. When the option is not set, every works as it worked before.