### PR TITLE
Add --stats=N option to replay -a

### DIFF
--- a/src/ReplayCommand.cc
+++ b/src/ReplayCommand.cc
@@ -362,12 +362,12 @@ static void serve_replay_no_debugger(const string& trace_dir,
       Session::Statistics stats = replay_session->statistics();
       fprintf(stderr,
           "[ReplayStatistics] ticks %lld syscalls %lld bytes_written %lld "
-          "microseconds %lld %%realtime %.1f%%\n",
+          "microseconds %lld %%realtime %.0f%%\n",
           (long long)(stats.ticks_processed - last_stats.ticks_processed),
           (long long)(stats.syscalls_performed - last_stats.syscalls_performed),
           (long long)(stats.bytes_written - last_stats.bytes_written),
           (long long)elapsed_usec,
-          100.0 * (double)elapsed_usec / ((rectime - last_dump_rectime) * 1.0e6)
+          100.0 * ((rectime - last_dump_rectime) * 1.0e6) / (double)elapsed_usec
         );
       last_dump_time = now;
       last_stats = stats;

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -525,7 +525,7 @@ TraceFrame TraceReader::read_frame() {
   if (ret.ticks_ < 0) {
     FATAL() << "Invalid ticks value";
   }
-  ret.monotonic_time_ = frame.getMonotonicSec();
+  monotonic_time_ = ret.monotonic_time_ = frame.getMonotonicSec();
 
   SupportedArch arch = from_trace_arch(frame.getArch());
   ret.recorded_regs.set_arch(arch);

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -394,6 +394,8 @@ public:
 
   TicksSemantics ticks_semantics() const { return ticks_semantics_; }
 
+  double recording_time() const { return monotonic_time_; }
+
 private:
   CompressedReader& reader(Substream s) { return *readers[s]; }
   const CompressedReader& reader(Substream s) const { return *readers[s]; }
@@ -404,6 +406,7 @@ private:
   std::vector<RawDataMetadata> raw_recs;
   TicksSemantics ticks_semantics_;
   bool trace_uses_cpuid_faulting;
+  double monotonic_time_;
 };
 
 extern std::string trace_save_dir();


### PR DESCRIPTION
I was looking at a replay hang, which is looking like it was just a very slow replay, and it was convenient to have a periodic dump showing the speed of the replay relative to the original recording.

You'll probably have a better idea for what to call things (monotonic time vs realtime vs record time), and I can also eliminate the zero-check on every step if you like (by displaying "nan%" for the first dump).
