### PR TITLE
Fix chown test

### DIFF
--- a/src/preload/overrides.c
+++ b/src/preload/overrides.c
@@ -140,7 +140,13 @@ void spurious_desched_syscall(struct syscall_info* info) {
  * which sometimes can't be hooked. So override it here with something that
  * can be hooked.
  */
-uid_t geteuid(void) { return syscall(SYS_geteuid); }
+uid_t geteuid(void) {
+#ifdef __i386__
+  return syscall(SYS_geteuid32);
+#else
+  return syscall(SYS_geteuid);
+#endif
+}
 
 /**
  * clang's LeakSanitizer has regular threads call sched_yield() in a loop while

--- a/src/test/chown.c
+++ b/src/test/chown.c
@@ -28,15 +28,20 @@ static void change_group_at(const char* path, gid_t new_gid) {
 }
 
 int main(void) {
-  gid_t groups[32];
+  long ngroups_max;
+  gid_t *groups;
   int ngroups;
   gid_t this_group, other_group;
   int fd;
 
+  ngroups_max = sysconf(_SC_NGROUPS_MAX);
+  test_assert(ngroups_max != -1);
+  groups = alloca(sizeof(gid_t)*ngroups_max);
+
   this_group = getegid();
   atomic_printf("Current group is %d\n", this_group);
 
-  ngroups = getgroups(ALEN(groups), groups);
+  ngroups = getgroups(ngroups_max, groups);
   test_assert(ngroups > 0);
 
   other_group = groups[0];


### PR DESCRIPTION
This fixes two issues I saw locally in the `chown` test
1. My user has more than 32 supplemental groups, so the hardcoded maximum of 32
   groups in the chown test caused a failure. Instead, get this limit from sysconf.
2. My euid is larger than 16 bits, but rr was hooking geteuid to use the SYS_geteuid
   syscall, rather than the SYS_geteuid32 syscall, which returns the euid of
   proper bitwidth.

With fixes for both of these the `chown` test passes again locally.