### PR TITLE
fix hooks test

### DIFF
--- a/src/test/hooks.c
+++ b/src/test/hooks.c
@@ -7,7 +7,8 @@ int do_close(int fd);
 const int sys_close = SYS_close;
 
 #ifdef __x86_64__
-asm ("do_close:\n\t"
+asm (".text\n"
+     "do_close:\n\t"
      "mov sys_close(%rip),%eax\n\t"
      "syscall\n\t"
      "ret\n\t"


### PR DESCRIPTION
Explicitly specify ".text" before generating code, to avoid code being
placed in the non-executable data section.