### PR TITLE
Fix the installation command for the bash completion script (take 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,7 +535,7 @@ install(PROGRAMS scripts/signal-rr-recording.sh
                   ${CMAKE_CURRENT_BINARY_DIR}/bin/rr_page_32_replay
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(PROGRAMS scripts/rr_completion
-  DESTINATION ${CMAKE_INSTALL_DATADIR}/share/bash-completion/completions RENAME rr)
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/bash-completion/completions RENAME rr)
 
 install(TARGETS ${RR_BIN} rrpreload rr_exec_stub
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
The destination specified `share/` under `${CMAKE_INSTALL_DATADIR}`, which is usually `/usr/share`, giving `/usr/share/share`.