### PR TITLE
Split up mmaps that extend past the end of a file

### DIFF
--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -851,10 +851,9 @@ static void process_mmap(ReplayTask* t, const TraceFrame& trace_frame,
     } else {
       TraceReader::MappedData data;
       KernelMapping km = t->trace_reader().read_mapped_region(&data);
-      uint64_t file_bytes = data.file_size_bytes - data.data_offset_bytes;
 
-      if (data.source == TraceReader::SOURCE_FILE &&
-         ceil_page_size(file_bytes) >= ceil_page_size(length)) {
+      if (data.source == TraceReader::SOURCE_FILE) {
+        uint64_t file_bytes = data.file_size_bytes - data.data_offset_bytes;
         struct stat real_file;
         string real_file_name;
         finish_direct_mmap(t, remote, addr, length, prot, flags,
@@ -864,6 +863,20 @@ static void process_mmap(ReplayTask* t, const TraceFrame& trace_frame,
         t->vm()->map(t, km.start(), length, prot, flags,
                      page_size() * offset_pages, real_file_name,
                      real_file.st_dev, real_file.st_ino, nullptr, &km);
+        if (length > ceil_page_size(file_bytes)) {
+          length -= ceil_page_size(file_bytes);
+          addr += ceil_page_size(file_bytes);
+          offset_pages -= ceil_page_size(file_bytes) / page_size();
+          km = km.subrange(km.start() + ceil_page_size(file_bytes), km.end());
+          if (MAP_PRIVATE & flags) {
+            finish_private_mmap(t, remote, addr, length, prot, flags,
+                                offset_pages, km, data);
+          } else {
+            finish_shared_mmap(t, remote, addr, length, prot, flags, fd,
+                               offset_pages, km, data);
+          }
+          addr -= ceil_page_size(file_bytes);
+        }
       } else {
         if (MAP_PRIVATE & flags) {
           finish_private_mmap(t, remote, addr, length, prot, flags,


### PR DESCRIPTION
The old code would fail to coalesce mappings in some cases
(https://github.com/mozilla/rr/commit/8f5a8b5ed63d2389da81865c6f3c0931abb332f0#r30518535).

It would be really nice to have a test for this that fails with the old code (on non-Debian systems).