### PR TITLE
Better detection for running under rr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1133,6 +1133,7 @@ set(TESTS_WITH_PROGRAM
   # history
   ignored_async_usr1
   ignored_sigsegv
+  ignore_nested
   immediate_restart
   int3_ok
   interrupt

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -197,6 +197,14 @@ static inline const char* extract_file_name(const char* s) {
  * once, so be prepared to handle overlapping or redundant intervals.
  */
 #define SYS_rrcall_notify_stap_semaphore_removed 449
+/**
+ * This syscall can be used be the application being recorded to check for the
+ * presence of the rr recorder. It is used e.g. to enable nested recording of
+ * rr itself. Use of this syscall should be limited to situations where it is
+ * absolutely necessary to avoid deviation of behavior depending on the
+ * presence of absence of rr.
+ */
+#define SYS_rrcall_check_presence 450
 
 /* Define macros that let us compile a struct definition either "natively"
  * (when included by preload.c) or as a template over Arch for use by rr.

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -4218,6 +4218,20 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
       syscall_state.reg_parameter<rrcall_init_buffers_params<Arch>>(1, IN_OUT);
       return PREVENT_SWITCH;
 
+    case SYS_rrcall_check_presence: {
+      // Since this is "user" facing, we follow best practices for regular
+      // syscalls and make sure that unused arguments (in this case all of them)
+      // are zero.
+      bool arguments_are_zero = true;
+      Registers r = t->regs();
+      for (int i = 1; i <= 6; ++i) {
+        arguments_are_zero &= r.arg(i) == 0;
+      }
+      syscall_state.emulate_result(arguments_are_zero ? 0 : (uintptr_t)-EINVAL);
+      syscall_state.expect_errno = ENOSYS;
+      return PREVENT_SWITCH;
+    }
+
     case Arch::brk:
     case Arch::munmap:
     case Arch::process_vm_readv:

--- a/src/test/ignore_nested.c
+++ b/src/test/ignore_nested.c
@@ -1,0 +1,15 @@
+#include "util.h"
+
+// This simply execs the commands passed to it on
+// the command line without passing through the
+// environment. The runner uses this to test
+// --ignore-nested in the absence of RR_UNDER_RR
+// environment variable.
+int main(int argc, char *argv[]) {
+    if (argc > 1 && strcmp(argv[1], "--inner") == 0) {
+        atomic_puts("EXIT-SUCCESS");
+        return 0;
+    }
+    char *newenv[] = { NULL };
+    return execve(argv[1], &argv[1], newenv);
+}

--- a/src/test/ignore_nested.run
+++ b/src/test/ignore_nested.run
@@ -1,0 +1,4 @@
+source `dirname $0`/util.sh
+record $TESTNAME "$(which rr) record --ignore-nested $PWD/$TESTNAME-$nonce --inner"
+replay
+check 'EXIT-SUCCESS'

--- a/src/util.cc
+++ b/src/util.cc
@@ -1131,7 +1131,17 @@ double monotonic_now_sec() {
   return (double)tp.tv_sec + (double)tp.tv_nsec / 1e9;
 }
 
-bool running_under_rr() { return getenv("RUNNING_UNDER_RR") != NULL; }
+bool running_under_rr() {
+  static bool rr_under_rr = false;
+  static bool rr_check_done = false;
+  if (!rr_check_done) {
+    rr_check_done = true;
+    int ret = syscall(SYS_rrcall_check_presence, 0, 0, 0, 0, 0, 0);
+    DEBUG_ASSERT(ret == 0 || (ret == -1 && errno == ENOSYS));
+    rr_under_rr = ret == 0;
+  }
+  return rr_under_rr;
+}
 
 vector<string> read_proc_status_fields(pid_t tid, const char* name,
                                        const char* name2, const char* name3) {
@@ -1336,7 +1346,7 @@ void dump_rr_stack() {
 }
 
 void check_for_leaks() {
-  if (getenv("RUNNING_UNDER_RR")) {
+  if (running_under_rr()) {
     // Don't do leak checking. The outer rr may have injected maps into our
     // address space that look like leaks to us.
     return;


### PR DESCRIPTION
As reported in #2451, if the RR_UNDER_RR environment variable does
not get passed down to the nested rr, said rr ignores the
`--ignore-nested` flags, because it assumes (wrongly) that it is
the top-level rr. To fix this, instead of relying on the environment
variable add another custom fake syscall (like the existing rrcalls
used by the preload library) that the inner rr can use to detect
whether or not it's being recorded.

Fixes #2451