### PR TITLE
vagrant: use system python in cmake

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
 		cd rr
 		mkdir obj
 		cd obj
-		cmake ..
+		cmake .. -DPYTHON_EXECUTABLE=/usr/bin/python
 		make -j8
 		make test
 	SHELL


### PR DESCRIPTION
Now the cmake use hardcode python3 (See [cmake](https://github.com/Kitware/CMake/blob/9df49ba020ebfa15571ce818631bed6043368c8e/Utilities/Release/linux64_release.cmake#L35)) as ${PYTHON_EXECUTABLE}, which will throw the error `ImportError: No module named 'pexpect'`.

This PR set the system python as ${PYTHON_EXECUTABLE} to let cmake works.