### PR TITLE
Some minor fixes in the tests to allow compilation with -Werror turned on

### DIFF
--- a/src/test/block_clone_checkpoint.c
+++ b/src/test/block_clone_checkpoint.c
@@ -8,7 +8,7 @@ static void breakpoint(void) { event_syscall(); }
 
 int main(void) {
   int i;
-  int fd = open("tmp.txt", O_RDWR | O_CREAT | O_EXCL);
+  int fd = open("tmp.txt", O_RDWR | O_CREAT | O_EXCL, 0600);
   char buf[BUF_SIZE];
   test_assert(fd >= 0);
   test_assert(0 == unlink("tmp.txt"));

--- a/src/test/block_clone_interrupted.c
+++ b/src/test/block_clone_interrupted.c
@@ -8,7 +8,7 @@
 
 int main(void) {
   int i, j, count;
-  int fd = open("tmp.txt", O_RDWR | O_CREAT | O_EXCL);
+  int fd = open("tmp.txt", O_RDWR | O_CREAT | O_EXCL, 0600);
   int buf[BUF_COUNT];
   test_assert(fd >= 0);
   test_assert(0 == unlink("tmp.txt"));

--- a/src/test/block_clone_syscallbuf_overflow.c
+++ b/src/test/block_clone_syscallbuf_overflow.c
@@ -8,7 +8,7 @@
 
 int main(void) {
   int i, j, count;
-  int fd = open("tmp.txt", O_RDWR | O_CREAT | O_EXCL);
+  int fd = open("tmp.txt", O_RDWR | O_CREAT | O_EXCL, 0600);
   int buf[BUF_COUNT];
   test_assert(fd >= 0);
   test_assert(0 == unlink("tmp.txt"));

--- a/src/test/copy_file_range.c
+++ b/src/test/copy_file_range.c
@@ -14,8 +14,8 @@ copy_file_range_syscall(int fd_in, loff_t *off_in, int fd_out,
 }
 
 int main(void) {
-  int in_fd = open("dummy.txt", O_RDWR | O_CREAT | O_TRUNC);
-  int out_fd = open("dummy2.txt", O_RDWR | O_CREAT | O_TRUNC);
+  int in_fd = open("dummy.txt", O_RDWR | O_CREAT | O_TRUNC, 0600);
+  int out_fd = open("dummy2.txt", O_RDWR | O_CREAT | O_TRUNC, 0600);
   int ret = write(in_fd, "Hello\n", 6);
   loff_t in_off = 0;
   loff_t out_off = 0;

--- a/src/test/direct.c
+++ b/src/test/direct.c
@@ -5,7 +5,7 @@
 #define SIZE 128*1024
 
 int main(void) {
-  int fd = open("test.out", O_RDWR | O_DIRECT | O_CREAT | O_TRUNC);
+  int fd = open("test.out", O_RDWR | O_DIRECT | O_CREAT | O_TRUNC, 0600);
   void* p;
   int ret = posix_memalign(&p, SIZE, SIZE);
   if (fd < 0 && errno == EINVAL) {

--- a/src/test/execve_loop.c
+++ b/src/test/execve_loop.c
@@ -10,7 +10,7 @@ int main(__attribute__((unused)) int argc, char* argv[], char* envp[]) {
   int count = atoi(argv[1]);
 
   if (count > 0) {
-    char buf[10];
+    char buf[16];
     sprintf(buf, "%d", count - 1);
     argv[1] = buf;
     execve(argv[0], argv, envp);

--- a/src/test/mmap_shared_write.c
+++ b/src/test/mmap_shared_write.c
@@ -12,7 +12,7 @@ static void check_mapping(int* page, int magic, ssize_t nr_ints) {
 
 int main(void) {
   size_t num_bytes = sysconf(_SC_PAGESIZE);
-  int fd = open("temp", O_CREAT | O_EXCL | O_RDWR);
+  int fd = open("temp", O_CREAT | O_EXCL | O_RDWR, 0600);
   int* rpage;
 
   unlink("temp");

--- a/src/test/mmap_shared_write_fork.c
+++ b/src/test/mmap_shared_write_fork.c
@@ -12,7 +12,7 @@ static void check_mapping(int* page, int magic, ssize_t nr_ints) {
 
 int main(void) {
   size_t num_bytes = sysconf(_SC_PAGESIZE);
-  int fd = open("temp", O_CREAT | O_EXCL | O_RDWR);
+  int fd = open("temp", O_CREAT | O_EXCL | O_RDWR, 0600);
   int* rpage;
   pid_t child;
   int status;

--- a/src/test/pivot_root.c
+++ b/src/test/pivot_root.c
@@ -19,11 +19,11 @@ int main(void) {
   test_assert(0 == mkdir("old_root/new_root/new_old_root", 0700));
 
   /* Write some files so we can identify directories */
-  int fd = open("old_root/old_root.txt", O_WRONLY | O_CREAT);
+  int fd = open("old_root/old_root.txt", O_WRONLY | O_CREAT, 0600);
   test_assert(fd != -1);
   test_assert(0 == close(fd));
 
-  fd = open("old_root/new_root/new_root.txt", O_WRONLY | O_CREAT);
+  fd = open("old_root/new_root/new_root.txt", O_WRONLY | O_CREAT, 0600);
   test_assert(fd != -1);
   test_assert(0 == close(fd));
 

--- a/src/test/sync_file_range.c
+++ b/src/test/sync_file_range.c
@@ -3,7 +3,7 @@
 #include "util.h"
 
 int main(void) {
-  int fd = open("dummy.txt", O_RDWR | O_CREAT | O_TRUNC);
+  int fd = open("dummy.txt", O_RDWR | O_CREAT | O_TRUNC, 0600);
   int ret;
   test_assert(fd >= 0);
   ret = write(fd, "x", 1);

--- a/src/test/unshare.c
+++ b/src/test/unshare.c
@@ -127,7 +127,7 @@ static void write_user_namespace_mappings(void) {
   char buf[100];
   int fd;
 
-  fd = open("/proc/self/uid_map", O_WRONLY | O_CREAT);
+  fd = open("/proc/self/uid_map", O_WRONLY | O_CREAT, 0600);
   test_assert(fd >= 0);
   sprintf(buf, "7 %d 1\n", uid);
   test_assert((ssize_t)strlen(buf) == write(fd, buf, strlen(buf)));
@@ -136,7 +136,7 @@ static void write_user_namespace_mappings(void) {
   /* Per user_namespaces(7), we need to write 'deny' to /proc/self/setgroups
    * before we set up gid_map. This means we can't test setgroups here. Oh well.
    */
-  fd = open("/proc/self/setgroups", O_WRONLY | O_CREAT);
+  fd = open("/proc/self/setgroups", O_WRONLY | O_CREAT, 0600);
   /* This file does not exist in some old kernel */
   if (fd >= 0) {
     sprintf(buf, "deny");
@@ -144,7 +144,7 @@ static void write_user_namespace_mappings(void) {
     test_assert(0 == close(fd));
   }
 
-  fd = open("/proc/self/gid_map", O_WRONLY | O_CREAT);
+  fd = open("/proc/self/gid_map", O_WRONLY | O_CREAT, 0600);
   test_assert(fd >= 0);
   sprintf(buf, "8 %d 1\n", gid);
   test_assert((ssize_t)strlen(buf) == write(fd, buf, strlen(buf)));


### PR DESCRIPTION
I have been working to package rr as a Fedora Project rpm.   When enabling the various compiler flags using by default for the Fedora Project builds I found some open calls that created files were missing the mode argument and there was a sprintf flagged for possible buffer overrun.  With the -Werror compiler option these would cause the build to fail.  The patches in this branch fix the code in the tests so -Werror can be enabled for the build.