### PR TITLE
Fix build in newer glibc.

### DIFF
--- a/src/test/tgkill.c
+++ b/src/test/tgkill.c
@@ -4,9 +4,8 @@
 
 static int num_signals_caught;
 
-static int tgkill(int tgid, int tid, int sig) {
-  return syscall(SYS_tgkill, tgid, tid, sig);
-}
+#define tgkill(tgid, tid, sig) \
+  syscall(SYS_tgkill, (int)(tgid), (int)(tid), (int)(sig))
 
 static void sighandler(int sig) {
   atomic_printf("Task %d got signal %d\n", sys_gettid(), sig);


### PR DESCRIPTION
Seems tgkill was added recently to glibc.

build/32/tgkill.c:7:12: error: static declaration of 'tgkill' follows non-static declaration
static int tgkill(int tgid, int tid, int sig) {
           ^
/usr/include/bits/signal_ext.h:29:12: note: previous declaration is here
extern int tgkill (__pid_t __tgid, __pid_t __tid, int __signal);