### PR TITLE
Fix -Wnonnull warnings converting nullptr to std::string.

### DIFF
--- a/src/Event.cc
+++ b/src/Event.cc
@@ -208,7 +208,7 @@ std::string Event::type_name() const {
 #undef CASE
     default:
       FATAL() << "Unknown event type " << event_type;
-      return nullptr; // not reached
+      return ""; // not reached
   }
 }
 

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -1177,8 +1177,7 @@ static string make_trace_dir(const string& exe_path, const string& output_trace_
     return dir;
   }
 
-  // never should reach that
-  return nullptr;
+  return ""; // not reached
 }
 
 #define STR_HELPER(x) #x


### PR DESCRIPTION
There are a couple of functions in rr that return std::string values but have "return nullptr" in unreachable cases.  This now causes warnings with Clang at head, so this patch replaces them with returning an empty string.