### PR TITLE
Fix the installation command for the bash completion script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,7 +535,7 @@ install(PROGRAMS scripts/signal-rr-recording.sh
                   ${CMAKE_CURRENT_BINARY_DIR}/bin/rr_page_32_replay
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(PROGRAMS scripts/rr_completion
-  DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/share/bash-completion/completions)
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/share/bash-completion/completions RENAME rr)
 
 install(TARGETS ${RR_BIN} rrpreload rr_exec_stub
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
The `install()` command specified a path under `${CMAKE_CURRENT_BINARY_DIR}`, but that path is in the build directory, not the install directory.

Furthermore, the completion scripts in the completions/ directory must have the same name as the command they provide completions for. The script is therefore renamed to `rr` upon installation.