### PR TITLE
Remove xmalloc, which is no longer used.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1177,14 +1177,6 @@ bool copy_file(int dest_fd, int src_fd) {
   return true;
 }
 
-void* xmalloc(size_t size) {
-  void* mem_ptr = malloc(size);
-  if (!mem_ptr) {
-    notifying_abort();
-  }
-  return mem_ptr;
-}
-
 bool has_effective_caps(uint64_t caps) {
   struct NativeArch::cap_header header = {.version =
                                               _LINUX_CAPABILITY_VERSION_3,

--- a/src/util.h
+++ b/src/util.h
@@ -286,12 +286,6 @@ inline void msan_unpoison(void* ptr, size_t n) {
 #endif
 
 /**
- * Allocate new memory of |size| in bytes. The pointer returned is never NULL.
- * This calls aborts the program if the host runs out of memory.
- */
-void* xmalloc(size_t size);
-
-/**
  * Determine if the given capabilities are a subset of the process' current
  * active capabilities.
  */


### PR DESCRIPTION
Fixes #820.

The tests still use an inlined version of xmalloc from src/test/util.h, which is unaffected by this removal.
