### PR TITLE
Remove use of variable-length arrays.

### DIFF
--- a/src/GdbConnection.cc
+++ b/src/GdbConnection.cc
@@ -1608,7 +1608,8 @@ void GdbConnection::reply_get_reg(const GdbRegisterValue& reg) {
 }
 
 void GdbConnection::reply_get_regs(const vector<GdbRegisterValue>& file) {
-  char buf[file.size() * 2 * GdbRegisterValue::MAX_SIZE + 1];
+  std::unique_ptr<char[]> buf(
+      new char[file.size() * 2 * GdbRegisterValue::MAX_SIZE + 1]);
 
   DEBUG_ASSERT(DREQ_GET_REGS == req.type);
 
@@ -1616,7 +1617,7 @@ void GdbConnection::reply_get_regs(const vector<GdbRegisterValue>& file) {
   for (auto& reg : file) {
     offset += print_reg_value(reg, &buf[offset]);
   }
-  write_packet(buf);
+  write_packet(buf.get());
 
   consume_request();
 }

--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -289,11 +289,12 @@ static bool patch_syscall_with_hook_x86ish(Monkeypatcher& patcher,
   static const uint8_t NOP = 0x90;
   DEBUG_ASSERT(syscall_instruction_length(x86_64) ==
                syscall_instruction_length(x86));
-  uint8_t nops[syscall_instruction_length(x86_64) +
-               hook.next_instruction_length - sizeof(jump_patch)];
-  memset(nops, NOP, sizeof(nops));
-  write_and_record_mem(t, jump_patch_start + sizeof(jump_patch), nops,
-                       sizeof(nops));
+  size_t nops_bufsize = syscall_instruction_length(x86_64) +
+                        hook.next_instruction_length - sizeof(jump_patch);
+  std::unique_ptr<uint8_t[]> nops(new uint8_t[nops_bufsize]);
+  memset(nops.get(), NOP, nops_bufsize);
+  write_and_record_mem(t, jump_patch_start + sizeof(jump_patch), nops.get(),
+                       nops_bufsize);
 
   return true;
 }

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -771,9 +771,9 @@ string Task::read_c_str(remote_ptr<char> child_addr) {
     // end_of_page) is mapped.
     remote_ptr<void> end_of_page = ceil_page_size(p + 1);
     ssize_t nbytes = end_of_page - p;
-    char buf[nbytes];
+    std::unique_ptr<char[]> buf(new char[nbytes]);
 
-    read_bytes_helper(p, nbytes, buf);
+    read_bytes_helper(p, nbytes, buf.get());
     for (int i = 0; i < nbytes; ++i) {
       if ('\0' == buf[i]) {
         return str;

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -639,9 +639,12 @@ Switchable TaskSyscallState::done_preparing_internal(Switchable sw) {
     ASSERT(t, param.num_bytes.incoming_size < size_t(-1));
     if (param.mode == IN_OUT || param.mode == IN) {
       // Initialize scratch buffer with input data
-      uint8_t buf[param.num_bytes.incoming_size];
-      t->read_bytes_helper(param.dest, param.num_bytes.incoming_size, buf);
-      t->write_bytes_helper(param.scratch, param.num_bytes.incoming_size, buf);
+      std::unique_ptr<uint8_t[]> buf(
+          new uint8_t[param.num_bytes.incoming_size]);
+      t->read_bytes_helper(param.dest, param.num_bytes.incoming_size,
+                           buf.get());
+      t->write_bytes_helper(param.scratch, param.num_bytes.incoming_size,
+                            buf.get());
     }
   }
   // Step 2: Update pointers in registers/memory to point to scratch areas


### PR DESCRIPTION
Although variable-length arrays (VLAs) are standard C, they are not part of standard C++ and lead to warnings in strict compilation modes.  This patch replaces rr's use of them with heap-allocated arrays using std::unique_ptr, so that we get the same lifetime behavior and essentially the same runtime cost aside from the memory allocation.