### PR TITLE
Restore raw recs field after peeking in peek_frame

### DIFF
--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -1324,12 +1324,14 @@ TraceFrame TraceReader::peek_frame() {
   auto& events = reader(EVENTS);
   events.save_state();
   auto saved_time = global_time;
+  auto saved_raw_recs = raw_recs;
   TraceFrame frame;
   if (!at_end()) {
     frame = read_frame();
   }
   events.restore_state();
   global_time = saved_time;
+  raw_recs = saved_raw_recs;
   return frame;
 }
 


### PR DESCRIPTION
Without this patch, calling peek_frame while there
are pending raw recs clears the raw_recs field and
(if there are any such records) causing them to fail
to be applied. The failure is usually an extremely
subtle discrepancy between the record and replay :/
I'm embarassed to say how many hours finding this took
me. Anyway, it's not an issue on master, because
there's only one use of peek_frame, and the frame it
peeks tends to not have any raw recs, but let's fix
it anyway, for the future sanity of anybody who
might try peeking at frames while raw recs are
pending.