### PR TITLE
Handle invalid path/argv in exec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -802,6 +802,7 @@ set(BASIC_TESTS
   intr_read_restart
   intr_sleep
   intr_sleep_no_restart
+  invalid_exec
   invalid_fcntl
   invalid_ioctl
   io

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -765,8 +765,7 @@ bool Task::execed() const { return tg->execed; }
 
 void Task::flush_inconsistent_state() { ticks = 0; }
 
-string Task::read_c_str(remote_ptr<char> child_addr) {
-  // XXX handle invalid C strings
+string Task::read_c_str(remote_ptr<char> child_addr, bool *ok) {
   remote_ptr<void> p = child_addr;
   string str;
   while (true) {
@@ -776,7 +775,10 @@ string Task::read_c_str(remote_ptr<char> child_addr) {
     ssize_t nbytes = end_of_page - p;
     std::unique_ptr<char[]> buf(new char[nbytes]);
 
-    read_bytes_helper(p, nbytes, buf.get());
+    read_bytes_helper(p, nbytes, buf.get(), ok);
+    if (ok && !*ok) {
+      return "";
+    }
     for (int i = 0; i < nbytes; ++i) {
       if ('\0' == buf[i]) {
         return str;

--- a/src/Task.h
+++ b/src/Task.h
@@ -439,9 +439,11 @@ public:
 
   /**
    * Read and return the C string located at |child_addr| in
-   * this address space.
+   * this address space. If the data can't all be read (because the c string to
+   * be read is invalid), then if |ok| is non-null, sets *ok to
+   * false, otherwise asserts.
    */
-  std::string read_c_str(remote_ptr<char> child_addr);
+  std::string read_c_str(remote_ptr<char> child_addr, bool *ok = nullptr);
 
   /**
    * Resume execution |how|, deliverying |sig| if nonzero.

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3044,17 +3044,30 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
     case Arch::execve: {
       vector<string> cmd_line;
       remote_ptr<typename Arch::unsigned_word> argv = regs.arg2();
+      bool ok = true;
       while (true) {
-        auto p = t->read_mem(argv);
+        auto p = t->read_mem(argv, &ok);
+        if (!ok) {
+          syscall_state.expect_errno = EFAULT;
+          return ALLOW_SWITCH;
+        }
         if (!p) {
           break;
         }
-        cmd_line.push_back(t->read_c_str(p));
+        cmd_line.push_back(t->read_c_str(p, &ok));
+        if (!ok) {
+          syscall_state.expect_errno = EFAULT;
+          return ALLOW_SWITCH;
+        }
         argv++;
       }
 
       // Save the event. We can't record it here because the exec might fail.
-      string raw_filename = t->read_c_str(regs.arg1());
+      string raw_filename = t->read_c_str(regs.arg1(), &ok);
+      if (!ok) {
+        syscall_state.expect_errno = EFAULT;
+        return ALLOW_SWITCH;
+      }
       syscall_state.exec_saved_event =
           unique_ptr<TraceTaskEvent>(new TraceTaskEvent(
               TraceTaskEvent::for_exec(t->tid, raw_filename, cmd_line)));

--- a/src/test/invalid_exec.c
+++ b/src/test/invalid_exec.c
@@ -1,0 +1,17 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(void) {
+  /* Do several variations of invalid execs */
+#pragma GCC diagnostic ignored "-Wnonnull"
+  test_assert(-1 == execve(NULL, NULL, NULL));
+  test_assert(errno == EFAULT);
+  test_assert(-1 == execve("/proc/self/exe", (void*)0xdeadbeef, NULL));
+  test_assert(errno == EFAULT);
+  char *argv[] = { (char*)0xdeadbeef, NULL };
+  test_assert(-1 == execve("/proc/self/exe", argv, NULL));
+  test_assert(errno == EFAULT);
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
Prior to this patch, passing invalid (as in faulting) addresses as
the path or argv to exec would cause rr to assert because it was
itself trying to read that memory and failing. Instead, we should
go ahead and simply abort processing of the exec on such a fault,
since we know the kernel will fail it with EFAULT as soon as it
gets the chance.