### PR TITLE
Fix forward decl of struct TraceUuid

### DIFF
--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -25,7 +25,7 @@ struct CPUIDRecord;
 struct DisableCPUIDFeatures;
 class KernelMapping;
 class RecordTask;
-class TraceUuid;
+struct TraceUuid;
 
 /**
  * TraceStream stores all the data common to both recording and


### PR DESCRIPTION
TraceUuid is a struct, not a class -- but currently this header forward-declares it as a class.

In clang 9.0, that gives me a build warning when we get to the actual struct definition (treated as an error via -Werror): "RecordSession.h:49:1: error: 'TraceUuid' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]"

Fixed here by correcting the mistaken forward declaration.