### PR TITLE
Support LLDB as a client.

### DIFF
--- a/src/GdbConnection.h
+++ b/src/GdbConnection.h
@@ -688,6 +688,7 @@ private:
   std::vector<uint8_t> outbuf; /* buffered output for gdb */
   Features features_;
   bool connection_alive_;
+  bool multiprocess_supported_; // client supports multiprocess extension
 };
 
 } // namespace rr


### PR DESCRIPTION
- Do not use "multiprocess" thread id syntax, unless the client supports it.
- Support "c" packet, which LLDB prefers to use instead of "vCont;c".