### PR TITLE
Skip CPUID bug check on AMD

### DIFF
--- a/src/CPUIDBugDetector.cc
+++ b/src/CPUIDBugDetector.cc
@@ -45,7 +45,7 @@ static bool rcb_counts_ok(uint64_t prev, uint64_t current) {
 void CPUIDBugDetector::notify_reached_syscall_during_replay(ReplayTask* t) {
   // We only care about events that happen before the first exec,
   // when our detection code runs.
-  if (t->session().done_initial_exec()) {
+  if (t->session().done_initial_exec() || PerfCounters::skip_cpuid_bug_check()) {
     return;
   }
   const Event& ev = t->current_trace_frame().event();

--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -550,6 +550,10 @@ static void check_for_bugs() {
   check_working_counters();
 }
 
+bool PerfCounters::skip_cpuid_bug_check() {
+  return pmu_flags & PMU_SKIP_INTEL_BUG_CHECK;
+}
+
 static void init_attributes() {
   if (attributes_initialized) {
     return;

--- a/src/PerfCounters.h
+++ b/src/PerfCounters.h
@@ -86,6 +86,8 @@ public:
    * hope that tracees don't either. */
   enum { TIME_SLICE_SIGNAL = SIGSTKFLT };
 
+  static bool skip_cpuid_bug_check();
+
   static bool is_rr_ticks_attr(const perf_event_attr& attr);
 
   /**


### PR DESCRIPTION
I've left this as a separate PR because I wanted to keep #2255 as simple as possible, and it doesn't affect the tests. However, I'm not sure it's correct, because I don't know the details of the vmware bug this used to work around. Is it still relevant today?

make check is still in progress.