### PR TITLE
Add --resource-path option.

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -258,7 +258,7 @@ remote_code_ptr AddressSpace::find_syscall_instruction(Task* t) {
 }
 
 static string find_rr_page_file(Task* t) {
-  string path = exe_directory() + "../bin/rr_page_";
+  string path = resource_path() + "bin/rr_page_";
   switch (t->arch()) {
     case x86:
       path += "32";

--- a/src/Flags.h
+++ b/src/Flags.h
@@ -61,6 +61,9 @@ struct Flags {
   // under valgrind.
   std::string forced_uarch;
 
+  // User override for the path to page files and other resources.
+  std::string resource_path;
+
   Flags()
       : checksum(CHECKSUM_NONE),
         dump_on(DUMP_ON_NONE),

--- a/src/GdbConnection.cc
+++ b/src/GdbConnection.cc
@@ -399,7 +399,7 @@ void GdbConnection::write_xfer_response(const void* data, size_t size,
 }
 
 static string read_target_desc(const char* file_name) {
-  string path = exe_directory() + "../share/rr/" + string(file_name);
+  string path = resource_path() + "share/rr/" + string(file_name);
   stringstream ss;
   FILE* f = fopen(path.c_str(), "r");
   DEBUG_ASSERT(f);

--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -519,7 +519,7 @@ static void copy_preload_sources_to_trace(const string& trace_dir) {
   mkdir(files_dir.c_str(), 0700);
   pid_t pid;
   string dest_path = files_dir + "/librrpreload.zip";
-  string src_path = exe_directory() + "../share/rr/src";
+  string src_path = resource_path() + "share/rr/src";
   char zip[] = "zip";
   char r[] = "-r";
   char j[] = "-j";

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1718,12 +1718,12 @@ bool RecordSession::prepare_to_inject_signal(RecordTask* t,
 }
 
 static string find_syscall_buffer_library() {
-  string lib_path = exe_directory() + "../lib64/rr/";
+  string lib_path = resource_path() + "lib64/rr/";
   string file_name = lib_path + SYSCALLBUF_LIB_FILENAME;
   if (access(file_name.c_str(), F_OK) == 0) {
     return lib_path;
   }
-  lib_path = exe_directory() + "../lib/rr/";
+  lib_path = resource_path() + "lib/rr/";
   file_name = lib_path + SYSCALLBUF_LIB_FILENAME;
   if (access(file_name.c_str(), F_OK) == 0) {
     return lib_path;

--- a/src/main.cc
+++ b/src/main.cc
@@ -54,6 +54,12 @@ void print_global_options(FILE* out) {
   fputs(
       "Global options:\n"
       "  --disable-cpuid-faulting   disable use of CPUID faulting\n"
+      "  --resource-path=PATH       specify the paths that rr should use to "
+      "find\n"
+      "                             files such as rr_page_*.  These files "
+      "should\n"
+      "                             be located in PATH/bin, PATH/lib[64], and\n"
+      "                             PATH/share as appropriate.\n"
       "  -A, --microarch=<NAME>     force rr to assume it's running on a CPU\n"
       "                             with microarch NAME even if runtime "
       "detection\n"
@@ -127,6 +133,7 @@ static void init_random() {
 bool parse_global_option(std::vector<std::string>& args) {
   static const OptionSpec options[] = {
     { 0, "disable-cpuid-faulting", NO_PARAMETER },
+    { 1, "resource-path", HAS_PARAMETER },
     { 'A', "microarch", HAS_PARAMETER },
     { 'C', "checksum", HAS_PARAMETER },
     { 'D', "dump-on", HAS_PARAMETER },
@@ -149,6 +156,12 @@ bool parse_global_option(std::vector<std::string>& args) {
   switch (opt.short_name) {
     case 0:
       flags.disable_cpuid_faulting = true;
+      break;
+    case 1:
+      flags.resource_path = opt.value;
+      if (flags.resource_path.back() != '/') {
+        flags.resource_path.append("/");
+      }
       break;
     case 'A':
       flags.forced_uarch = opt.value;

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -336,7 +336,7 @@ template <typename Arch> static void prepare_clone(ReplayTask* t) {
 }
 
 static string find_exec_stub(SupportedArch arch) {
-  string exe_path = exe_directory() + "../bin/";
+  string exe_path = resource_path() + "bin/";
   if (arch == x86 && NativeArch::arch() == x86_64) {
     exe_path += "rr_exec_stub_32";
   } else {

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -141,7 +141,10 @@ TESTDIR="${SRCDIR}/src/test"
 # Make rr treat temp files as durable. This saves copying all test
 # binaries into the trace.
 export RR_TRUST_TEMP_FILES=1
+
+# Set options to find rr and resource files in the expected places.
 export PATH="${OBJDIR}/bin:${PATH}"
+GLOBAL_OPTIONS="${GLOBAL_OPTIONS} --resource-path=${OBJDIR}"
 
 which rr >/dev/null 2>&1
 if [[ "$?" != "0" ]]; then

--- a/src/util.cc
+++ b/src/util.cc
@@ -1090,9 +1090,13 @@ static string read_exe_dir() {
   return exe_path;
 }
 
-string exe_directory() {
-  static string exe_path = read_exe_dir();
-  return exe_path;
+string resource_path() {
+  string resource_path = Flags::get().resource_path;
+  if (resource_path.empty()) {
+    static string exe_path = read_exe_dir() + "../";
+    return exe_path;
+  }
+  return resource_path;
 }
 
 /**

--- a/src/util.h
+++ b/src/util.h
@@ -244,7 +244,7 @@ void dump_task_map(const std::map<pid_t, Task*>& tasks);
 
 std::string real_path(const std::string& path);
 
-std::string exe_directory();
+std::string resource_path();
 
 /**
  * Get the current time from the preferred monotonic clock in units of


### PR DESCRIPTION
In some cases, we may need to override the default that expects these files to be located relative to the location of the mmap'ed rr executable.  This is particularly relevant when the executable is a symlink, as the symlink is effectively resolved before computing the relative paths, and this may not be the desired behavior.