### PR TITLE
Fix step1 test on newer gcc/gdb versions

### DIFF
--- a/src/test/breakpoint.c
+++ b/src/test/breakpoint.c
@@ -4,14 +4,20 @@
 
 static void C(void) { atomic_puts("in C"); }
 
-static void B(void) {
-  atomic_puts("calling C");
+// In our test driver, we rely on the debugger stopping
+// on the first call inside the function. However, different
+// versions of gdb/gcc are inconsistent about whether the breakpoint
+// for the function is on the same line as the opening brace or the
+// first statement in the function, so make sure they're on the same
+// line irrespective of our usual style guide.
+static void B(void)
+{ atomic_puts("calling C");
   C();
   atomic_puts("finished C");
 }
 
-static void A(void) {
-  atomic_puts("calling B");
+static void A(void)
+{ atomic_puts("calling B");
   B();
   atomic_puts("finished B");
 }


### PR DESCRIPTION
On one of our machines this test is failing. Upon investigation,
the reason for this is that the breakpoint for a function is
considered by gdb to be on the line of the opening brace, while
the test driver for this test assumes that the breakpoint for the
function is on the line of the first statement. This is likely
a change in the debug information emitted by the compiler on this
machine (gcc (Ubuntu 9.2.1-31ubuntu1) 9.2.1 20200304), but may also
be a change in GDB (GNU gdb (Ubuntu 9.0.50.20191119-0ubuntu1) 9.0.50.20191119-git).
In either case, it's easy to paper over the difference by making sure
that the opening brace and the first statement are on the same line
(even if it looks a bit ugly).