### PR TITLE
Implement rr record --num-cores=N

### DIFF
--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -406,8 +406,11 @@ static void setup_session_from_flags(RecordSession& session,
   session.scheduler().set_max_ticks(flags.max_ticks);
   session.scheduler().set_always_switch(flags.always_switch);
   session.set_enable_chaos(flags.chaos);
-  if (flags.num_cores)
+  if (flags.num_cores) {
+    // Set the number of cores reported, possibly overriding the chaos mode
+    // setting.
     session.set_num_cores(flags.num_cores);
+  }
   session.set_use_read_cloning(flags.use_read_cloning);
   session.set_use_file_cloning(flags.use_file_cloning);
   session.set_ignore_sig(flags.ignore_sig);

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -135,6 +135,9 @@ public:
   }
   bool enable_chaos() const { return enable_chaos_; }
 
+  void set_num_cores(int num_cores) {
+    scheduler().set_num_cores(num_cores);
+  }
   void set_use_read_cloning(bool enable) { use_read_cloning_ = enable; }
   void set_use_file_cloning(bool enable) { use_file_cloning_ = enable; }
   void set_syscall_buffer_size(size_t size) { syscall_buffer_size_ = size; }

--- a/src/Scheduler.cc
+++ b/src/Scheduler.cc
@@ -157,7 +157,13 @@ void Scheduler::set_enable_chaos(bool enable_chaos) {
    * return 1 to maximize throughput (since effectively we really only have
    * one core).
    */
+  ASSERT(current_, pretend_num_cores_ == 1);
   pretend_num_cores_ = enable_chaos ? (random() % 8 + 1) : 1;
+  regenerate_affinity_mask();
+}
+
+void Scheduler::set_num_cores(int cores) {
+  pretend_num_cores_ = cores;
   regenerate_affinity_mask();
 }
 

--- a/src/Scheduler.cc
+++ b/src/Scheduler.cc
@@ -157,7 +157,6 @@ void Scheduler::set_enable_chaos(bool enable_chaos) {
    * return 1 to maximize throughput (since effectively we really only have
    * one core).
    */
-  ASSERT(current_, pretend_num_cores_ == 1);
   pretend_num_cores_ = enable_chaos ? (random() % 8 + 1) : 1;
   regenerate_affinity_mask();
 }

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -94,6 +94,7 @@ public:
     this->always_switch = always_switch;
   }
   void set_enable_chaos(bool enable_chaos);
+  void set_num_cores(int cores);
 
   /**
    * Schedule a new runnable task (which may be the same as current()).


### PR DESCRIPTION
Fixes issue #1738.

While it seems good for --chaos to randomize the number of cores, there are times when I would like to control the core count separately from scheduler randomization. This implementation allows passing --num-cores=N with or without --chaos, and will override chaos mode's setting if both are given (but scheduling will still be randomized, it will just use the given number of cores.)

It also slightly helps resolve the confusion that people have about rr reporting 1 core by default. Though I could have been more explicit about that in the usage message, I suppose. ("default is 1 core, or a random number from 1-8 if chaos mode is enabled"?)