### PR TITLE
Properly report unexpected stops during early execution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1116,6 +1116,7 @@ set(TESTS_WITH_PROGRAM
   dev_tty
   diversion_syscall
   dlopen
+  early_error
   elapsed_time
   exec_failed
   exec_many

--- a/src/Task.h
+++ b/src/Task.h
@@ -161,6 +161,12 @@ public:
   void proceed_to_exit();
 
   /**
+   * Kill this task and wait for it to exit.
+   * N.B.: If may_reap() is false, this may hang.
+   */
+  void kill();
+
+  /**
    * This must be in an emulated syscall, entered through
    * |cont_sysemu()| or |cont_sysemu_singlestep()|, but that's
    * not checked.  If so, step over the system call instruction
@@ -999,7 +1005,7 @@ protected:
    * (i.e. an exec does not occur before an exit), an error may be
    * readable from the other end of the pipe whose write end is error_fd.
    */
-  static Task* spawn(Session& session, const ScopedFd& error_fd,
+  static Task* spawn(Session& session, ScopedFd& error_fd,
                      ScopedFd* sock_fd_out, int* tracee_socket_fd_number_out,
                      TraceStream& trace, const std::string& exe_path,
                      const std::vector<std::string>& argv,

--- a/src/test/early_error.c
+++ b/src/test/early_error.c
@@ -1,0 +1,62 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(int argc, char *argv[]) {
+  test_assert(argc >= 2);
+
+  struct sock_filter filter[] = {
+    { BPF_LD | BPF_W | BPF_ABS,  0, 0, offsetof(struct seccomp_data, arch) },
+    { BPF_JMP | BPF_JEQ | BPF_K, 0, 4, AUDIT_ARCH_I386 },
+    // i386
+    { BPF_LD | BPF_W | BPF_ABS,  0, 0, offsetof(struct seccomp_data, nr) },
+    { BPF_JMP | BPF_JEQ | BPF_K, 0, 1, 172 /* __NR_prctl */ },
+    { BPF_RET | BPF_K,           0, 0, SECCOMP_RET_TRAP },
+    { BPF_RET | BPF_K,           0, 0, SECCOMP_RET_ALLOW },
+    // x86_64
+    { BPF_LD | BPF_W | BPF_ABS,  0, 0, offsetof(struct seccomp_data, nr) },
+    { BPF_JMP | BPF_JEQ | BPF_K, 0, 1, 157 /* __NR_prctl */ },
+    { BPF_RET | BPF_K,           0, 0, SECCOMP_RET_TRAP },
+    { BPF_RET | BPF_K,           0, 0, SECCOMP_RET_ALLOW }
+  };
+  struct sock_fprog fprog = { 10, filter };
+  int ret;
+  int status;
+
+  int fd_pair[2];
+  ret = pipe(fd_pair);
+
+  pid_t child = fork();
+
+  if (!child) {
+    ret = prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);
+    test_assert(ret == 0);
+    ret = prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, (uintptr_t)&fprog, 0, 0);
+    test_assert(ret == 0);
+
+    ret = close(fd_pair[0]);
+    test_assert(ret == 0);
+    ret = dup2(fd_pair[1], 2);
+    test_assert(ret >= 0);
+
+    execve(argv[1], &argv[1], NULL); // Should not return
+    test_assert(0);
+  }
+  ret = close(fd_pair[1]);
+
+  wait(&status);
+  test_assert(WIFSIGNALED(status));
+  test_assert(WTERMSIG(status) == SIGABRT);
+
+  char buf[4096];
+  memset(buf, 0, sizeof(buf));
+  ssize_t nread = read(fd_pair[0], buf, sizeof(buf)-1);
+  test_assert(nread >= 0);
+  if (NULL == strstr(buf, "Unexpected stop")) {
+    write(2, buf, nread);
+    test_assert(0);
+  }
+
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}

--- a/src/test/early_error.run
+++ b/src/test/early_error.run
@@ -1,0 +1,4 @@
+source `dirname $0`/util.sh
+save_exe "$TESTNAME"
+_RR_TRACE_DIR="$workdir" test-monitor $TIMEOUT record.err "./$TESTNAME-$nonce" \
+    $(which rr) $GLOBAL_OPTIONS record $LIB_ARG $RECORD_ARGS "./$TESTNAME-$nonce"


### PR DESCRIPTION
The code that attempted to report errors during early
execution doens't quite work. The problem is that it
tries to read the error pipe of the child before the
child has fully exited, thus blocking on the closure
of the child's pipe. The solution here is quite simple:
Just kill the child on error. Coming up with a test is
a bit trickier since the early execution doesn't fail
very often. This uses a small seccomp filter to turn
the first prctl call into a SIGSYS. Without this patch
that would hang. With this patch, we properly get the
expected error message.