### PR TITLE
Avoid a macro-redefinition error.

### DIFF
--- a/src/test/privileged_net_ioctl.c
+++ b/src/test/privileged_net_ioctl.c
@@ -25,7 +25,9 @@ void buf_put_attr(char** cur_buf_pos, uint16_t opt, void* data, size_t size) {
   *cur_buf_pos += RTA_ALIGN(size) - size;
 }
 
+#ifndef htonl
 #define htonl(x) __bswap_32(x)
+#endif
 
 int main(void) {
   if (-1 == try_setup_ns(CLONE_NEWNET)) {


### PR DESCRIPTION
This duplicates a definition in glibc's netinet/in.h, so we should only define it if we need to.