### PR TITLE
Add RR_FALLTHROUGH as appropriate.

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1058,7 +1058,7 @@ void RecordTask::signal_delivered(int sig) {
         if (h.disposition() == SIGNAL_HANDLER) {
           break;
         }
-      // Fall through...
+        RR_FALLTHROUGH;
       case SIGSTOP:
         // All threads in the process are stopped.
         for (Task* t : thread_group()->task_set()) {

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -879,10 +879,7 @@ static bool block_sock_opt(int level, int optname,
         case PACKET_TX_RING:
           syscall_state.emulate_result(-ENOPROTOOPT);
           return true;
-        default:
-          break;
       }
-    default:
       break;
   }
   return false;
@@ -3631,7 +3628,7 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
       syscall_state.reg_parameter<typename Arch::kernel_sigset_t>(
           4, IN, protect_rr_sigs);
       t->invalidate_sigmask();
-    /* fall through */
+      RR_FALLTHROUGH;
     case Arch::poll: {
       auto nfds = (nfds_t)regs.arg2();
       syscall_state.reg_parameter(1, sizeof(typename Arch::pollfd) * nfds,
@@ -3905,7 +3902,8 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
         case Q_SETQUOTA:
           FATAL() << "Trying to set disk quota usage, this may interfere with "
                      "rr recording";
-        // not reached
+          // not reached; the break is just to silence fallthrough warnings
+          break;
         case Q_QUOTAON:
         case Q_QUOTAOFF:
         case Q_SETINFO:

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -1282,7 +1282,7 @@ static void rep_process_syscall_arch(ReplayTask* t, ReplayTraceStep* step,
         default:
           return;
       }
-    /* fall through */
+      RR_FALLTHROUGH;
     case Arch::arch_prctl: {
       auto arg1 = t->regs().arg1();
       if (sys == Arch::arch_prctl &&
@@ -1290,7 +1290,7 @@ static void rep_process_syscall_arch(ReplayTask* t, ReplayTraceStep* step,
         return;
       }
     }
-    /* fall through */
+      RR_FALLTHROUGH;
     case Arch::munmap:
     case Arch::mprotect:
     case Arch::modify_ldt:


### PR DESCRIPTION
This fixes all warnings I found with -Wimplicit-fallthrough.  It also cleans up a couple of meaningless "default: break;" clauses that I noticed because we implicitly fell through into one of them.