### PR TITLE
add ability to set a temporary trace directory

### DIFF
--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -53,6 +53,10 @@ RecordCommand RecordCommand::singleton(
     "  --no-file-cloning          disable file cloning for mmapped files\n"
     "  --no-read-cloning          disable file-block cloning for syscallbuf\n"
     "                             reads\n"
+    "  -o, --output-trace-dir<DIR> set the output trace directory.\n"
+    "                             _RR_TRACE_DIR gets ignored.\n"
+    "                             Directory name is given name, not the\n"
+    "                             application name.\n"
     "  -p --print-trace-dir=<NUM> print trace directory followed by a newline\n"
     "                             to given file descriptor\n"
     "  --syscall-buffer-size=<NUM> desired size of syscall buffer in kB.\n"
@@ -109,6 +113,8 @@ struct RecordFlags {
 
   int print_trace_dir;
 
+  string output_trace_dir;
+
   /* Whether to use file-cloning optimization during recording. */
   bool use_file_cloning;
 
@@ -143,6 +149,7 @@ struct RecordFlags {
         use_syscall_buffer(RecordSession::ENABLE_SYSCALL_BUF),
         syscall_buffer_size(0),
         print_trace_dir(-1),
+        output_trace_dir(""),
         use_file_cloning(true),
         use_read_cloning(true),
         bind_cpu(BIND_CPU),
@@ -210,6 +217,7 @@ static bool parse_record_arg(vector<string>& args, RecordFlags& flags) {
     { 'i', "ignore-signal", HAS_PARAMETER },
     { 'n', "no-syscall-buffer", NO_PARAMETER },
     { 'p', "print-trace-dir", HAS_PARAMETER },
+    { 'o', "output-trace-dir", HAS_PARAMETER },
     { 's', "always-switch", NO_PARAMETER },
     { 't', "continue-through-signal", HAS_PARAMETER },
     { 'u', "cpu-unbound", NO_PARAMETER },
@@ -251,6 +259,9 @@ static bool parse_record_arg(vector<string>& args, RecordFlags& flags) {
         return false;
       }
       flags.print_trace_dir = opt.int_value;
+      break;
+    case 'o':
+      flags.output_trace_dir = opt.value;
       break;
     case 0:
       flags.use_read_cloning = false;
@@ -411,7 +422,7 @@ static WaitStatus record(const vector<string>& args, const RecordFlags& flags) {
 
   auto session = RecordSession::create(
       args, flags.extra_env, flags.disable_cpuid_features,
-      flags.use_syscall_buffer, flags.bind_cpu);
+      flags.use_syscall_buffer, flags.bind_cpu, flags.output_trace_dir);
   setup_session_from_flags(*session, flags);
 
   static_session = session.get();

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1775,7 +1775,8 @@ static string lookup_by_path(const string& name) {
 /*static*/ RecordSession::shr_ptr RecordSession::create(
     const vector<string>& argv, const vector<string>& extra_env,
     const DisableCPUIDFeatures& disable_cpuid_features,
-    SyscallBuffering syscallbuf, BindCPU bind_cpu) {
+    SyscallBuffering syscallbuf, BindCPU bind_cpu,
+    const string& output_trace_dir) {
   // The syscallbuf library interposes some critical
   // external symbols like XShmQueryExtension(), so we
   // preload it whether or not syscallbuf is enabled. Indicate here whether
@@ -1860,7 +1861,7 @@ static string lookup_by_path(const string& name) {
 
   shr_ptr session(
       new RecordSession(full_path, argv, env, disable_cpuid_features,
-                        syscallbuf, bind_cpu));
+                        syscallbuf, bind_cpu, output_trace_dir));
   return session;
 }
 
@@ -1868,9 +1869,10 @@ RecordSession::RecordSession(const std::string& exe_path,
                              const std::vector<std::string>& argv,
                              const std::vector<std::string>& envp,
                              const DisableCPUIDFeatures& disable_cpuid_features,
-                             SyscallBuffering syscallbuf, BindCPU bind_cpu)
+                             SyscallBuffering syscallbuf, BindCPU bind_cpu,
+                             const string& output_trace_dir)
     : trace_out(argv[0], choose_cpu(bind_cpu), has_cpuid_faulting_,
-                disable_cpuid_features),
+                disable_cpuid_features, output_trace_dir),
       scheduler_(*this),
       disable_cpuid_features_(disable_cpuid_features),
       ignore_sig(0),

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -60,7 +60,8 @@ public:
       const std::vector<std::string>& extra_env,
       const DisableCPUIDFeatures& features,
       SyscallBuffering syscallbuf = ENABLE_SYSCALL_BUF,
-      BindCPU bind_cpu = BIND_CPU);
+      BindCPU bind_cpu = BIND_CPU,
+      const std::string& output_trace_dir = "");
 
   const DisableCPUIDFeatures& disable_cpuid_features() const {
     return disable_cpuid_features_;
@@ -166,7 +167,8 @@ private:
                 const std::vector<std::string>& argv,
                 const std::vector<std::string>& envp,
                 const DisableCPUIDFeatures& features,
-                SyscallBuffering syscallbuf, BindCPU bind_cpu);
+                SyscallBuffering syscallbuf, BindCPU bind_cpu,
+                const std::string& output_trace_dir);
 
   virtual void on_create(Task* t) override;
 
@@ -214,6 +216,8 @@ private:
    * When true, wait for all tracees to exit before finishing recording.
    */
   bool wait_for_all_;
+
+  std::string output_trace_dir;
 };
 
 } // namespace rr

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -195,11 +195,13 @@ public:
    * Create a trace where the tracess are bound to cpu |bind_to_cpu|. This
    * data is recorded in the trace. If |bind_to_cpu| is -1 then the tracees
    * were not bound.
-   * The trace name is determined by |file_name| and _RR_TRACE_DIR (if set).
+   * The trace name is determined by |file_name| and _RR_TRACE_DIR (if set)
+   * or by setting -o=<OUTPUT_TRACE_DIR>.
    */
   TraceWriter(const std::string& file_name, int bind_to_cpu,
               bool has_cpuid_faulting,
-              const DisableCPUIDFeatures& disable_cpuid_features);
+              const DisableCPUIDFeatures& disable_cpuid_features,
+              const string& output_trace_dir);
 
   /**
    * We got far enough into recording that we should set this as the latest


### PR DESCRIPTION
Sorry, I am really new to using git. I think I destroyed something in my repository of the git history.
I forked again, added the changes, and made one commit. Everything is the same. Sorry for the circumstances...

This commit adds the ability to set a trace-directory with `-o=<DIR>`
The `<DIR>` path is then the trace directory. The name of the directory can be choosen by the user and doesn't need to be `<application>-<x>`.
Latest Trace is not updated, because I think it's not a good way to add a latest-trace symlink to this "temporary" trace-dir.
Replay is only possible by given the path name.

I wanted to add this feature, to store traces in more than one directory, by not changing the environment variable `_RR_TRACE_DIR` every time. When the option is not set, every works as it worked before.

Trace directory does now not get reomoved at all.