### PR TITLE
support prctl PR_GET_SPECULATION_CTRL/PR_SET_SPECULATION_CTRL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,6 +765,7 @@ set(BASIC_TESTS
   prctl_deathsig
   prctl_name
   prctl_short_name
+  prctl_speculation_ctrl
   prctl_tsc
   privileged_net_ioctl
   proc_fds

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3690,6 +3690,8 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
         case PR_CAP_AMBIENT:
         case PR_CAPBSET_DROP:
         case PR_CAPBSET_READ:
+        case PR_GET_SPECULATION_CTRL:
+        case PR_SET_SPECULATION_CTRL:
           break;
 
         case PR_SET_DUMPABLE:

--- a/src/test/prctl_speculation_ctrl.c
+++ b/src/test/prctl_speculation_ctrl.c
@@ -1,0 +1,44 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(void) {
+
+  int ret = prctl(PR_GET_SPECULATION_CTRL, PR_SPEC_STORE_BYPASS, 0, 0, 0);
+
+  /* which path is taken here is out of our control */
+  if (ret == -1) {
+    test_assert(errno == EINVAL || errno == ENODEV);
+    test_assert(-1 == prctl(PR_SET_SPECULATION_CTRL, PR_SPEC_STORE_BYPASS,
+                            PR_SPEC_ENABLE, 0, 0) &&
+                errno == ENXIO);
+  } else if (ret != PR_SPEC_NOT_AFFECTED) {
+    if (ret & PR_SPEC_PRCTL) {
+      if (ret & PR_SPEC_ENABLE) {
+        test_assert(0 == prctl(PR_SET_SPECULATION_CTRL, PR_SPEC_STORE_BYPASS,
+                               PR_SPEC_DISABLE, 0, 0));
+        test_assert(
+            prctl(PR_GET_SPECULATION_CTRL, PR_SPEC_STORE_BYPASS, 0, 0, 0) &
+            PR_SPEC_DISABLE);
+      } else if (ret & PR_SPEC_DISABLE) {
+        test_assert(0 == prctl(PR_SET_SPECULATION_CTRL, PR_SPEC_STORE_BYPASS,
+                               PR_SPEC_ENABLE, 0, 0));
+        test_assert(
+            prctl(PR_GET_SPECULATION_CTRL, PR_SPEC_STORE_BYPASS, 0, 0, 0) &
+            PR_SPEC_ENABLE);
+      } else {
+        test_assert(ret & PR_SPEC_FORCE_DISABLE);
+        test_assert(-1 == prctl(PR_SET_SPECULATION_CTRL, PR_SPEC_STORE_BYPASS,
+                                PR_SPEC_ENABLE, 0, 0) &&
+                    errno == EPERM);
+      }
+    } else {
+      test_assert(-1 == prctl(PR_SET_SPECULATION_CTRL, PR_SPEC_STORE_BYPASS,
+                              PR_SPEC_ENABLE, 0, 0) &&
+                  errno == ENXIO);
+    }
+  }
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
Implementation is trivial, but the test for this is a bit tricky as it
depends on Linux kernel, CPU, firmware, etc.

recording LibreOffice on Fedora 28 we get:

[FATAL /home/roc/rr/rr/src/record_syscall.cc:4877:rec_process_syscall_arch()] 
 (task 27472 (rec:27472) at time 23038)
 -> Assertion `t->regs().syscall_result_signed() == -syscall_state.expect_errno' failed to hold. Expected EINVAL for 'prctl' but got result -6 (errno ENXIO); unknown prctl(0x35)
