### PR TITLE
Add support for breakpoints on SystemTap probes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,11 +327,13 @@ set_target_properties(rrpreload PROPERTIES LINK_FLAGS "-nostartfiles")
 
 set(AUDIT_FILES
   rtld-audit.c
+  stap-note-iter.c
   ../preload/raw_syscall.S
 )
 set(AUDIT_SOURCE_FILES
   ${AUDIT_FILES}
   rtld-audit.h
+  stap-note-iter.h
   ../preload/preload_interface.h
 )
 add_library(rraudit)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,23 @@ foreach(file ${PRELOAD_FILES})
 endforeach(file)
 set_target_properties(rrpreload PROPERTIES LINK_FLAGS "-nostartfiles")
 
+set(AUDIT_FILES
+  rtld-audit.c
+  ../preload/raw_syscall.S
+)
+set(AUDIT_SOURCE_FILES
+  ${AUDIT_FILES}
+  rtld-audit.h
+  ../preload/preload_interface.h
+)
+add_library(rraudit)
+foreach(file ${AUDIT_FILES})
+  target_sources(rraudit PUBLIC "${CMAKE_SOURCE_DIR}/src/audit/${file}")
+  set_source_files_properties("${CMAKE_SOURCE_DIR}/src/audit/${file}"
+                              PROPERTIES COMPILE_FLAGS ${PRELOAD_COMPILE_FLAGS})
+endforeach(file)
+set_target_properties(rraudit PROPERTIES LINK_FLAGS "-nostartfiles -ldl")
+
 # Ensure that CMake knows about our generated files.
 #
 # Alphabetical, please.
@@ -594,7 +611,7 @@ install(TARGETS ${RR_BIN} rrpreload rr_exec_stub
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/rr
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/rr)
 
-# Build 32-bit librrpreload on 64-bit builds.
+# Build 32-bit librrpreload and librraudit on 64-bit builds.
 # We copy the source files into '32' subdirectories in the output
 # directory, so we can set different compile options on them.
 # This sucks but I can't find a better way to get CMake to build
@@ -604,18 +621,37 @@ if(rr_32BIT AND rr_64BIT)
 
   foreach(file ${PRELOAD_SOURCE_FILES})
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/preload/${file}"
-                   "${CMAKE_CURRENT_BINARY_DIR}/32/${file}"
+                   "${CMAKE_CURRENT_BINARY_DIR}/32/preload/${file}"
                    COPYONLY)
   endforeach(file)
 
   foreach(file ${PRELOAD_FILES})
-    target_sources(rrpreload_32 PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/32/${file}")
-    set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/32/${file}"
+    target_sources(rrpreload_32 PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/32/preload/${file}")
+    set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/32/preload/${file}"
                                 PROPERTIES COMPILE_FLAGS "-m32 ${PRELOAD_COMPILE_FLAGS}")
   endforeach(file)
 
   set_target_properties(rrpreload_32 PROPERTIES LINK_FLAGS "-m32 -nostartfiles")
   target_link_libraries(rrpreload_32
+    ${CMAKE_DL_LIBS}
+  )
+
+  add_library(rraudit_32)
+
+  foreach(file ${AUDIT_SOURCE_FILES})
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/audit/${file}"
+                   "${CMAKE_CURRENT_BINARY_DIR}/32/audit/${file}"
+                   COPYONLY)
+  endforeach(file)
+
+  foreach(file ${AUDIT_FILES})
+    target_sources(rraudit_32 PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/32/audit/${file}")
+    set_source_files_properties("${CMAKE_CURRENT_BINARY_DIR}/32/audit/${file}"
+                                PROPERTIES COMPILE_FLAGS "-m32 ${PRELOAD_COMPILE_FLAGS}")
+  endforeach(file)
+
+  set_target_properties(rraudit_32 PROPERTIES LINK_FLAGS "-m32 -nostartfiles")
+  target_link_libraries(rraudit_32
     ${CMAKE_DL_LIBS}
   )
 
@@ -632,7 +668,7 @@ if(rr_32BIT AND rr_64BIT)
   set_target_properties(rr_exec_stub_32
                         PROPERTIES LINK_FLAGS "-static -nostartfiles -nodefaultlibs -m32")
 
-  install(TARGETS rrpreload_32 rr_exec_stub_32
+  install(TARGETS rrpreload_32 rraudit_32 rr_exec_stub_32
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/rr
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/rr)

--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -1983,4 +1983,38 @@ remote_ptr<void> AddressSpace::find_free_memory(size_t required_space,
   return current->map.end();
 }
 
+void AddressSpace::add_stap_semaphore_range(Task* task, MemoryRange range) {
+  ASSERT(task, range.start() != range.end())
+    << "Unexpected zero-length SystemTap semaphore range: " << range;
+  ASSERT(task, (range.size() & 1) == 0)
+    << "Invalid SystemTap semaphore range at "
+    << range
+    << ": size is not a multiple of the size of a STap semaphore!";
+
+  auto ptr = range.start().cast<uint16_t>(),
+       end = range.end().cast<uint16_t>();
+  for (; ptr < end; ++ptr) {
+    stap_semaphores.insert(ptr);
+  }
+}
+
+void AddressSpace::remove_stap_semaphore_range(Task* task, MemoryRange range) {
+  ASSERT(task, range.start() != range.end())
+    << "Unexpected zero-length SystemTap semaphore range: " << range;
+  ASSERT(task, (range.size() & 1) == 0)
+    << "Invalid SystemTap semaphore range at "
+    << range
+    << ": size is not a multiple of the size of a STap semaphore!";
+
+  auto ptr = range.start().cast<uint16_t>(),
+       end = range.end().cast<uint16_t>();
+  for (; ptr < end; ++ptr) {
+    stap_semaphores.erase(ptr);
+  }
+}
+
+bool AddressSpace::is_stap_semaphore(remote_ptr<uint16_t> addr) {
+  return stap_semaphores.find(addr) != stap_semaphores.end();
+}
+
 } // namespace rr

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -776,6 +776,10 @@ public:
    */
   static void print_process_maps(Task* t);
 
+  void add_stap_semaphore_range(Task* t, MemoryRange range);
+  void remove_stap_semaphore_range(Task* t, MemoryRange range);
+  bool is_stap_semaphore(remote_ptr<uint16_t> addr);
+
 private:
   struct Breakpoint;
   typedef std::map<remote_code_ptr, Breakpoint> BreakpointMap;
@@ -1065,6 +1069,8 @@ private:
    * 0 if no such event has occurred.
    */
   FrameTime first_run_event_;
+
+  std::set<remote_ptr<uint16_t>> stap_semaphores;
 
   /**
    * For each architecture, the offset of a syscall instruction with that

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -504,6 +504,14 @@ void GdbServer::dispatch_debugger_request(Session& session,
         dbg->reply_set_mem(true);
         return;
       }
+      // If an address is recognised as belonging to a SystemTap semaphore it's
+      // because it was detected by the audit library during recording and
+      // pre-incremented.
+      if (target->vm()->is_stap_semaphore(req.mem().addr)) {
+        LOG(info) << "Suppressing write to SystemTap semaphore";
+        dbg->reply_set_mem(true);
+        return;
+      }
       // We only allow the debugger to write memory if the
       // memory will be written to an diversion session.
       // Arbitrary writes to replay sessions cause

--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -61,14 +61,14 @@ static void write_and_record_mem(RecordTask* t, remote_ptr<T> child_addr,
  * because we're recording an rr replay).
  */
 #define setup_library_path(arch, env_var, soname, task) \
-  _setup_library_path<arch>(task, env_var, soname ## _BASE, \
-                            soname ## _PADDED, soname ## _32)
+  setup_library_path_arch<arch>(task, env_var, soname ## _BASE, \
+                                soname ## _PADDED, soname ## _32)
 
 template <typename Arch>
-static void _setup_library_path(RecordTask* t, const char* env_var,
-                                const char* soname_base,
-                                const char* soname_padded,
-                                const char* soname_32) {
+static void setup_library_path_arch(RecordTask* t, const char* env_var,
+                                    const char* soname_base,
+                                    const char* soname_padded,
+                                    const char* soname_32) {
   const char* lib_name =
       sizeof(typename Arch::unsigned_word) < sizeof(uintptr_t)
           ? soname_32

--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -47,10 +47,11 @@ static void write_and_record_mem(RecordTask* t, remote_ptr<T> child_addr,
 
 /**
  * RecordSession sets up an LD_PRELOAD environment variable with an entry
- * SYSCALLBUF_LIB_FILENAME_PADDED which is big enough to hold either the
- * 32-bit or 64-bit preload library file names. Immediately after exec we
- * enter this function, which patches the environment variable value with
- * the correct library name for the task's architecture.
+ * SYSCALLBUF_LIB_FILENAME_PADDED (and, if enabled, an LD_AUDIT environment
+ * variable with an entry RTLDAUDIT_LIB_FILENAME_PADDED) which is big enough to
+ * hold either the 32-bit or 64-bit preload/audit library file names.
+ * Immediately after exec we enter this function, which patches the environment
+ * variable value with the correct library name for the task's architecture.
  *
  * It's possible for this to fail if a tracee alters the LD_PRELOAD value
  * and then does an exec. That's just too bad. If we ever have to handle that,
@@ -59,15 +60,20 @@ static void write_and_record_mem(RecordTask* t, remote_ptr<T> child_addr,
  * overridden by the preload library, or might override them itself (e.g.
  * because we're recording an rr replay).
  */
-template <typename Arch> static void setup_preload_library_path(RecordTask* t) {
-  static_assert(sizeof(SYSCALLBUF_LIB_FILENAME_PADDED) ==
-                    sizeof(SYSCALLBUF_LIB_FILENAME_32),
-                "filename length mismatch");
+#define setup_library_path(arch, env_var, soname, task) \
+  _setup_library_path<arch>(task, env_var, soname ## _BASE, \
+                            soname ## _PADDED, soname ## _32)
 
+template <typename Arch>
+static void _setup_library_path(RecordTask* t, const char* env_var,
+                                const char* soname_base,
+                                const char* soname_padded,
+                                const char* soname_32) {
   const char* lib_name =
       sizeof(typename Arch::unsigned_word) < sizeof(uintptr_t)
-          ? SYSCALLBUF_LIB_FILENAME_32
-          : SYSCALLBUF_LIB_FILENAME_PADDED;
+          ? soname_32
+          : soname_padded;
+  auto env_assignment = string(env_var) + "=";
 
   auto p = t->regs().sp().cast<typename Arch::unsigned_word>();
   auto argc = t->read_mem(p);
@@ -75,17 +81,17 @@ template <typename Arch> static void setup_preload_library_path(RecordTask* t) {
   while (true) {
     auto envp = t->read_mem(p);
     if (!envp) {
-      LOG(debug) << "LD_PRELOAD not found";
+      LOG(debug) << env_var << " not found";
       return;
     }
     string env = t->read_c_str(envp);
-    if (env.find("LD_PRELOAD=") != 0) {
+    if (env.find(env_assignment) != 0) {
       ++p;
       continue;
     }
-    size_t lib_pos = env.find(SYSCALLBUF_LIB_FILENAME_BASE);
+    size_t lib_pos = env.find(soname_base);
     if (lib_pos == string::npos) {
-      LOG(debug) << SYSCALLBUF_LIB_FILENAME_BASE " not found in LD_PRELOAD";
+      LOG(debug) << soname_base << " not found in " << env_var;
       return;
     }
     size_t next_colon = env.find(':', lib_pos);
@@ -95,21 +101,36 @@ template <typename Arch> static void setup_preload_library_path(RecordTask* t) {
         ++next_colon;
       }
       if (next_colon + 1 <
-          lib_pos + sizeof(SYSCALLBUF_LIB_FILENAME_PADDED) - 1) {
+          lib_pos + sizeof(soname_padded) - 1) {
         LOG(debug) << "Insufficient space for " << lib_name
-                   << " in LD_PRELOAD before next ':'";
+                   << " in " << env_var << " before next ':'";
         return;
       }
     }
-    if (env.length() < lib_pos + sizeof(SYSCALLBUF_LIB_FILENAME_PADDED) - 1) {
+    if (env.length() < lib_pos + sizeof(soname_padded) - 1) {
       LOG(debug) << "Insufficient space for " << lib_name
-                 << " in LD_PRELOAD before end of string";
+                 << " in " << env_var << " before end of string";
       return;
     }
     remote_ptr<void> dest = envp + lib_pos;
-    write_and_record_mem(t, dest.cast<char>(), lib_name,
-                         sizeof(SYSCALLBUF_LIB_FILENAME_PADDED) - 1);
+    write_and_record_mem(t, dest.cast<char>(), lib_name, strlen(soname_padded));
     return;
+  }
+}
+
+template <typename Arch> static void setup_preload_library_path(RecordTask* t) {
+  static_assert(sizeof(SYSCALLBUF_LIB_FILENAME_PADDED) ==
+                    sizeof(SYSCALLBUF_LIB_FILENAME_32),
+                "filename length mismatch");
+  setup_library_path(Arch, "LD_PRELOAD", SYSCALLBUF_LIB_FILENAME, t);
+}
+
+template <typename Arch> static void setup_audit_library_path(RecordTask* t) {
+  static_assert(sizeof(RTLDAUDIT_LIB_FILENAME_PADDED) ==
+                    sizeof(RTLDAUDIT_LIB_FILENAME_32),
+                "filename length mismatch");
+  if (t->session().use_audit()) {
+    setup_library_path(Arch, "LD_AUDIT", RTLDAUDIT_LIB_FILENAME, t);
   }
 }
 
@@ -602,6 +623,7 @@ static void obliterate_debug_info(RecordTask* t, VdsoReader& reader) {
 template <>
 void patch_after_exec_arch<X86Arch>(RecordTask* t, Monkeypatcher& patcher) {
   setup_preload_library_path<X86Arch>(t);
+  setup_audit_library_path<X86Arch>(t);
 
   VdsoReader reader(t);
   auto syms = reader.read_symbols(".dynsym", ".dynstr");
@@ -723,6 +745,7 @@ void patch_at_preload_init_arch<X86Arch>(RecordTask* t,
 template <>
 void patch_after_exec_arch<X64Arch>(RecordTask* t, Monkeypatcher& patcher) {
   setup_preload_library_path<X64Arch>(t);
+  setup_audit_library_path<X64Arch>(t);
 
   auto vdso_start = t->vm()->vdso().start();
   size_t vdso_size = t->vm()->vdso().size();

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1744,7 +1744,7 @@ static string find_helper_library(const char* basepath) {
   return lib_path;
 }
 
-static void inject_ld_helper_library(vector<string> env,
+static void inject_ld_helper_library(vector<string>& env,
                                      string env_var,
                                      string value) {
   // Our preload lib should come first if possible, because that will speed up
@@ -1769,7 +1769,7 @@ static void inject_ld_helper_library(vector<string> env,
   }
   value = env_assignment + value;
   if (it == env.end()) {
-    env.push_back(env_assignment + value);
+    env.push_back(value);
   } else {
     *it = value;
   }

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -67,7 +67,8 @@ public:
       unsigned char syscallbuf_desched_sig = SIGPWR,
       BindCPU bind_cpu = BIND_CPU,
       const std::string& output_trace_dir = "",
-      const TraceUuid* trace_id = nullptr);
+      const TraceUuid* trace_id = nullptr,
+      bool use_audit = false);
 
   const DisableCPUIDFeatures& disable_cpuid_features() const {
     return disable_cpuid_features_;
@@ -83,6 +84,7 @@ public:
   int get_continue_through_sig() const { return continue_through_sig; }
   void set_asan_active(bool active) { asan_active_ = active; }
   bool asan_active() const { return asan_active_; }
+  bool use_audit() const { return use_audit_; }
   uint64_t rr_signal_mask() const;
 
   enum RecordStatus {
@@ -190,7 +192,8 @@ private:
                 int syscallbuf_desched_sig,
                 BindCPU bind_cpu,
                 const std::string& output_trace_dir,
-                const TraceUuid* trace_id);
+                const TraceUuid* trace_id,
+                bool use_audit);
 
   virtual void on_create(Task* t) override;
 
@@ -243,6 +246,8 @@ private:
   bool wait_for_all_;
 
   std::string output_trace_dir;
+
+  bool use_audit_;
 };
 
 } // namespace rr

--- a/src/audit/rtld-audit.c
+++ b/src/audit/rtld-audit.c
@@ -1,5 +1,9 @@
+#include "stap-note-iter.h"
 #include "rtld-audit.h"
+#include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
+#include <string.h>
 #define RR_IMPLEMENT_AUDIT
 #include "../preload/preload_interface.h"
 
@@ -31,6 +35,10 @@
  * [2]: https://sourceware.org/bugzilla/show_bug.cgi?id=15971
  */
 
+typedef struct {
+  uintptr_t start, end;
+} SemaphoreAddrRange;
+
 extern __attribute__((visibility("hidden")))
 long _raw_syscall(int syscallno, long a0, long a1, long a2,
                   long a3, long a4, long a5,
@@ -42,4 +50,167 @@ bool rr_audit_debug;
 unsigned la_version(unsigned version) {
   rr_audit_debug = !!getenv("RR_AUDIT_DEBUG");
   return version;
+}
+
+static void semaphore_addr_range_init(SemaphoreAddrRange* range) {
+  range->start = 0;
+  range->end = 0;
+}
+
+static void semaphore_addr_range_init_single(SemaphoreAddrRange* range,
+                                             uintptr_t addr) {
+  range->start = addr;
+  range->end = addr + sizeof(uint16_t);
+}
+
+static bool semaphore_addr_range_is_valid(const SemaphoreAddrRange* range) {
+  return range->end > range->start;
+}
+
+static bool semaphore_addr_range_contains(const SemaphoreAddrRange* range,
+                                          uintptr_t addr) {
+  return addr >= range->start && addr < range->end;
+}
+
+static bool semaphore_addr_range_contiguous(const SemaphoreAddrRange* range,
+                                            uintptr_t addr) {
+  return addr + sizeof(uint16_t) == range->start || addr == range->end;
+}
+
+static void semaphore_addr_range_expand(SemaphoreAddrRange* range,
+                                        uintptr_t addr) {
+  if (addr < range->start) {
+    range->start = addr;
+  }
+  if (addr + sizeof(uint16_t) > range->end) {
+    range->end = addr + sizeof(uint16_t);
+  }
+}
+
+static void semaphore_addr_range_submit(const SemaphoreAddrRange* range,
+                                        int syscallno) {
+  if (rr_audit_debug) {
+    fprintf(stderr,
+            "Submitting STap semaphore range: "
+              "0x%" PRIxELFADDR "-0x%" PRIxELFADDR "\n",
+            range->start, range->end);
+  }
+  _raw_syscall(syscallno,
+               range->start, range->end,
+               0, 0, 0, 0,
+               RR_PAGE_SYSCALL_TRACED,
+               0, 0);
+}
+
+static void semaphore_addr_range_handle_add(SemaphoreAddrRange* range,
+                                            ElfW(Addr) address,
+                                            int submit_syscallno) {
+  if (semaphore_addr_range_contiguous(range, address)) {
+    semaphore_addr_range_expand(range, address);
+  } else {
+    if (semaphore_addr_range_is_valid(range)) {
+      semaphore_addr_range_submit(range, submit_syscallno);
+    }
+    semaphore_addr_range_init_single(range, address);
+  }
+}
+
+unsigned la_objopen(struct link_map* map,
+                    Lmid_t lmid,
+                    uintptr_t* cookie __attribute__((unused))) {
+  StapNoteIter iter;
+  ElfStapNote note;
+  SemaphoreAddrRange range;
+
+  if (lmid != LM_ID_BASE) {
+    return 0;
+  }
+
+  if (rr_audit_debug) {
+    fprintf(stderr,
+            "Processing STap semaphores for loaded object: %s\n",
+            map->l_name);
+  }
+
+  semaphore_addr_range_init(&range);
+  stap_note_iter_init(&iter, map);
+  while (stap_note_iter_next(&iter, &note)) {
+    if (note.semaphore_address &&
+        !semaphore_addr_range_contains(&range, note.semaphore_address)) {
+      uint16_t* semaphore = (void*) note.semaphore_address;
+      if (rr_audit_debug) {
+        fprintf(stderr,
+                "Incrementing STap semaphore for %s:%s at "
+                  "0x%" PRIxELFADDR " (was: %u)\n",
+                note.provider_name, note.probe_name,
+                note.semaphore_address,
+                *semaphore);
+      }
+      (*semaphore)++;
+      semaphore_addr_range_handle_add(&range,
+                                      note.semaphore_address,
+                                      SYS_rrcall_notify_stap_semaphore_added);
+    }
+  }
+  stap_note_iter_release(&iter);
+
+  if (semaphore_addr_range_is_valid(&range)) {
+    semaphore_addr_range_submit(&range, SYS_rrcall_notify_stap_semaphore_added);
+  }
+
+  return 0;
+}
+
+unsigned la_objclose(uintptr_t* cookie) {
+  StapNoteIter iter;
+  ElfStapNote note;
+  SemaphoreAddrRange range;
+
+  /* The default value of cookie is the address of the link_map structure.
+   * Since we don't modify the value in la_objopen, this should still be its
+   * value. */
+  const struct link_map* map = (void*) *cookie;
+
+  /* ld.so never has its cookie value initialised, so map will be NULL.
+   * However, none of its probes have associated semaphores so we can just
+   * ignore it. */
+  if (!map) {
+    return 0;
+  }
+
+  if (rr_audit_debug) {
+    fprintf(stderr,
+            "Processing STap semaphores for closing object: %s\n",
+            map->l_name);
+  }
+
+  semaphore_addr_range_init(&range);
+  stap_note_iter_init(&iter, map);
+  while (stap_note_iter_next(&iter, &note)) {
+    if (note.semaphore_address &&
+        !semaphore_addr_range_contains(&range, note.semaphore_address)) {
+      uint16_t* semaphore = (void*) note.semaphore_address;
+      if (rr_audit_debug) {
+        fprintf(stderr,
+                "Decrementing STap semaphore for %s:%s at "
+                  "0x%" PRIxELFADDR " (was: %u)\n",
+                note.provider_name, note.probe_name,
+                note.semaphore_address,
+                *semaphore);
+      }
+      assert(*semaphore != 0);
+      (*semaphore)--;
+      semaphore_addr_range_handle_add(&range,
+                                      note.semaphore_address,
+                                      SYS_rrcall_notify_stap_semaphore_removed);
+    }
+  }
+  stap_note_iter_release(&iter);
+
+  if (semaphore_addr_range_is_valid(&range)) {
+    semaphore_addr_range_submit(&range,
+                                SYS_rrcall_notify_stap_semaphore_removed);
+  }
+
+  return 0;
 }

--- a/src/audit/rtld-audit.c
+++ b/src/audit/rtld-audit.c
@@ -1,0 +1,45 @@
+#include "rtld-audit.h"
+#include <stdlib.h>
+#define RR_IMPLEMENT_AUDIT
+#include "../preload/preload_interface.h"
+
+/* Some notes about audit libraries:
+ *
+ * Due to some libpthread bugs[0][1] (and probably others in other libraries)
+ * not everything is safe to call from here. In particular, anything that calls
+ * _dlerror_run or __dlerror (i.e., most/all of the public dlfcn functions)
+ * will cause a TLS slot to be allocated more than once. Make sure nothing
+ * calls pthread_key_create() outside of the main link namespace.
+ *
+ * Since gdb lacks support for multiple link namespaces[2], no debugging
+ * information is available for audit libraries in gdb sessions by default. To
+ * avoid debugging unannotated disassembly, we have to inform gdb about the
+ * other libraries:
+ *  - Run rr-record with '-v LD_DEBUG=files'. This will present output in the form
+ *      <pid>:      file=libfoo.so [<link map id>];  needed by bar [<link map id>]
+ *      <pid>:      file=libfoo.so [<link map id>];  generating link map
+ *      <pid>:        dynamic: 0xxxxxxxxxxxxxxxxx  base: 0xxxxxxxxxxxxxxxxx  size:  0xxxxxxxxxxxxxxxxx
+ *      <pid>:        entry:   0xxxxxxxxxxxxxxxxx  phdr: 0xxxxxxxxxxxxxxxxx  phnum:                 XX
+ *    We're interested in entries with link map ID 1, assuming librraudit is
+ *    first in the audit library list.
+ *  - Load the library into gdb:
+ *      (rr) add-symbol-file /path/to/libfoo.so -o <base address>
+ *    Where <base address> is the value labelled 'base' above.
+ *
+ * [0]: https://sourceware.org/bugzilla/show_bug.cgi?id=24773#c1
+ * [1]: https://sourceware.org/bugzilla/show_bug.cgi?id=24776
+ * [2]: https://sourceware.org/bugzilla/show_bug.cgi?id=15971
+ */
+
+extern __attribute__((visibility("hidden")))
+long _raw_syscall(int syscallno, long a0, long a1, long a2,
+                  long a3, long a4, long a5,
+                  void* syscall_instruction,
+                  long stack_param_1, long stack_param_2);
+
+bool rr_audit_debug;
+
+unsigned la_version(unsigned version) {
+  rr_audit_debug = !!getenv("RR_AUDIT_DEBUG");
+  return version;
+}

--- a/src/audit/rtld-audit.h
+++ b/src/audit/rtld-audit.h
@@ -2,6 +2,12 @@
 #define __RR_RTLD_AUDIT_H__
 
 #include <stdbool.h>
+#include <inttypes.h>
+#include <elf.h>
+
+#define PRIxELFADDR _PRIxELFADDR(PRIx, __ELF_NATIVE_CLASS)
+#define _PRIxELFADDR(f, w) _PRIxELFADDR_1(f, w)
+#define _PRIxELFADDR_1(f, w) f##w
 
 extern bool rr_audit_debug;
 

--- a/src/audit/rtld-audit.h
+++ b/src/audit/rtld-audit.h
@@ -1,0 +1,8 @@
+#ifndef __RR_RTLD_AUDIT_H__
+#define __RR_RTLD_AUDIT_H__
+
+#include <stdbool.h>
+
+extern bool rr_audit_debug;
+
+#endif

--- a/src/audit/stap-note-iter.c
+++ b/src/audit/stap-note-iter.c
@@ -1,0 +1,253 @@
+#include "stap-note-iter.h"
+#include "rtld-audit.h"
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <assert.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+/* For more information about what's going on in here, see
+ * https://sourceware.org/systemtap/wiki/UserSpaceProbeImplementation */
+
+#define ALIGN_UP(x, p2) \
+  (((x) & ((p2) - 1)) == 0 ? (x) : ((x) + (p2)) & ~((p2) - 1))
+
+/* rtld doesn't mark itself as initialised until after it's loaded all the
+ * initially required objects. dladdr() checks this flag, and when not set it
+ * delegates functionality to dlfcn_hook; in our case no such hook is
+ * installed, so it segfaults trying.
+ *
+ * This is the function dladdr() normally calls into. The signature doesn't
+ * seem to have changed since at least 2007, so redeclaring it here is probably
+ * relatively safe. */
+extern int _dl_addr(const void* address, Dl_info* info,
+                    struct link_map** mapp, const ElfW(Sym)** symbolp);
+
+static void* stap_note_iter_map(StapNoteIter* self,
+                                size_t offset, size_t size) {
+  void* map;
+  size_t requested_offset = offset;
+  size_t slack;
+
+  if (self->fd == -1) {
+    const char* path = self->map->l_name;
+
+    if (*path == '\0') {
+      path = "/proc/self/exe";
+    }
+
+    if ((self->fd = open(path, O_RDONLY)) == -1) {
+      if (rr_audit_debug) {
+        fprintf(stderr, "Failed to open '%s': %s\n", path, strerror(errno));
+      }
+      return NULL;
+    }
+  }
+
+  offset &= ~(sysconf(_SC_PAGE_SIZE) - 1);
+  slack = requested_offset - offset;
+  size += slack;
+  map = mmap(NULL, size, PROT_READ, MAP_SHARED, self->fd, offset);
+  if (map == MAP_FAILED) {
+    if (rr_audit_debug) {
+      fprintf(stderr,
+              "Failed to map 0x%" PRIxELFADDR "+0x%" PRIxELFADDR
+                " from '%s': %s\n",
+              offset, size,
+              self->map->l_name,
+              strerror(errno));
+    }
+    return NULL;
+  }
+
+  return (char*) map + slack;
+}
+
+static void stap_note_iter_unmap(StapNoteIter* self __attribute__((unused)),
+                                 void* data, size_t size) {
+  uintptr_t data_addr = (uintptr_t) data;
+  void* page = (void*) (data_addr & ~(sysconf(_SC_PAGE_SIZE) - 1));
+  size += (char*) data - (char*) page;
+  munmap(page, size);
+}
+
+void stap_note_iter_init(StapNoteIter* self, const struct link_map* map) {
+  const ElfW(Ehdr)* ehdr;
+  const ElfW(Shdr) *shstrtab_hdr, *shdr_iter;
+  const char* shstrtab;
+
+  memset(self, '\0', sizeof(*self));
+  self->fd = -1;
+
+  self->map = map;
+
+  {
+    /* We want the image base address. Kind of round-about, but it works.
+     *
+     * A warning about anyone thinking about alternate approaches: The initial
+     * implementation of this used dl_phdr_info::dlpi_addr[0], but this
+     * approach was changed since the documentation of the field doesn't appear
+     * to be correct[1].
+     *
+     * [0]: dl_iterate_phdr(3)
+     * [1]: https://bugzilla.kernel.org/show_bug.cgi?id=205837 */
+    Dl_info info;
+    if (!_dl_addr((void*) map->l_ld, &info, NULL, NULL)) {
+      if (rr_audit_debug) {
+        fprintf(stderr, "Base address lookup for '%s' failed\n", map->l_name);
+      }
+      return;
+    }
+    self->base = info.dli_fbase;
+  }
+
+  ehdr = self->base;
+
+  assert(ehdr->e_shentsize == sizeof(ElfW(Shdr)));
+
+  self->shdrs = stap_note_iter_map(self,
+                                   ehdr->e_shoff,
+                                   ehdr->e_shnum * sizeof(ElfW(Shdr)));
+  if (!self->shdrs) {
+    if (rr_audit_debug) {
+      fprintf(stderr, "Mapping section headers for '%s' failed\n", map->l_name);
+    }
+    return;
+  }
+
+  self->shdr_iter = self->shdrs;
+  self->shdr_end = self->shdrs + ehdr->e_shnum;
+
+  assert(ehdr->e_shstrndx < ehdr->e_shnum);
+  shstrtab_hdr = self->shdrs + ehdr->e_shstrndx;
+  shstrtab = stap_note_iter_map(self,
+                                shstrtab_hdr->sh_offset,
+                                shstrtab_hdr->sh_size);
+  if (!shstrtab) {
+    if (rr_audit_debug) {
+      fprintf(stderr,
+              "Mapping section string table for '%s' failed\n",
+              map->l_name);
+    }
+    return;
+  }
+
+  /* STap notes store the link-time memory address of the .stapsdt.base section
+   * within the note, allowing us to relocate addresses in the note by finding
+   * the difference between this value and the real run-time address of the
+   * section. */
+  for (shdr_iter = self->shdrs; shdr_iter < self->shdr_end; shdr_iter++) {
+    if (strcmp(shstrtab + shdr_iter->sh_name, ".stapsdt.base") == 0) {
+      break;
+    }
+  }
+
+  if (shdr_iter < self->shdr_end) {
+    self->stapbase = self->map->l_addr + shdr_iter->sh_addr;
+  }
+
+  stap_note_iter_unmap(self, (void*) shstrtab, shstrtab_hdr->sh_size);
+}
+
+bool stap_note_iter_next(StapNoteIter* self, ElfStapNote* out_note) {
+  /* did the initialisation fail? */
+  if (!self->stapbase) {
+    return false;
+  }
+
+  if (!self->note_data) {
+    /* ran out of note data, mmap the next note section */
+    for (; self->shdr_iter < self->shdr_end; self->shdr_iter++) {
+      if (self->shdr_iter->sh_type == SHT_NOTE) {
+        break;
+      }
+    }
+
+    if (self->shdr_iter == self->shdr_end) {
+      return false;
+    }
+    assert(self->shdr_iter < self->shdr_end);
+    assert(self->shdr_iter->sh_type == SHT_NOTE);
+
+    self->note_data = stap_note_iter_map(self,
+                                         self->shdr_iter->sh_offset,
+                                         self->shdr_iter->sh_size);
+    if (!self->note_data) {
+      if (rr_audit_debug) {
+        fprintf(stderr, "Mapping note data failed\n");
+      }
+      return false;
+    }
+  }
+
+  while (self->note_data_offset + sizeof(ElfW(Nhdr))
+          < self->shdr_iter->sh_size) {
+    const ElfW(Nhdr)* nhdr;
+    const char* name = NULL;
+    const void* desc = NULL;
+
+    nhdr = (void*) ((char*) self->note_data + self->note_data_offset);
+    self->note_data_offset += sizeof(*nhdr);
+
+    if (nhdr->n_namesz) {
+      name = (char*) self->note_data + self->note_data_offset;
+      self->note_data_offset += ALIGN_UP(nhdr->n_namesz, 4);
+    }
+
+    if (nhdr->n_descsz) {
+      desc = (char*) self->note_data + self->note_data_offset;
+      self->note_data_offset += ALIGN_UP(nhdr->n_descsz, 4);
+    }
+
+    if (!name || strcmp(name, "stapsdt") != 0 || nhdr->n_type != 3) {
+      continue;
+    }
+
+    out_note->probe_address = *(ElfW(Addr)*) desc;
+    desc = (char*) desc + sizeof (ElfW(Addr));
+    out_note->base_address = *(ElfW(Addr)*) desc;
+    desc = (char*) desc + sizeof (ElfW(Addr));
+    out_note->semaphore_address = *(ElfW(Addr)*) desc;
+    desc = (char*) desc + sizeof (ElfW(Addr));
+
+    /* relocate addresses */
+    out_note->probe_address += self->stapbase - out_note->base_address;
+    if (out_note->semaphore_address) {
+      out_note->semaphore_address += self->stapbase - out_note->base_address;
+    }
+
+    out_note->provider_name = desc;
+    desc = out_note->provider_name + strlen(out_note->provider_name) + 1;
+    out_note->probe_name = desc;
+    desc = out_note->probe_name + strlen(out_note->probe_name) + 1;
+    out_note->argument_format = desc;
+
+    return true;
+  }
+
+  /* We've exhausted the note data in the currently mapped section. Unmap it
+   * and try again with the next note section. */
+  stap_note_iter_unmap(self, self->note_data, self->shdr_iter->sh_size);
+  self->shdr_iter++;
+  self->note_data = NULL;
+  self->note_data_offset = 0;
+  return stap_note_iter_next(self, out_note);
+}
+
+void stap_note_iter_release(StapNoteIter* self) {
+  if (self->note_data) {
+    stap_note_iter_unmap(self, self->note_data, self->shdr_iter->sh_size);
+  }
+  if (self->shdrs) {
+    stap_note_iter_unmap(self,
+                         (void*) self->shdrs,
+                         (char*) self->shdr_end - (char*) self->shdrs);
+  }
+  if (self->fd != -1) {
+    close(self->fd);
+  }
+  memset(self, '\0', sizeof(*self));
+  self->fd = -1;
+}

--- a/src/audit/stap-note-iter.h
+++ b/src/audit/stap-note-iter.h
@@ -1,0 +1,34 @@
+#ifndef __RR_STAP_NOTE_ITER_H__
+#define __RR_STAP_NOTE_ITER_H__
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <link.h>
+
+typedef struct {
+  ElfW(Addr) probe_address;
+  ElfW(Addr) base_address;
+  ElfW(Addr) semaphore_address;
+  const char* provider_name;
+  const char* probe_name;
+  const char* argument_format;
+} ElfStapNote;
+
+typedef struct {
+  /*< private >*/
+  const struct link_map* map;
+  const void* base;
+  int fd;
+  uintptr_t stapbase;
+  const ElfW(Shdr) *shdrs, *shdr_iter, *shdr_end;
+  void* note_data;
+  size_t note_data_offset;
+} StapNoteIter;
+
+void stap_note_iter_init(StapNoteIter* iter, const struct link_map* map);
+
+bool stap_note_iter_next(StapNoteIter* iter, ElfStapNote* out_note);
+
+void stap_note_iter_release(StapNoteIter* iter);
+
+#endif

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -18,7 +18,7 @@
  */
 #define SYSCALLBUF_PROTOCOL_VERSION 0
 
-#ifdef RR_IMPLEMENT_PRELOAD
+#if defined(RR_IMPLEMENT_PRELOAD) || defined(RR_IMPLEMENT_AUDIT)
 /* Avoid using <string.h> library functions */
 static inline int streq(const char* s1, const char* s2) {
   while (1) {
@@ -94,6 +94,11 @@ static inline const char* extract_file_name(const char* s) {
 #define SYSCALLBUF_LIB_FILENAME SYSCALLBUF_LIB_FILENAME_BASE ".so"
 #define SYSCALLBUF_LIB_FILENAME_PADDED SYSCALLBUF_LIB_FILENAME_BASE ".so:::"
 #define SYSCALLBUF_LIB_FILENAME_32 SYSCALLBUF_LIB_FILENAME_BASE "_32.so"
+
+#define RTLDAUDIT_LIB_FILENAME_BASE "librraudit"
+#define RTLDAUDIT_LIB_FILENAME RTLDAUDIT_LIB_FILENAME_BASE ".so"
+#define RTLDAUDIT_LIB_FILENAME_PADDED RTLDAUDIT_LIB_FILENAME_BASE ".so:::"
+#define RTLDAUDIT_LIB_FILENAME_32 RTLDAUDIT_LIB_FILENAME_BASE "_32.so"
 
 /* Set this env var to enable syscall buffering. */
 #define SYSCALLBUF_ENABLED_ENV_VAR "_RR_USE_SYSCALLBUF"
@@ -175,7 +180,7 @@ static inline const char* extract_file_name(const char* s) {
 /* Define macros that let us compile a struct definition either "natively"
  * (when included by preload.c) or as a template over Arch for use by rr.
  */
-#ifdef RR_IMPLEMENT_PRELOAD
+#if defined(RR_IMPLEMENT_PRELOAD) || defined(RR_IMPLEMENT_AUDIT)
 #define TEMPLATE_ARCH
 #define PTR(T) T*
 #define PTR_ARCH(T) T*

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -176,6 +176,27 @@ static inline const char* extract_file_name(const char* s) {
  * fourth parameter is the prot.
  */
 #define SYS_rrcall_mprotect_record 447
+/**
+ * The audit library calls SYS_rrcall_notify_stap_semaphore_added once a batch
+ * of SystemTap semaphores have been incremented. The first parameter is the
+ * beginning of an address interval containing semaphores (inclusive) and the
+ * second parameter is the end of the address interval (exclusive).
+ *
+ * In practice a particular probe may be listed in an object's notes more than
+ * once, so be prepared to handle overlapping or redundant intervals.
+ */
+#define SYS_rrcall_notify_stap_semaphore_added 448
+/**
+ * The audit library calls SYS_rrcall_notify_stap_semaphore_removed once a
+ * batch of previously-incremented SystemTap semaphores have been decremented.
+ * The first parameter is the beginning of an address interval containing
+ * semaphores (inclusive) and the second parameter is the end of the address
+ * interval (exclusive).
+ *
+ * In practice a particular probe may be listed in an object's notes more than
+ * once, so be prepared to handle overlapping or redundant intervals.
+ */
+#define SYS_rrcall_notify_stap_semaphore_removed 449
 
 /* Define macros that let us compile a struct definition either "natively"
  * (when included by preload.c) or as a template over Arch for use by rr.

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -4201,6 +4201,8 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
 
     case SYS_rrcall_notify_control_msg:
     case SYS_rrcall_init_preload:
+    case SYS_rrcall_notify_stap_semaphore_added:
+    case SYS_rrcall_notify_stap_semaphore_removed:
       syscall_state.emulate_result(0);
       return PREVENT_SWITCH;
 

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -1432,6 +1432,22 @@ static void rep_process_syscall_arch(ReplayTask* t, ReplayTraceStep* step,
       return;
     }
 
+    case SYS_rrcall_notify_stap_semaphore_added: {
+      remote_ptr<uint16_t> range_start(t->regs().arg1()),
+                           range_end(t->regs().arg2());
+      MemoryRange semaphore_range(range_start, range_end);
+      t->vm()->add_stap_semaphore_range(t, semaphore_range);
+      return;
+    }
+
+    case SYS_rrcall_notify_stap_semaphore_removed: {
+      remote_ptr<uint16_t> range_start(t->regs().arg1()),
+                           range_end(t->regs().arg2());
+      MemoryRange semaphore_range(range_start, range_end);
+      t->vm()->remove_stap_semaphore_range(t, semaphore_range);
+      return;
+    }
+
     default:
       return;
   }

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -1698,6 +1698,8 @@ rrcall_notify_syscall_hook_exit = IrregularEmulatedSyscall(x86=444, x64=444)
 rrcall_notify_control_msg = IrregularEmulatedSyscall(x86=445, x64=445)
 rrcall_reload_auxv = IrregularEmulatedSyscall(x86=446, x64=446)
 rrcall_mprotect_record = IrregularEmulatedSyscall(x86=447, x64=447)
+rrcall_notify_stap_semaphore_added = IrregularEmulatedSyscall(x86=448, x64=448)
+rrcall_notify_stap_semaphore_removed = IrregularEmulatedSyscall(x86=449, x64=449)
 
 # These syscalls are also subsumed under socketcall on x86.
 socket = EmulatedSyscall(x86=359, x64=41)


### PR DESCRIPTION
Sorry, this is kind of a big one. Some notes:
 - I split this into two commits: one adding librraudit, and another actually implementing stap probe support. The auditing library may be useful in its own right for future work, so it seemed logical to break that out into a separate commit.
 - The implementation of `AddressSpace::add_stap_semaphore_range` is kind of ugly. I do have a version that implemented the semaphore data structure as the minimal set of disjoint intervals, but the code ended up looking almost comically over-complicated given the objective it fulfilled.
 - I'm not sure how you might want the test suite altered to exercise this. FWIW, I did run the suite with `--stap-sdt` and it passed with the exception of one test (which failed due to a watchpoint on mmap'd memory being triggered when the same address was mmap'd again by the audit library)