### PR TITLE
Added support for CPU 0x30670 (Intel Silvermont)

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -172,6 +172,7 @@ static CpuMicroarch get_cpu_microarch() {
     case 0x50650:
     case 0x506e0:
       return IntelSkylake;
+    case 0x30670:
     case 0x50670:
       return IntelSilvermont;
     case 0x806e0:


### PR DESCRIPTION
A previous issue (https://github.com/mozilla/rr/issues/1642) discussed the lack of support for deterministic counters for CPUID 0x30670. 

```
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
CPU(s):              2
On-line CPU(s) list: 0,1
Thread(s) per core:  1
Core(s) per socket:  2
Socket(s):           1
NUMA node(s):        1
Vendor ID:           GenuineIntel
CPU family:          6
Model:               55
Model name:          Intel(R) Celeron(R) CPU  N2840  @ 2.16GHz
Stepping:            8
CPU MHz:             1533.173
CPU max MHz:         2582.3000
CPU min MHz:         499.8000
BogoMIPS:            4333.08
Virtualization:      VT-x
L1d cache:           24K
L1i cache:           32K
L2 cache:            1024K
NUMA node0 CPU(s):   0,1
Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology tsc_reliable nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 cx16 xtpr pdcm sse4_1 sse4_2 movbe popcnt tsc_deadline_timer rdrand lahf_lm 3dnowprefetch epb pti tpr_shadow vnmi flexpriority ept vpid tsc_adjust smep erms dtherm ida arat
```

Running `make test` and `make check` seem to return test cases that almost all fail with an `Error regular expression found in error`. However, doing a simple record and replay of the `bin/simple` binary is successful:

```
$ ./bin/rr record ./bin/simple
EXIT_SUCCESS
$ ./bin/rr replay -a
EXIT_SUCCESS
```

I feel like there's some sort of caveat in terms of non-determinism (I'm not the most proficient with performance counters and all that), but my machine is not misbehaving for my record-replay tests.

Let me know what you think. 



