### PR TITLE
syscalls: Fix ParamSize of sched_getaffinity.

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -4067,8 +4067,7 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
     }
 
     case Arch::sched_getaffinity:
-      syscall_state.reg_parameter(
-          3, ParamSize::from_syscall_result<int>((unsigned int)regs.arg2()));
+      syscall_state.reg_parameter(3, ParamSize(regs.arg2()));
       return PREVENT_SWITCH;
 
     case Arch::ptrace:


### PR DESCRIPTION
Looking at the manpage, it suffers the same issue as the one
75a83e4ed59accdc590d2b9152ac6079eddbdb39 fixed for sched_getattr.