### PR TITLE
python3 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,10 +222,8 @@ if(NOT SECCOMP)
 endif()
 
 # Check for Python >=2.7 but not Python 3.
+find_package(PythonInterp 3.0 QUIET)
 find_package(PythonInterp 2.7 REQUIRED)
-if(PYTHON_VERSION_MAJOR GREATER 2)
-  message(FATAL_ERROR "Python 3 is not supported, please use Python 2.7.")
-endif()
 
 execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c" "# nothing"
                 RESULT_VARIABLE python_status)

--- a/src/assembly_templates.py
+++ b/src/assembly_templates.py
@@ -238,14 +238,14 @@ def generate_size_member(byte_array):
 
 def generate(f):
     # Raw bytes.
-    for name, template in templates.iteritems():
+    for name, template in templates.items():
         bytes = template.bytes()
         f.write('static const uint8_t %s[] = { %s };\n'
                 % (byte_array_name(name), ', '.join(['0x%x' % b for b in bytes])))
     f.write('\n')
 
     # Objects representing assembly templates.
-    for name, template in templates.iteritems():
+    for name, template in templates.items():
         byte_array = byte_array_name(name)
         f.write("""class %(class_name)s {
 public:

--- a/src/chaos-test/harness.py
+++ b/src/chaos-test/harness.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python2
 
+from __future__ import print_function
+
 import sys
 import multiprocessing
 import tempfile
@@ -29,7 +31,7 @@ def run(rr_params):
                 stdout=out, stderr=out)
             ret = p.wait()
         if ret != 0 and ret != GOOD_FAIL:
-            print "Test %s failed unexpectedly; leaving behind trace in %s"%(name, d)
+            print("Test %s failed unexpectedly; leaving behind trace in %s"%(name, d))
         out_array = []
         with open(d + "/out", 'r') as out:
             for line in out:
@@ -47,7 +49,7 @@ def safe_exit(code):
     pool.join()
     sys.exit(code)
 
-print "Running %d iterations of %s/bin/%s %s without chaos mode"%(sanity_runs, objdir, name, ' '.join(params))
+print("Running %d iterations of %s/bin/%s %s without chaos mode"%(sanity_runs, objdir, name, ' '.join(params)))
 sanity_failed = 0
 for r in pool.imap_unordered(run, itertools.repeat([], sanity_runs)):
     if r[0] == 0:
@@ -57,11 +59,11 @@ for r in pool.imap_unordered(run, itertools.repeat([], sanity_runs)):
         break
     sanity_failed = sanity_failed + 1
 if sanity_failed == sanity_runs:
-    print "PROBLEM: %d runs of %s all failed; not a good chaos mode test"%(sanity_failed, name)
+    print("PROBLEM: %d runs of %s all failed; not a good chaos mode test"%(sanity_failed, name))
     safe_exit(2)
-print "Without chaos mode, %d runs of %s failed out of %d"%(sanity_failed, name, sanity_runs)
+print("Without chaos mode, %d runs of %s failed out of %d"%(sanity_failed, name, sanity_runs))
 
-print "Running %d iterations of %s/bin/%s %s in chaos mode"%(runs, objdir, name, ' '.join(params))
+print("Running %d iterations of %s/bin/%s %s in chaos mode"%(runs, objdir, name, ' '.join(params)))
 failed = 0
 for r in pool.imap_unordered(run, itertools.repeat(["--chaos"], runs)):
     if r[0] == 0:
@@ -70,18 +72,18 @@ for r in pool.imap_unordered(run, itertools.repeat(["--chaos"], runs)):
         safe_exit(r[0])
         break
     if failed == 0:
-        print "First test failure detected, output:"
+        print("First test failure detected, output:")
         for line in r[1]:
-            print line,
+            print(line,)
     failed = failed + 1
 if failed == 0:
-    print "PROBLEM: With chaos mode, test %s did not fail in %d runs"%(name, runs)
+    print("PROBLEM: With chaos mode, test %s did not fail in %d runs"%(name, runs))
     safe_exit(1)
 
-print "With chaos mode, %d runs of %s failed out of %d"%(failed, name, runs)
+print("With chaos mode, %d runs of %s failed out of %d"%(failed, name, runs))
 if float(failed)/runs < 3*float(sanity_failed)/sanity_runs:
-    print "PROBLEM: Chaos mode didn't really help!"
+    print("PROBLEM: Chaos mode didn't really help!")
     safe_exit(3)
 
 safe_exit(0)
-print
+print()

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -1703,7 +1703,7 @@ epoll_ctl_old = UnsupportedSyscall(x64=214)
 epoll_wait_old = UnsupportedSyscall(x64=215)
 
 def _syscalls():
-    for name, obj in globals().iteritems():
+    for name, obj in globals().items():
         if isinstance(obj, BaseSyscall):
             yield name, obj
 

--- a/src/test/break_block.py
+++ b/src/test/break_block.py
@@ -3,7 +3,7 @@ from util import *
 send_gdb('b breakpoint')
 expect_gdb('Breakpoint 1')
 
-for i in xrange(2):
+for i in range(2):
     send_gdb('c')
     expect_gdb('Breakpoint 1, breakpoint')
 

--- a/src/test/break_clock.py
+++ b/src/test/break_clock.py
@@ -3,7 +3,7 @@ from util import *
 send_gdb('b breakpoint')
 expect_gdb('Breakpoint 1')
 
-for i in xrange(3):
+for i in range(3):
     send_gdb('c')
     expect_gdb('Breakpoint 1, breakpoint')
 

--- a/src/test/break_clone.py
+++ b/src/test/break_clone.py
@@ -3,7 +3,7 @@ from util import *
 send_gdb('b breakpoint')
 expect_gdb('Breakpoint 1')
 
-for i in xrange(3):
+for i in range(3):
     send_gdb('c')
     expect_gdb('Breakpoint 1, breakpoint')
 

--- a/src/test/break_mmap_private.py
+++ b/src/test/break_mmap_private.py
@@ -3,7 +3,7 @@ from util import *
 send_gdb('b breakpoint')
 expect_gdb('Breakpoint 1')
 
-for i in xrange(3):
+for i in range(3):
     send_gdb('c')
     expect_gdb('Breakpoint 1, breakpoint')
 

--- a/src/test/check_syscall_perf_interval.py
+++ b/src/test/check_syscall_perf_interval.py
@@ -1,10 +1,12 @@
+from __future__ import print_function
+
 import sys
 import re
 
 if len(sys.argv) < 4:
-    print '''Usage: %s <syscall-name> <perf-counter-name> <expected-perf-events-between-syscalls>
+    print('''Usage: %s <syscall-name> <perf-counter-name> <expected-perf-events-between-syscalls>
 Exits with status 0 if exactly the expected number of perf events occur between
-every pair of consecutive system calls of the given type.''' % sys.argv[0]
+every pair of consecutive system calls of the given type.''' % sys.argv[0])
     sys.exit(2)
 
 syscall = sys.argv[1]
@@ -27,8 +29,8 @@ while True:
             if m:
                 v = int(m.group(1))
                 if last_perfctr_value >= 0 and v - last_perfctr_value != expected_count:
-                    print "Mismatch: saw %d %ss between %ss (from %d to %d), expected %d" % \
-                      (v - last_perfctr_value, counter, syscall, last_perfctr_value, v, expected_count)
+                    print("Mismatch: saw %d %ss between %ss (from %d to %d), expected %d" % \
+                      (v - last_perfctr_value, counter, syscall, last_perfctr_value, v, expected_count))
                     sys.exit(1)
                 last_perfctr_value = v
         else:

--- a/src/test/clone_interruption_finder.py
+++ b/src/test/clone_interruption_finder.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import re
 
@@ -14,4 +16,4 @@ while True:
         if m:
             futex_time = m.group(1)
 
-print futex_time
+print(futex_time)

--- a/src/test/fxregs.py
+++ b/src/test/fxregs.py
@@ -9,11 +9,11 @@ expect_gdb('Breakpoint 1, breakpoint')
 
 # See fxregs.c for the list of constants that are loaded into the
 # $st*, $xmm* and $ymm* registers.
-for i in xrange(8):
+for i in range(8):
     send_gdb('p $st%d'%(i))
     expect_gdb(' = %d'%(i + 1))
 
-for i in xrange(8):
+for i in range(8):
     send_gdb('p $xmm%d.v4_float[0]'%(i))
     expect_gdb(' = %d'%(i + 10))
 
@@ -21,7 +21,7 @@ send_gdb('show architecture')
 have_64 = 0 == expect_list([re.compile('i386:x86-64\)'), re.compile('i386\)')])
 
 if have_64:
-    for i in xrange(8,16):
+    for i in range(8,16):
         send_gdb('p $xmm%d.v4_float[0]'%(i))
         expect_gdb(' = %d'%(i + 10))
 
@@ -29,13 +29,13 @@ send_gdb('p AVX_enabled')
 have_AVX = 0 == expect_list([re.compile(' = 1'), re.compile(' = 0')])
 
 if have_AVX:
-    for i in xrange(8):
+    for i in range(8):
         send_gdb('p $ymm%d.v8_float[0]'%(i))
         expect_gdb(' = %d'%(i + 10))
         send_gdb('p $ymm%d.v8_float[4]'%(i))
         expect_gdb(' = %d'%((i + 1)%8 + 10))
     if have_64:
-        for i in xrange(8,16):
+        for i in range(8,16):
             send_gdb('p $ymm%d.v8_float[0]'%(i))
             expect_gdb(' = %d'%(i + 10))
             send_gdb('p $ymm%d.v8_float[4]'%(i))

--- a/src/test/get_thread_list.py
+++ b/src/test/get_thread_list.py
@@ -26,7 +26,7 @@ stopped_locations = {
                     '0x0*70000002 in \?\?'],
 }
 
-for i in xrange(NUM_THREADS + 1, 1, -1):
+for i in range(NUM_THREADS + 1, 1, -1):
     # The threads are at the kernel syscall entry, or either the
     # traced/untraced entry reached through the rr monkeypatched one.
     # Rarely, non-main threads have been observed to be reordered (i.e. gdb

--- a/src/test/mprotect_step.py
+++ b/src/test/mprotect_step.py
@@ -12,7 +12,7 @@ expect_gdb('Breakpoint 2')
 
 # step through mprotect() until we reach the system call that
 # gets performed during replay
-for i in xrange(0,200):
+for i in range(0,200):
     send_gdb('stepi')
     expect_gdb('(rr)')
 

--- a/src/test/reverse_step_threads_break.py
+++ b/src/test/reverse_step_threads_break.py
@@ -9,7 +9,7 @@ send_gdb('b breakpoint_thread')
 expect_gdb('Breakpoint 2')
 
 send_gdb('set scheduler-locking off')
-for i in xrange(50):
+for i in range(50):
   send_gdb('reverse-step')
 
 expect_gdb('Breakpoint 2')

--- a/src/test/signal_numbers.py
+++ b/src/test/signal_numbers.py
@@ -34,10 +34,10 @@ gdb_signals = [
   '#SIGPWR',
   'SIGSYS']
 
-for sig in xrange(32,65):
+for sig in range(32,65):
     gdb_signals.append('SIG%d'%sig)
 
-for sig in xrange(1,65):
+for sig in range(1,65):
     gdb_sig = gdb_signals[sig]
     if not gdb_sig.startswith('#'):
         send_gdb('handle %s stop'%gdb_sig)

--- a/src/test/step_thread.py
+++ b/src/test/step_thread.py
@@ -48,7 +48,7 @@ while 1:
     hit_bps[bp] = 1
     expect_gdb(r'\(rr\)')
 
-for bp in hit_bps.iterkeys():
+for bp in hit_bps.keys():
     assert hit_bps[bp]
 
 arch = get_exe_arch()

--- a/src/test/util.py
+++ b/src/test/util.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import pexpect, re, signal, sys, time
 
 __all__ = [ 'expect_gdb', 'send_gdb','expect_rr', 'expect_list',
@@ -15,16 +17,16 @@ def expect_rr(what):
     expect(gdb_rr, what)
 
 def failed(why, e=None):
-    print 'FAILED:', why
+    print('FAILED:', why)
     if e:
-        print 'exception:', e
+        print('exception:', e)
     clean_up()
     sys.exit(1)
 
 def interrupt_gdb():
     try:
         gdb_rr.kill(signal.SIGINT)
-    except Exception, e:
+    except Exception as e:
         failed('interrupting gdb', e)
     expect_gdb('stopped.')
 
@@ -74,9 +76,9 @@ def clean_up():
             time.sleep(0.1)
             gdb_rr.close(force=1)
             gdb_rr = None
-        except Exception, e:
+        except Exception as e:
             if iterations < 5:
-                print "close() failed with '%s', retrying..."%e
+                print("close() failed with '%s', retrying..."%e)
                 iterations = iterations + 1
             else:
                 gdb_rr = None
@@ -84,7 +86,7 @@ def clean_up():
 def expect(prog, what):
     try:
         prog.expect(what)
-    except Exception, e:
+    except Exception as e:
         failed('expecting "%s"'% (what), e)
 
 def get_exe_arch():
@@ -102,7 +104,7 @@ def get_rr_cmd():
 def send(prog, what):
     try:
         prog.send(what)
-    except Exception, e:
+    except Exception as e:
         failed('sending "%s"'% (what), e)
 
 def set_up():
@@ -111,7 +113,7 @@ def set_up():
         gdb_rr = pexpect.spawn(*get_rr_cmd(), timeout=TIMEOUT_SEC, logfile=open('gdb_rr.log', 'w'))
         gdb_rr.delaybeforesend = 0
         expect_gdb(r'\(rr\)')
-    except Exception, e:
+    except Exception as e:
         failed('initializing rr and gdb', e)
 
 set_up()


### PR DESCRIPTION
test: `pylint3 -rn -E $(find . -name "*.py")`

Should make the code compatible with both python2 and python3.
Add silent CMake rule to prefer python 3 over python2

mostly regexes:
```
sed -i 's/\<xrange\>/range/g' $(find . -name "*.py")
sed -i 's/\<iteritems\>/items/g' $(find . -name "*.py")
sed -i 's/\<iterkeys\>/keys/g' $(find . -name "*.py")
```

manually transformed print -> print() and import it from the future

(This should address issue: https://github.com/mozilla/rr/issues/2174)