### PR TITLE
Add missing include to kernel_supplement.h.

### DIFF
--- a/src/kernel_supplement.h
+++ b/src/kernel_supplement.h
@@ -8,6 +8,7 @@
 #include <linux/seccomp.h>
 #include <linux/usbdevice_fs.h>
 #include <signal.h>
+#include <stdint.h>
 #include <sys/ioctl.h>
 #include <sys/ptrace.h>
 


### PR DESCRIPTION
The current version only happens to work because all users (by luck) already include stdint.h before including kernel_supplement.h.  However, precompiling the header alone will fail.