### PR TITLE
Enable rr to be built on older compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,13 @@ set(FLAGS_COMMON "-msse2 -D__MMX__ -D__SSE__ -D__SSE2__ -D__USE_LARGEFILE64 -pth
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS_COMMON} -Wstrict-prototypes -std=gnu11")
 # Define __STDC_LIMIT_MACROS so |#include <stdint.h>| works as expected.
 # Define __STDC_FORMAT_MACROS so |#include <inttypes.h>| works as expected.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++14")
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++14" SUPPORTS_CXX14)
+if (SUPPORTS_CXX14)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++14")
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++11")
+endif()
 
 # We support three build types:
 # DEBUG: suitable for debugging rr

--- a/src/Dwarf.h
+++ b/src/Dwarf.h
@@ -181,6 +181,19 @@ private:
   std::vector<DwarfSourceFile> file_names_;
 };
 
+#if __cplusplus == 201103L
+
+/**
+ * Implementation of make_unique for C++11 (from https://herbsutter.com/gotw/_102/).
+ */
+template<typename T, typename ...Args>
+std::unique_ptr<T> make_unique( Args&& ...args )
+{
+    return std::unique_ptr<T>( new T( std::forward<Args>(args)... ) );
+}
+
+#endif /* __cplusplus == 201103L */
+
 } // namespace rr
 
 #endif /* RR_DWARF_H_ */


### PR DESCRIPTION
These changes allow us to package rr for EPEL7 using its base compiler.

- The additional compilation options are added to avoid errors that arise from -D_FORTIFY_SOURCE=2 and -Werror (in the building of the RPM).
- The conditional implementation of `make_unique` was added as it's not available in C++11.
- _FORTIFY_SOURCE was disabled in the `read_oversize.c` test as it triggers an error.

