### PR TITLE
WIP: AMD Family 15h model 30h support

### DIFF
--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -31,8 +31,10 @@ namespace rr {
 
 static bool attributes_initialized;
 static struct perf_event_attr ticks_attr;
+static struct perf_event_attr minus_ticks_attr;
 static struct perf_event_attr cycles_attr;
 static struct perf_event_attr hw_interrupts_attr;
+static uint32_t pmu_flags;
 static uint32_t skid_size;
 static bool has_ioc_period_bug;
 static bool has_kvm_in_txcp_bug;
@@ -60,43 +62,59 @@ enum CpuMicroarch {
   IntelSkylake,
   IntelSilvermont,
   IntelKabylake,
+  AMDF15R30,
   AMDRyzen,
 };
+
+#define PMU_UNSUPPORTED (1<<0)
+
+/*
+ * Some CPUs turn off the whole PMU when there are no remaining events
+ * scheduled (perhaps as a power consumption optimization). This can be a
+ * very expensive operation, and is thus best avoided. For cpus, where this
+ * is a problem, we keep a cycles counter (which corresponds to one of the
+ * fixed function counters, so we don't use up a programmable PMC) that we
+ * don't otherwise use, but keeps the PMU active, greatly increasing
+ * performance.
+ */
+
+#define PMU_BENEFITS_FROM_USELESS_COUNTER (1<<1)
+
+/*
+ * Whether we need to increment ticks when emulating an unconditional
+ * indirect branch.
+ */
+
+#define PMU_UNCONDITIONAL_INDIRECT_BRANCH_ADDS_TICK (1<<2)
+#define PMU_SKIP_INTEL_BUG_CHECK (1<<3)
 
 struct PmuConfig {
   CpuMicroarch uarch;
   const char* name;
   unsigned rcb_cntr_event;
+  unsigned minus_ticks_cntr_event;
   unsigned hw_intr_cntr_event;
   uint32_t skid_size;
-  bool supported;
-  /*
-   * Some CPUs turn off the whole PMU when there are no remaining events
-   * scheduled (perhaps as a power consumption optimization). This can be a
-   * very expensive operation, and is thus best avoided. For cpus, where this
-   * is a problem, we keep a cycles counter (which corresponds to one of the
-   * fixed function counters, so we don't use up a programmable PMC) that we
-   * don't otherwise use, but keeps the PMU active, greatly increasing
-   * performance.
-   */
-  bool benefits_from_useless_counter;
+  uint32_t flags;
 };
 
 // XXX please only edit this if you really know what you're doing.
 static const PmuConfig pmu_configs[] = {
-  { IntelKabylake, "Intel Kabylake", 0x5101c4, 0x5301cb, 100, true, false },
-  { IntelSilvermont, "Intel Silvermont", 0x517ec4, 0x5301cb, 100, true, true },
-  { IntelSkylake, "Intel Skylake", 0x5101c4, 0x5301cb, 100, true, false },
-  { IntelBroadwell, "Intel Broadwell", 0x5101c4, 0x5301cb, 100, true, false },
-  { IntelHaswell, "Intel Haswell", 0x5101c4, 0x5301cb, 100, true, false },
-  { IntelIvyBridge, "Intel Ivy Bridge", 0x5101c4, 0x5301cb, 100, true, false },
-  { IntelSandyBridge, "Intel Sandy Bridge", 0x5101c4, 0x5301cb, 100, true,
-    false },
-  { IntelNehalem, "Intel Nehalem", 0x5101c4, 0x50011d, 100, true, false },
-  { IntelWestmere, "Intel Westmere", 0x5101c4, 0x50011d, 100, true, false },
-  { IntelPenryn, "Intel Penryn", 0, 0, 100, false, false },
-  { IntelMerom, "Intel Merom", 0, 0, 100, false, false },
-  { AMDRyzen, "AMD Ryzen", 0x5100d1, 0, 1000, true, false },
+  { IntelKabylake, "Intel Kabylake", 0x5101c4, 0, 0x5301cb, 100, 0 },
+  { IntelSilvermont, "Intel Silvermont", 0x517ec4, 0, 0x5301cb, 100, 0 },
+  { IntelSkylake, "Intel Skylake", 0x5101c4, 0, 0x5301cb, 100, 0 },
+  { IntelBroadwell, "Intel Broadwell", 0x5101c4, 0, 0x5301cb, 100, 0 },
+  { IntelHaswell, "Intel Haswell", 0x5101c4, 0, 0x5301cb, 100, 0 },
+  { IntelIvyBridge, "Intel Ivy Bridge", 0x5101c4, 0, 0x5301cb, 100, 0 },
+  { IntelSandyBridge, "Intel Sandy Bridge", 0x5101c4, 0, 0x5301cb, 100, 0 },
+  { IntelNehalem, "Intel Nehalem", 0x5101c4, 0, 0x50011d, 100, 0 },
+  { IntelWestmere, "Intel Westmere", 0x5101c4, 0, 0x50011d, 100, 0 },
+  { IntelPenryn, "Intel Penryn", 0, 0, 0, 100, PMU_UNSUPPORTED },
+  { IntelMerom, "Intel Merom", 0, 0, 0, 100, PMU_UNSUPPORTED },
+  { AMDF15R30, "AMD Family 15h Revision 30h", 0xc4, 0xc6, 0, 250,
+    PMU_UNCONDITIONAL_INDIRECT_BRANCH_ADDS_TICK |
+    PMU_SKIP_INTEL_BUG_CHECK },
+  { AMDRyzen, "AMD Ryzen", 0x5100d1, 0, 0, 1000, 0 },
 };
 
 static string lowercase(const string& s) {
@@ -179,6 +197,8 @@ static CpuMicroarch get_cpu_microarch() {
     case 0x806e0:
     case 0x906e0:
       return IntelKabylake;
+    case 0x30f00:
+      return AMDF15R30;
     case 0x00f10:
       if (ext_family == 8) {
         if (!Flags::get().suppress_environment_warnings) {
@@ -542,12 +562,17 @@ static void init_attributes() {
   }
   DEBUG_ASSERT(pmu);
 
-  if (!pmu->supported) {
+  if (pmu->flags & PMU_UNSUPPORTED) {
     FATAL() << "Microarchitecture `" << pmu->name << "' currently unsupported.";
   }
 
   skid_size = pmu->skid_size;
+  pmu_flags = pmu->flags;
   init_perf_event_attr(&ticks_attr, PERF_TYPE_RAW, pmu->rcb_cntr_event);
+  if (pmu->minus_ticks_cntr_event != 0) {
+    init_perf_event_attr(&minus_ticks_attr, PERF_TYPE_RAW,
+                         pmu->minus_ticks_cntr_event);
+  }
   init_perf_event_attr(&cycles_attr, PERF_TYPE_HARDWARE,
                        PERF_COUNT_HW_CPU_CYCLES);
   init_perf_event_attr(&hw_interrupts_attr, PERF_TYPE_RAW,
@@ -556,11 +581,14 @@ static void init_attributes() {
   // same thing.  Unclear if necessary.
   hw_interrupts_attr.exclude_hv = 1;
 
-  check_for_bugs();
+  if (!(pmu_flags & PMU_SKIP_INTEL_BUG_CHECK)) {
+    check_for_bugs();
+  }
   /*
    * For maintainability, and since it doesn't impact performance when not
    * needed, we always activate this. If it ever turns out to be a problem,
-   * this can be set to pmu->benefits_from_useless_counter, instead.
+   * this can be set to pmu->flags & PMU_BENEFITS_FROM_USELESS_COUNTER,
+   * instead.
    *
    * We also disable this counter when running under rr. Even though it's the
    * same event for the same task as the outer rr, the linux kernel does not
@@ -576,6 +604,14 @@ bool PerfCounters::is_ticks_attr(const perf_event_attr& attr) {
   tmp_attr.sample_period = 0;
   tmp_attr.config &= ~IN_TXCP;
   return memcmp(&ticks_attr, &tmp_attr, sizeof(attr)) == 0;
+}
+
+bool PerfCounters::is_minus_ticks_attr(const perf_event_attr& attr) {
+  init_attributes();
+  perf_event_attr tmp_attr = attr;
+  tmp_attr.sample_period = 0;
+  tmp_attr.config &= ~IN_TXCP;
+  return memcmp(&minus_ticks_attr, &tmp_attr, sizeof(attr)) == 0;
 }
 
 uint32_t PerfCounters::skid_size() {
@@ -614,8 +650,12 @@ void PerfCounters::reset(Ticks ticks_period) {
     LOG(debug) << "Recreating counters with period " << ticks_period;
 
     struct perf_event_attr attr = rr::ticks_attr;
+    struct perf_event_attr minus_attr = rr::minus_ticks_attr;
     attr.sample_period = ticks_period;
     fd_ticks_interrupt = start_counter(tid, -1, &attr);
+    if (minus_attr.config != 0) {
+      fd_minus_ticks_measure = start_counter(tid, fd_ticks_interrupt, &minus_attr);
+    }
 
     if (!only_one_counter && supports_txcp) {
       if (has_kvm_in_txcp_bug) {
@@ -671,6 +711,14 @@ void PerfCounters::reset(Ticks ticks_period) {
     if (ioctl(fd_ticks_interrupt, PERF_EVENT_IOC_ENABLE, 0)) {
       FATAL() << "ioctl(PERF_EVENT_IOC_ENABLE) failed";
     }
+    if (fd_minus_ticks_measure.is_open()) {
+      if (ioctl(fd_minus_ticks_measure, PERF_EVENT_IOC_RESET, 0)) {
+        FATAL() << "ioctl(PERF_EVENT_IOC_RESET) failed";
+      }
+      if (ioctl(fd_minus_ticks_measure, PERF_EVENT_IOC_ENABLE, 0)) {
+        FATAL() << "ioctl(PERF_EVENT_IOC_ENABLE) failed";
+      }
+    }
     if (fd_ticks_measure.is_open()) {
       if (ioctl(fd_ticks_measure, PERF_EVENT_IOC_RESET, 0)) {
         FATAL() << "ioctl(PERF_EVENT_IOC_RESET) failed";
@@ -707,6 +755,7 @@ void PerfCounters::stop() {
 
   fd_ticks_interrupt.close();
   fd_ticks_measure.close();
+  fd_minus_ticks_measure.close();
   fd_useless_counter.close();
   fd_ticks_in_transaction.close();
 }
@@ -720,6 +769,9 @@ void PerfCounters::stop_counting() {
     stop();
   } else {
     ioctl(fd_ticks_interrupt, PERF_EVENT_IOC_DISABLE, 0);
+    if (fd_minus_ticks_measure.is_open()) {
+      ioctl(fd_minus_ticks_measure, PERF_EVENT_IOC_DISABLE, 0);
+    }
     if (fd_ticks_measure.is_open()) {
       ioctl(fd_ticks_measure, PERF_EVENT_IOC_DISABLE, 0);
     }
@@ -727,6 +779,10 @@ void PerfCounters::stop_counting() {
       ioctl(fd_ticks_in_transaction, PERF_EVENT_IOC_DISABLE, 0);
     }
   }
+}
+
+Ticks PerfCounters::ticks_for_unconditional_indirect_branch(Task*) {
+  return (pmu_flags & PMU_UNCONDITIONAL_INDIRECT_BRANCH_ADDS_TICK) ? 1 : 0;
 }
 
 Ticks PerfCounters::read_ticks(Task* t) {
@@ -755,6 +811,10 @@ Ticks PerfCounters::read_ticks(Task* t) {
       (t->session().is_recording() ? recording_skid_size() : skid_size());
   uint64_t interrupt_val = read_counter(fd_ticks_interrupt);
   if (!fd_ticks_measure.is_open()) {
+    if (fd_minus_ticks_measure.is_open()) {
+      uint64_t minus_measure_val = read_counter(fd_minus_ticks_measure);
+      interrupt_val -= minus_measure_val;
+    }
     ASSERT(t, !counting_period || interrupt_val <= adjusted_counting_period)
         << "Detected " << interrupt_val << " ticks, expected no more than "
         << adjusted_counting_period;

--- a/src/PerfCounters.h
+++ b/src/PerfCounters.h
@@ -67,6 +67,12 @@ public:
   void stop_counting();
 
   /**
+   * Return the number of ticks we need for an emulated branch.
+   * `t` is used for debugging purposes.
+   */
+  static Ticks ticks_for_unconditional_indirect_branch(Task* t);
+
+  /**
    * Read the current value of the ticks counter.
    * `t` is used for debugging purposes.
    */
@@ -82,6 +88,7 @@ public:
   enum { TIME_SLICE_SIGNAL = SIGSTKFLT };
 
   static bool is_ticks_attr(const perf_event_attr& attr);
+  static bool is_minus_ticks_attr(const perf_event_attr& attr);
 
   /**
    * When an interrupt is requested, at most this many ticks may elapse before
@@ -105,6 +112,7 @@ private:
   // sample_period; the latter does not ignore ticks in aborted transactions,
   // but does support sample_period.
   ScopedFd fd_ticks_measure;
+  ScopedFd fd_minus_ticks_measure;
   ScopedFd fd_ticks_interrupt;
   ScopedFd fd_ticks_in_transaction;
   ScopedFd fd_useless_counter;

--- a/src/PerfCounters.h
+++ b/src/PerfCounters.h
@@ -68,9 +68,8 @@ public:
 
   /**
    * Return the number of ticks we need for an emulated branch.
-   * `t` is used for debugging purposes.
    */
-  static Ticks ticks_for_unconditional_indirect_branch(Task* t);
+  static Ticks ticks_for_unconditional_indirect_branch(Task*);
 
   /**
    * Read the current value of the ticks counter.
@@ -87,8 +86,7 @@ public:
    * hope that tracees don't either. */
   enum { TIME_SLICE_SIGNAL = SIGSTKFLT };
 
-  static bool is_ticks_attr(const perf_event_attr& attr);
-  static bool is_minus_ticks_attr(const perf_event_attr& attr);
+  static bool is_rr_ticks_attr(const perf_event_attr& attr);
 
   /**
    * When an interrupt is requested, at most this many ticks may elapse before

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -251,6 +251,13 @@ void Task::close_buffers_for(AutoRemoteSyscalls& remote, Task* other) {
   }
 }
 
+void Task::emulate_jump(remote_code_ptr ip) {
+  Registers r = regs();
+  r.set_ip(ip);
+  set_regs(r);
+  ticks += PerfCounters::ticks_for_unconditional_indirect_branch(this);
+}
+
 bool Task::is_desched_event_syscall() {
   return is_ioctl_syscall(regs().original_syscallno(), arch()) &&
          desched_fd_child != -1 &&

--- a/src/Task.h
+++ b/src/Task.h
@@ -237,6 +237,11 @@ public:
   remote_code_ptr ip() { return regs().ip(); }
 
   /**
+   * Emulate a jump to a new IP, updating the ticks counter as appropriate.
+   */
+  void emulate_jump(remote_code_ptr);
+
+  /**
    * Return true if this is at an arm-desched-event or
    * disarm-desched-event syscall.
    */

--- a/src/VirtualPerfCounterMonitor.cc
+++ b/src/VirtualPerfCounterMonitor.cc
@@ -20,7 +20,7 @@ std::map<TaskUid, VirtualPerfCounterMonitor*>
 
 bool VirtualPerfCounterMonitor::should_virtualize(
     const struct perf_event_attr& attr) {
-  return PerfCounters::is_ticks_attr(attr);
+  return PerfCounters::is_rr_ticks_attr(attr);
 }
 
 VirtualPerfCounterMonitor::VirtualPerfCounterMonitor(
@@ -120,7 +120,8 @@ bool VirtualPerfCounterMonitor::emulate_read(RecordTask* t,
                                              LazyOffset&, uint64_t* result) {
   RecordTask* target = t->session().find_task(target_tuid());
   if (target) {
-    int64_t val = target->tick_count() - initial_ticks;
+    int64_t val;
+    val = target->tick_count() - initial_ticks;
     *result = write_ranges(t, ranges, &val, sizeof(val));
   } else {
     *result = 0;

--- a/src/record_signal.cc
+++ b/src/record_signal.cc
@@ -253,9 +253,7 @@ bool handle_syscallbuf_breakpoint(RecordTask* t) {
                   "enable signal dispatch";
     // This is a single instruction that jumps to the location stored in
     // preload_thread_locals::stub_scratch_1. Emulate it.
-    Registers r = t->regs();
-    r.set_ip(get_stub_scratch_1(t));
-    t->set_regs(r);
+    t->emulate_jump(get_stub_scratch_1(t));
 
     restore_sighandler_if_not_default(t, SIGTRAP);
     // Now we're back in application code so any pending stashed signals


### PR DESCRIPTION
* support using the difference of two PMCs as tick count
* support AMD family 15h model 30h CPUs that way.

I revisited the issue of running rr on my AMD bdver3 (family 15h, model 30h) laptop, which I unfortunately appear  to be stuck with for a while. I'm not sure whether it's due to a microcode update, but it appears that there are now two performance counters whose difference is predictable enough to run rr:
0xc4 (taken branches including exceptions, interrupts, far branches, and syscalls) and 0xc6 (exceptions, interrupts, far branches, and syscalls).

The difference, of course, is the count of taken near branches, conditional or not. I think that's good enough for us.

Most tests pass without a syscallbuf, and those that do not appear to fail for unrelated reasons.  I'm still looking at the syscallbuf code to see how it breaks.

This is just a snapshot for now; I think the hard part was working out which counters to use. Any preferences for how best to submit this?

Both PMCs I'm using appear to be unchanged for family 17h, which I think is Ryzen, so it's possible this approach would also work for that CPU.