### PR TITLE
Fix clang -Wmain warning

### DIFF
--- a/src/chaos-test/pipe_wakeup.c
+++ b/src/chaos-test/pipe_wakeup.c
@@ -15,7 +15,8 @@ static void* run_thread(__attribute__((unused)) void* p) {
   return NULL;
 }
 
-int main(__attribute__((unused)) int argc) {
+int main(__attribute__((unused)) int argc,
+         __attribute__((unused)) const char** argv) {
   int i;
   int ret;
   pthread_t thread;


### PR DESCRIPTION
`main` accepts either 0 or 2 parameters.