### PR TITLE
add bash completion script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,6 +531,8 @@ install(PROGRAMS scripts/signal-rr-recording.sh
                   ${CMAKE_CURRENT_BINARY_DIR}/bin/rr_page_32
                   ${CMAKE_CURRENT_BINARY_DIR}/bin/rr_page_32_replay
   DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(PROGRAMS scripts/rr_completion
+  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/share/bash-completion/completions)
 
 install(TARGETS ${RR_BIN} rrpreload rr_exec_stub
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/scripts/rr_completion
+++ b/scripts/rr_completion
@@ -1,0 +1,29 @@
+# vi:syntax=sh
+#
+# completion script for rr commands (to be sourced)
+
+_rr_subcmd_completion() {
+    local cmd=$1
+    local short_opts=$(rr help $cmd | sed -n 's/\s*-\([a-zA-Z]\),.*/-\1/p')
+    local long_opts=$(rr help $cmd | sed -n 's/.*--\([^= ]*\).*/--\1/p')
+    echo "$short_opts" "$long_opts"
+}
+
+_rr_completion() {
+    COMPREPLY=()
+    local rr_commands="$(rr --list-commands | cut -s -d ' ' -f 3)"
+
+    # completion for rr
+    if [ $COMP_CWORD -eq 1 ]; then
+        COMPREPLY=( $( compgen -W "$rr_commands" -- "${COMP_WORDS[1]}" ) )
+        return
+    fi
+
+    # completion for rr <command>'s options
+    local cmd="$(echo "${COMP_WORDS[1]}" | tr -d '[:space:]')"
+
+    if [ "$(echo $rr_commands | grep -w "$cmd")" ] ; then
+        COMPREPLY=( $( compgen -W "$(_rr_subcmd_completion "$cmd")" -- "${COMP_WORDS[COMP_CWORD]}" ) )
+    fi
+}
+complete -F _rr_completion rr

--- a/src/main.cc
+++ b/src/main.cc
@@ -25,6 +25,7 @@ namespace rr {
 
 // Show version and quit.
 static bool show_version = false;
+static bool show_cmd_list = false;
 
 void assert_prerequisites(bool use_syscall_buffer) {
   struct utsname uname_buf;
@@ -100,10 +101,14 @@ void print_global_options(FILE* out) {
       out);
 }
 
+void list_commands(FILE* out) {
+  Command::print_help_all(out);
+}
+
 void print_usage(FILE* out) {
   print_version(out);
   fputs("\nUsage:\n", out);
-  Command::print_help_all(out);
+  list_commands(out);
   fputs("\nIf no subcommand is provided, we check if the first non-option\n"
         "argument is a directory. If it is, we assume the 'replay' subcommand\n"
         "otherwise we assume the 'record' subcommand.\n\n",
@@ -128,6 +133,7 @@ bool parse_global_option(std::vector<std::string>& args) {
     { 'E', "fatal-errors", NO_PARAMETER },
     { 'F', "force-things", NO_PARAMETER },
     { 'K', "check-cached-mmaps", NO_PARAMETER },
+    { 'L', "list-commands", NO_PARAMETER },
     { 'M', "mark-stdio", NO_PARAMETER },
     { 'N', "version", NO_PARAMETER },
     { 'S', "suppress-environment-warnings", NO_PARAMETER },
@@ -188,6 +194,9 @@ bool parse_global_option(std::vector<std::string>& args) {
     case 'N':
       show_version = true;
       break;
+    case 'L':
+      show_cmd_list = true;
+      break;
     default:
       DEBUG_ASSERT(0 && "Invalid flag");
   }
@@ -212,6 +221,10 @@ int main(int argc, char* argv[]) {
 
   if (show_version) {
     print_version(stdout);
+    return 0;
+  }
+  if (show_cmd_list) {
+    list_commands(stdout);
     return 0;
   }
 


### PR DESCRIPTION
Add --list-commands option to rr which is the first part of the current --help display.
Use it to generate rr completion (calling rr help command, and parsing the output).

This should also address https://github.com/mozilla/rr/issues/2253