### PR TITLE
Fix crash in `rr ls` when a trace is incomplete

### DIFF
--- a/src/LsCommand.cc
+++ b/src/LsCommand.cc
@@ -194,7 +194,7 @@ static int ls(const string& traces_dir, const LsFlags& flags, FILE* out) {
         return max(m, static_cast<int>(t.first.length()));
     });
 
-  fprintf(out, "%-*s %19s %5s %s\n", max_name_size,
+  fprintf(out, "%-*s %-19s %5s %s\n", max_name_size,
           "NAME", "WHEN", "SIZE", "CMD");
 
   for (TraceInfo& t : traces) {


### PR DESCRIPTION
I've been running `./mach mochitest --debugger=rr ...` and I want to check on the traces that accumulate before the entire run is over. That mostly means running `rr ls` to see what's there, then `rr ps` on each trace to see if there's a -11 exit value.

But currently `rr ls` crashes out if it finds an in-progress trace.