### PR TITLE
use size_t (instead of uint64_t) in TraceStream

### DIFF
--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -93,9 +93,9 @@ public:
     /** Name of file to map the data from. */
     string file_name;
     /** Data offset within |file_name|. */
-    uint64_t data_offset_bytes;
+    size_t data_offset_bytes;
     /** Original size of mapped file. */
-    uint64_t file_size_bytes;
+    size_t file_size_bytes;
   };
 
 protected:


### PR DESCRIPTION
The function `min`

https://github.com/mozilla/rr/blob/40cc1f47fd27922e01643cc042d5d8611d771851/src/replay_syscall.cc#L859

requires the types of two arguments are the same. But this contract is not always valid since `data.data_offset_bytes` has type `uint64_t`: e.g. on system where `size_t != uint64_t`, the contract is invalidated.

The PR changes the types of fields in `TraceStream`.