### PR TITLE
Provide better error when rr_page_* file isn't found.

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -315,6 +315,8 @@ void AddressSpace::map_rr_page(AutoRemoteSyscalls& remote) {
     map(t, rr_page_start(), rr_page_size(), prot, flags, 0, file_name,
         fstat.st_dev, fstat.st_ino);
   } else {
+    ASSERT(t, child_fd != -ENOENT) << "rr_page file not found: "
+        << path.c_str();
     ASSERT(t, child_fd == -EACCES) << "Unexpected error mapping rr_page";
     flags |= MAP_ANONYMOUS;
     remote.infallible_mmap_syscall(rr_page_start(), rr_page_size(), prot, flags,


### PR DESCRIPTION
I ran into this error when trying to use rr in our (somewhat-weird) environment, and spent a while tracking down the Linux error code and figuring out where rr was actually looking for the file.  I thought I'd add a better error message for the next person to run into the same issue -- which is probably going to be me again!