### PR TITLE
syscalls: Add support for the sched_getattr syscall.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -933,7 +933,7 @@ set(BASIC_TESTS
   rusage
   samask
   save_data_fd
-  # sched_attr ... disabled since suitable headers are not widely available yet
+  sched_attr
   sched_setaffinity
   sched_setparam
   sched_yield

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -4050,6 +4050,12 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
           2, ParamSize::from_syscall_result<ssize_t>(regs.arg3()));
       return PREVENT_SWITCH;
 
+    case Arch::sched_getattr: {
+      syscall_state.reg_parameter(
+          2, ParamSize::from_syscall_result<unsigned>((unsigned) regs.arg3()));
+      return PREVENT_SWITCH;
+    }
+
     case Arch::sched_setaffinity: {
       // Ignore all sched_setaffinity syscalls. They might interfere
       // with our own affinity settings.

--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -1188,6 +1188,15 @@ futex = IrregularEmulatedSyscall(x86=240, x64=202)
 # would be specified as sizeof(cpu_set_t).
 sched_setaffinity = IrregularEmulatedSyscall(x86=241, x64=203)
 
+# int sched_getattr(pid_t pid, struct sched_attr *attr,
+#                   unsigned int size, unsigned int flags);
+#
+# The sched_getattr() system call fetches the scheduling policy and the
+# associated attributes for the thread whose ID is specified in pid.
+# If pid equals zero, the scheduling policy and attributes of the call‐
+# ing thread will be retrieved.
+sched_getattr = IrregularEmulatedSyscall(x86=352, x64=315)
+
 #  int sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask);
 #
 # sched_getaffinity() writes the affinity mask of the process whose
@@ -1634,7 +1643,6 @@ process_vm_writev = IrregularEmulatedSyscall(x86=348, x64=311)
 kcmp = EmulatedSyscall(x86=349, x64=312)
 finit_module = UnsupportedSyscall(x86=350, x64=313)
 sched_setattr = UnsupportedSyscall(x86=351, x64=314)
-sched_getattr = UnsupportedSyscall(x86=352, x64=315)
 renameat2 = EmulatedSyscall(x86=353, x64=316)
 seccomp = IrregularEmulatedSyscall(x86=354, x64=317)
 getrandom = IrregularEmulatedSyscall(x86=355, x64=318)

--- a/src/test/sched_attr.c
+++ b/src/test/sched_attr.c
@@ -2,19 +2,29 @@
 
 #include "util.h"
 
+struct sched_attr {
+  uint32_t size;
+  uint32_t sched_policy;
+  uint64_t sched_flags;
+  int32_t sched_nice;
+  uint32_t sched_priority;
+  uint64_t sched_runtime;
+  uint64_t sched_deadline;
+  uint64_t sched_period;
+};
+
 int main(void) {
   struct sched_attr* attr;
-
   ALLOCATE_GUARD(attr, 'x');
-  test_assert(0 == sched_getattr(0, attr, sizeof(*attr), 0));
+  syscall(__NR_sched_getattr, 0, attr, sizeof(*attr), 0);
   /* Don't check specific scheduling parameters in case someone
      is running the rr tests with low priority or something like that */
   test_assert(attr->size == sizeof(*attr));
-  test_assert(attr->flags == 0);
+  test_assert(attr->sched_flags == 0);
   VERIFY_GUARD(attr);
 
-  test_assert(0 == sched_setattr(0, attr, 0));
-  VERIFY_GUARD(attr);
+  // TODO
+  // test_assert(0 == sched_setattr(0, &attr, 0));
 
   atomic_puts("EXIT-SUCCESS");
   return 0;


### PR DESCRIPTION
This is used when spawing firefox with glibc trunk. Seems pretty
straight-forward to support.