### PR TITLE
Fix ls

### DIFF
--- a/src/LsCommand.cc
+++ b/src/LsCommand.cc
@@ -235,11 +235,6 @@ static int ls(const string& traces_dir, const LsFlags& flags, FILE* out) {
 }
 
 int LsCommand::run(vector<string>& args) {
-  if (getenv("RUNNING_UNDER_RR")) {
-    fprintf(stderr, "rr: cannot run rr replay under rr. Exiting.\n");
-    return 1;
-  }
-
   bool found_dir = false;
   string trace_dir;
   LsFlags flags;


### PR DESCRIPTION
I guess I should open an issue for this, but `rr ls -t` is crashing for me.

The problem is that in one place, it neglects to add a trailing '/' to a path component and produces a malformed path. Because of the way std::sort works, that makes the comparison function return inconsistent results, which results in std::sort accessing out of bounds memory before the beginning of the sorted array.

The minimal fix would be to add in the trailing '/'. But that's an incomplete fix; if inconsistent sort results can cause an OOB error, then it is theoretically possible to trigger that intentionally by racing file entry updates with `rr ls -t` (because it's implemented in a stupid way and re-stat'ing for every compare). So this patch stats everything once and remembers the results.