### PR TITLE
support replaying traces that involve persistent memory

### DIFF
--- a/src/kernel_supplement.h
+++ b/src/kernel_supplement.h
@@ -314,6 +314,11 @@ struct rr_input_mask {
 #define ARCH_SET_CPUID 0x1012
 #endif
 
+// New in the 4.15 kernel
+#ifndef MAP_SYNC
+#define MAP_SYNC  0x80000
+#endif
+
 } // namespace rr
 
 #endif /* RR_KERNEL_SUPPLEMENT_H_ */

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -4590,7 +4590,7 @@ static void process_mmap(RecordTask* t, size_t length, int prot, int flags,
   remote_ptr<void> addr = t->regs().syscall_result();
   if (flags & MAP_ANONYMOUS) {
     KernelMapping km;
-    if (flags & MAP_PRIVATE) {
+    if (!(flags & MAP_SHARED)) {
       // Anonymous mappings are by definition not backed by any file-like
       // object, and are initialized to zero, so there's no nondeterminism to
       // record.

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -44,6 +44,7 @@
 #include "core.h"
 #include "kernel_abi.h"
 #include "kernel_metadata.h"
+#include "kernel_supplement.h"
 #include "log.h"
 #include "util.h"
 
@@ -373,7 +374,12 @@ static void finish_direct_mmap(ReplayTask* t, AutoRemoteSyscalls& remote,
                                   * mappings go through while
                                   * they're not handled properly,
                                   * but we shouldn't do that.) */
-                                 prot, flags | MAP_FIXED, fd,
+                                 prot, (flags & ~MAP_SYNC) | MAP_FIXED, fd,
+                                /* MAP_SYNC is used to request direct mapping
+                                  * (DAX) from the filesystem for persistent
+                                  * memory devices (requires
+                                  * MAP_SHARED_VALIDATE). Drop it for the
+                                  * backing file. */
                                  backing_offset_pages);
 
   // While it's open, grab the link reference.


### PR DESCRIPTION
Linux 4.15+ adds support for persistent (non-volatile) memory devices (e.g. Intel Optane DIMM) by introducing two new flags to mmap(): MAP_SHARED_VALIDATE and MAP_SYNC.

This is implemented by defining MAP_SHARED_VALIDATE as MAP_SHARED | MAP_PRIVATE, which forcibly breaks legacy implementations, instead of silently ignoring unrecognized flags. Otherwise, it is equivalent to MAP_SHARED. 

MAP_SYNC is used to ensure consistency for persistent memory throughout the memory hierarchy, by requesting that the that the file be mapped without any intermediate caching (filesystem must be mounted in direct access / DAX mode), such that a cacheline flush + memory barrier is guaranteed to persist changes, even if the system crashes immediately afterwards. Because the trace recorder writes mapped regions in the trace log, which are materialized into a temporary backing file during replay, this flag needs to be unset, as tmpfs doesn't and shouldn't support DAX.

These patches pass the test suite, but I haven't added any additional tests because they require hardware that isn't yet publicly available, and can't be emulated without [adding a kernel boot parameter to modify the system memory map](https://docs.pmem.io/getting-started-guide/creating-development-environments/linux-environments/linux-memmap).