### PR TITLE
string_instructions_multiwatch: Work around buggy compiler DWARF

### DIFF
--- a/src/test/string_instructions_multiwatch.c
+++ b/src/test/string_instructions_multiwatch.c
@@ -20,6 +20,7 @@ int main(void) {
     buf[i] = i;
   }
 
+  atomic_printf("Buf is at %p\n", buf);
   my_memmove(buf, buf + 4000, 90000);
 
   atomic_puts("EXIT-SUCCESS");

--- a/src/test/string_instructions_multiwatch.py
+++ b/src/test/string_instructions_multiwatch.py
@@ -4,13 +4,11 @@ import re
 send_gdb('b my_memmove')
 expect_gdb('Breakpoint 1')
 send_gdb('c')
+expect_gdb(re.compile(r'Buf is at ([^ ]+)'))
+buf = eval(last_match().group(1));
 expect_gdb('Breakpoint 1')
 
-send_gdb('p src')
-expect_gdb(re.compile(r'= ([^ ]+)'))
-buf = eval(last_match().group(1));
-
-send_gdb('watch -l *(char*)%d'%(buf + 10000))
+send_gdb('watch -l *(char*)%d'%(buf + 14000))
 expect_gdb('atchpoint 2')
 
 send_gdb('c')


### PR DESCRIPTION
Using the same gcc/gdb versions as in #2457, I see the
string_instructions_multiwatch test fail, because gdb fails to
properly print the location of the `src` variable in my_memmove.
The reason for this is that it has not yet executed the part
of the prologue that moves the src value from its ABI register into
the register assigned to it for the rest of the function as recorded
in DWARF. However, it didn't mark the instructions that do that as
part of the prologue either. To me, this is a compiler bug, but
given the poor state of DWARF emission in mainstream compilers,
I can't say I'm particularly surprised. This fixes the test by
having the test itself print out the location of the `buf` variable,
rather than relying on the DWARF to be accurate.