### PR TITLE
WIP/RFC: --nested=separate for multi-threaded recording of subtrees

### DIFF
--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -780,6 +780,10 @@ public:
   void remove_stap_semaphore_range(Task* t, MemoryRange range);
   bool is_stap_semaphore(remote_ptr<uint16_t> addr);
 
+  void on_reparented(Session *session) {
+    session_ = session;
+  }
+
 private:
   struct Breakpoint;
   typedef std::map<remote_code_ptr, Breakpoint> BreakpointMap;

--- a/src/Event.h
+++ b/src/Event.h
@@ -85,6 +85,8 @@ enum EventType {
   // Use .syscall.
   EV_SYSCALL,
 
+  EV_DETACH,
+
   EV_LAST
 };
 

--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -11,6 +11,7 @@
 #include "preload/preload_interface.h"
 
 #include "Flags.h"
+#include "RecordSettings.h"
 #include "RecordSession.h"
 #include "StringVectorToCharArray.h"
 #include "WaitStatus.h"
@@ -100,101 +101,6 @@ RecordCommand RecordCommand::singleton(
     "  --stap-sdt                 Enables the use of SystemTap statically-\n"
     "                             defined tracepoints\n");
 
-struct RecordFlags {
-  /* Max counter value before the scheduler interrupts a tracee. */
-  Ticks max_ticks;
-
-  /* Whenever |ignore_sig| is pending for a tracee, decline to
-   * deliver it. */
-  int ignore_sig;
-  /* Whenever |continue_through_sig| is delivered to a tracee, if there is no
-   * user handler and the signal would terminate the program, just ignore it. */
-  int continue_through_sig;
-
-  /* Whether to use syscall buffering optimization during recording. */
-  RecordSession::SyscallBuffering use_syscall_buffer;
-
-  /* If nonzero, the desired syscall buffer size. Must be a multiple of the page
-   * size.
-   */
-  size_t syscall_buffer_size;
-
-  /* CPUID features to disable */
-  DisableCPUIDFeatures disable_cpuid_features;
-
-  int print_trace_dir;
-
-  /* Whether to use file-cloning optimization during recording. */
-  bool use_file_cloning;
-
-  /* Whether to use read-cloning optimization during recording. */
-  bool use_read_cloning;
-
-  /* Whether tracee processes in record and replay are allowed
-   * to run on any logical CPU. */
-  BindCPU bind_cpu;
-
-  /* True if we should context switch after every rr event */
-  bool always_switch;
-
-  /* Whether to enable chaos mode in the scheduler */
-  bool chaos;
-
-  /* Controls number of cores reported to recorded process. */
-  int num_cores;
-
-  /* True if we should wait for all processes to exit before finishing
-   * recording. */
-  bool wait_for_all;
-
-  /* Start child process directly if run under nested rr recording */
-  NestedBehavior nested;
-
-  bool scarce_fds;
-
-  bool setuid_sudo;
-
-  TraceUuid trace_id;
-
-  /* Copy preload sources to trace dir */
-  bool copy_preload_src;
-
-  /* The signal to use for syscallbuf desched events */
-  int syscallbuf_desched_sig;
-
-  /* True if we should load the audit library for SystemTap SDT support. */
-  bool stap_sdt;
-
-  RecordFlags()
-      : max_ticks(Scheduler::DEFAULT_MAX_TICKS),
-        ignore_sig(0),
-        continue_through_sig(0),
-        use_syscall_buffer(RecordSession::ENABLE_SYSCALL_BUF),
-        syscall_buffer_size(0),
-        print_trace_dir(-1),
-        use_file_cloning(true),
-        use_read_cloning(true),
-        bind_cpu(BIND_CPU),
-        always_switch(false),
-        chaos(false),
-        num_cores(0),
-        wait_for_all(false),
-        nested(NESTED_ERROR),
-        scarce_fds(false),
-        setuid_sudo(false),
-        copy_preload_src(false),
-        syscallbuf_desched_sig(SYSCALLBUF_DEFAULT_DESCHED_SIGNAL),
-        stap_sdt(false) {
-          memset(trace_id.bytes, 0, sizeof(trace_id));
-        }
-};
-
-struct RecordSettings {
-  RecordFlags flags;
-  vector<string> extra_env;
-  string output_trace_dir;
-};
-
 static void parse_signal_name(ParsedOption& opt) {
   if (opt.int_value != INT64_MIN) {
     return;
@@ -265,7 +171,6 @@ static bool parse_record_arg(vector<string>& args, RecordSettings& settings) {
     { 'v', "env", HAS_PARAMETER },
     { 'w', "wait", NO_PARAMETER }
   };
-  bool explicit_uuid = false;
   ParsedOption opt;
   auto args_copy = args;
   if (!Command::parse_option(args_copy, options, &opt)) {
@@ -440,7 +345,6 @@ static bool parse_record_arg(vector<string>& args, RecordSettings& settings) {
         return false;
       }
       memcpy(&flags.trace_id, &trace_id, sizeof(TraceUuid));
-      explicit_uuid = true;
 
       break;
     }
@@ -478,11 +382,6 @@ static bool parse_record_arg(vector<string>& args, RecordSettings& settings) {
       break;
     default:
       DEBUG_ASSERT(0 && "Unknown option");
-  }
-
-  if (!explicit_uuid) {
-    // If the UUID was not provided explicitly, generate one randomly
-    good_random(&flags.trace_id, sizeof(flags.trace_id));
   }
 
   args = args_copy;
@@ -720,6 +619,11 @@ int RecordCommand::run(vector<string>& args) {
   RecordSettings settings;
   RecordFlags &flags = settings.flags;
   while (parse_record_arg(args, settings)) {
+  }
+
+  if (!flags.trace_id) {
+    // If the UUID was not provided explicitly, generate one randomly
+    good_random(&flags.trace_id, sizeof(flags.trace_id));
   }
 
   if (running_under_rr()) {

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -11,7 +11,7 @@
 #include "Session.h"
 #include "ThreadGroup.h"
 #include "TraceFrame.h"
-#include "TraceStream.h"
+#include "TraceTaskEvent.h"
 #include "WaitStatus.h"
 
 namespace rr {

--- a/src/RecordSettings.h
+++ b/src/RecordSettings.h
@@ -1,0 +1,107 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#ifndef RR_RECORD_SETTINGS_H_
+#define RR_RECORD_SETTINGS_H_
+
+#include "RecordSession.h"
+
+namespace rr {
+
+struct RecordFlags {
+  /* Max counter value before the scheduler interrupts a tracee. */
+  Ticks max_ticks;
+
+  /* Whenever |ignore_sig| is pending for a tracee, decline to
+   * deliver it. */
+  int ignore_sig;
+  /* Whenever |continue_through_sig| is delivered to a tracee, if there is no
+   * user handler and the signal would terminate the program, just ignore it. */
+  int continue_through_sig;
+
+  /* Whether to use syscall buffering optimization during recording. */
+  RecordSession::SyscallBuffering use_syscall_buffer;
+
+  /* If nonzero, the desired syscall buffer size. Must be a multiple of the page
+   * size.
+   */
+  size_t syscall_buffer_size;
+
+  /* CPUID features to disable */
+  DisableCPUIDFeatures disable_cpuid_features;
+
+  int print_trace_dir;
+
+  /* Whether to use file-cloning optimization during recording. */
+  bool use_file_cloning;
+
+  /* Whether to use read-cloning optimization during recording. */
+  bool use_read_cloning;
+
+  /* Whether tracee processes in record and replay are allowed
+   * to run on any logical CPU. */
+  BindCPU bind_cpu;
+
+  /* True if we should context switch after every rr event */
+  bool always_switch;
+
+  /* Whether to enable chaos mode in the scheduler */
+  bool chaos;
+
+  /* Controls number of cores reported to recorded process. */
+  int num_cores;
+
+  /* True if we should wait for all processes to exit before finishing
+   * recording. */
+  bool wait_for_all;
+
+  /* Start child process directly if run under nested rr recording */
+  NestedBehavior nested;
+
+  bool scarce_fds;
+
+  bool setuid_sudo;
+
+  TraceUuid trace_id;
+
+  /* Copy preload sources to trace dir */
+  bool copy_preload_src;
+
+  /* The signal to use for syscallbuf desched events */
+  int syscallbuf_desched_sig;
+
+  /* True if we should load the audit library for SystemTap SDT support. */
+  bool stap_sdt;
+
+  RecordFlags()
+      : max_ticks(Scheduler::DEFAULT_MAX_TICKS),
+        ignore_sig(0),
+        continue_through_sig(0),
+        use_syscall_buffer(RecordSession::ENABLE_SYSCALL_BUF),
+        syscall_buffer_size(0),
+        print_trace_dir(-1),
+        use_file_cloning(true),
+        use_read_cloning(true),
+        bind_cpu(BIND_CPU),
+        always_switch(false),
+        chaos(false),
+        num_cores(0),
+        wait_for_all(false),
+        nested(NESTED_ERROR),
+        scarce_fds(false),
+        setuid_sudo(false),
+        copy_preload_src(false),
+        syscallbuf_desched_sig(SYSCALLBUF_DEFAULT_DESCHED_SIGNAL),
+        stap_sdt(false) {
+          memset(trace_id.bytes, 0, sizeof(trace_id));
+        }
+};
+
+struct RecordSettings {
+  RecordFlags flags;
+  std::vector<std::string> extra_env;
+  std::string output_trace_dir;
+};
+
+}
+
+#endif

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -11,6 +11,7 @@
 
 #include "AutoRemoteSyscalls.h"
 #include "PreserveFileMonitor.h"
+#include "RecordSettings.h"
 #include "RecordSession.h"
 #include "core.h"
 #include "kernel_abi.h"

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -719,6 +719,8 @@ public:
 
   // This task is just waiting to be reaped.
   bool waiting_for_reap;
+
+  std::unique_ptr<RecordSettings> separation_settings;
 };
 
 } // namespace rr

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -10,6 +10,7 @@
 namespace rr {
 
 struct Sighandlers;
+class RecordSettings;
 
 /** Different kinds of waits a task can do.
  */

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -908,6 +908,23 @@ string Task::read_c_str(remote_ptr<char> child_addr, bool *ok) {
   }
 }
 
+vector<string> Task::read_c_str_arr(remote_ptr<remote_ptr<char>> child_addr, bool *ok) {
+  bool our_ok = true;
+  if (!ok)
+    ok = &our_ok;
+  vector<string> str_arr;
+  while (true) {
+    auto p = read_mem(child_addr, ok);
+    if (!*ok || !p)
+      break;
+    str_arr.push_back(read_c_str(p, ok));
+    if (!*ok)
+      break;
+    child_addr++;
+  }
+  return str_arr;
+}
+
 const Registers& Task::regs() const {
   ASSERT(this, is_stopped);
   return registers;

--- a/src/Task.h
+++ b/src/Task.h
@@ -485,6 +485,13 @@ public:
   std::string read_c_str(remote_ptr<char> child_addr, bool *ok = nullptr);
 
   /**
+   * Read and return the (null-terminated) array of C string located at
+   * `child_addr`. `ok` is as in `read_c_str`.
+   */
+  std::vector<std::string> read_c_str_arr(remote_ptr<remote_ptr<char>> child_addr,
+                                          bool *ok = nullptr);
+
+  /**
    * Resume execution |how|, deliverying |sig| if nonzero.
    * After resuming, |wait_how|. In replay, reset hpcs and
    * request a tick period of tick_period. The default value

--- a/src/Task.h
+++ b/src/Task.h
@@ -137,6 +137,18 @@ public:
   void detach();
 
   /**
+   * Stop the task and detach from it in such a way that another ptracer can
+   * re-attach without the task running in between.
+   * N.B.: The task must be in a signal stop.
+   */
+  void stop_and_detach();
+
+  /**
+   * Attempt to ptrace-seize this task.
+   */
+  int fallible_seize();
+
+  /**
    * Linux requires the invariant that that all members of a thread group
    * are reaped before the thread group leader. This determines whether or
    * not we're allowed to attempt reaping this thread or whether doing so
@@ -506,6 +518,7 @@ public:
 
   /** Return the session this is part of. */
   Session& session() const { return *session_; }
+  void on_reparented(Session *session) { session_ = session; }
 
   /** Set the tracee's registers to |regs|. Lazy. */
   void set_regs(const Registers& regs);

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -670,6 +670,9 @@ void TraceWriter::write_task_event(const TraceTaskEvent& event) {
     case TraceTaskEvent::EXIT:
       task.initExit().setExitStatus(event.exit_status().get());
       break;
+    case TraceTaskEvent::DETACH:
+      task.initDetach().setNewUuid(Data::Reader(event.new_uuid().bytes, sizeof(TraceUuid)));
+      break;
     case TraceTaskEvent::NONE:
       DEBUG_ASSERT(0 && "Writing NONE TraceTaskEvent");
       break;

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -26,9 +26,6 @@ struct DisableCPUIDFeatures;
 class KernelMapping;
 class RecordTask;
 
-struct TraceUuid {
-  uint8_t bytes[16];
-};
 
 /**
  * TraceStream stores all the data common to both recording and

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -25,7 +25,10 @@ struct CPUIDRecord;
 struct DisableCPUIDFeatures;
 class KernelMapping;
 class RecordTask;
-struct TraceUuid;
+
+struct TraceUuid {
+  uint8_t bytes[16];
+};
 
 /**
  * TraceStream stores all the data common to both recording and
@@ -255,7 +258,7 @@ public:
    *  call this before a crash that won't call the destructor, to ensure
    *  buffered data is flushed.
    */
-  void close(CloseStatus status, const TraceUuid* uuid);
+  void close(CloseStatus status, TraceUuid uuid);
 
   /**
    * We got far enough into recording that we should set this as the latest
@@ -405,7 +408,7 @@ public:
   // preload_thread_locals mapping if it was created by a clone(2) without
   // CLONE_VM. This is true if that has been fixed.
   bool preload_thread_locals_recorded() const { return preload_thread_locals_recorded_; }
-  const TraceUuid& uuid() const { return *uuid_; }
+  const TraceUuid& uuid() const { return uuid_; }
 
   TicksSemantics ticks_semantics() const { return ticks_semantics_; }
 
@@ -421,7 +424,7 @@ private:
   std::vector<RawDataMetadata> raw_recs;
   TicksSemantics ticks_semantics_;
   double monotonic_time_;
-  std::unique_ptr<TraceUuid> uuid_;
+  TraceUuid uuid_;
   bool trace_uses_cpuid_faulting;
   bool preload_thread_locals_recorded_;
 };

--- a/src/TraceTaskEvent.h
+++ b/src/TraceTaskEvent.h
@@ -33,7 +33,8 @@ public:
     NONE,
     CLONE, // created by clone(2), fork(2), vfork(2) syscalls
     EXEC,
-    EXIT
+    EXIT,
+    DETACH
   };
 
   TraceTaskEvent(Type type = NONE, pid_t tid = 0) : type_(type), tid_(tid) {}
@@ -57,6 +58,11 @@ public:
   static TraceTaskEvent for_exit(pid_t tid, WaitStatus exit_status) {
     TraceTaskEvent result(EXIT, tid);
     result.exit_status_ = exit_status;
+    return result;
+  }
+  static TraceTaskEvent for_detach(pid_t tid, TraceUuid new_uuid) {
+    TraceTaskEvent result(DETACH, tid);
+    result.new_uuid_ = new_uuid;
     return result;
   }
 
@@ -95,6 +101,10 @@ public:
     DEBUG_ASSERT(type() == EXIT);
     return exit_status_;
   }
+  TraceUuid new_uuid() const {
+    DEBUG_ASSERT(type() == DETACH);
+    return new_uuid_;
+  }
 
 private:
   friend class TraceReader;
@@ -109,6 +119,7 @@ private:
   std::vector<std::string> cmd_line_; // EXEC only
   remote_ptr<void> exe_base_;         // EXEC only
   WaitStatus exit_status_;            // EXIT only
+  TraceUuid new_uuid_;                // DETACH only
 };
 
 } // namespace rr

--- a/src/TraceTaskEvent.h
+++ b/src/TraceTaskEvent.h
@@ -18,6 +18,15 @@ namespace rr {
 class TraceReader;
 class TraceWriter;
 
+struct TraceUuid {
+  uint8_t bytes[16];
+  operator bool() {
+    uint8_t zeros[sizeof(*this)];
+    memset(&zeros, 0, sizeof(zeros));
+    return !memcmp(&zeros, this, sizeof(*this));
+  }
+};
+
 class TraceTaskEvent {
 public:
   enum Type {

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -205,6 +205,11 @@ static inline const char* extract_file_name(const char* s) {
  * presence of absence of rr.
  */
 #define SYS_rrcall_check_presence 450
+/**
+ * Request that after the next exec, the result process will be separated from
+ * the current recording session and instead be recorded by a new one.
+ */
+#define SYS_rrcall_separate_on_exec 451
 
 /* Define macros that let us compile a struct definition either "natively"
  * (when included by preload.c) or as a template over Arch for use by rr.

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -67,6 +67,7 @@
 #include "MmappedFileMonitor.h"
 #include "ProcFdDirMonitor.h"
 #include "ProcMemMonitor.h"
+#include "RecordSettings.h"
 #include "RecordSession.h"
 #include "RecordTask.h"
 #include "Scheduler.h"

--- a/src/rr_trace.capnp
+++ b/src/rr_trace.capnp
@@ -146,6 +146,9 @@ struct TaskEvent {
     exit :group {
       exitStatus @7 :Int32;
     }
+    detach :group {
+      newUuid @9 :Data;
+    }
   }
 }
 
@@ -231,6 +234,7 @@ struct Frame {
     signalDelivery @14 :Signal;
     signalHandler @15 :Signal;
     exit @16 :Void;
+    detach @26 :Void;
     syscallbufFlush :group {
       # Not used during replay, but affects virtual memory layout so
       # useful for some tools

--- a/src/test/ignore_nested.c
+++ b/src/test/ignore_nested.c
@@ -3,7 +3,7 @@
 // This simply execs the commands passed to it on
 // the command line without passing through the
 // environment. The runner uses this to test
-// --ignore-nested in the absence of RR_UNDER_RR
+// --nested=ignore in the absence of RR_UNDER_RR
 // environment variable.
 int main(int argc, char *argv[]) {
     if (argc > 1 && strcmp(argv[1], "--inner") == 0) {

--- a/src/test/ignore_nested.run
+++ b/src/test/ignore_nested.run
@@ -1,4 +1,4 @@
 source `dirname $0`/util.sh
-record $TESTNAME "$(which rr) record --ignore-nested $PWD/$TESTNAME-$nonce --inner"
+record $TESTNAME "$(which rr) record --nested=ignore $PWD/$TESTNAME-$nonce --inner"
 replay
 check 'EXIT-SUCCESS'

--- a/src/util.h
+++ b/src/util.h
@@ -458,6 +458,12 @@ std::string json_escape(const std::string& str, size_t pos = 0);
 
 void sleep_time(double t);
 
+enum NestedBehavior {
+  NESTED_ERROR,
+  NESTED_IGNORE,
+  NESTED_SEPARATE
+}
+
 } // namespace rr
 
 #endif /* RR_UTIL_H_ */

--- a/src/util.h
+++ b/src/util.h
@@ -462,7 +462,7 @@ enum NestedBehavior {
   NESTED_ERROR,
   NESTED_IGNORE,
   NESTED_SEPARATE
-}
+};
 
 } // namespace rr
 


### PR DESCRIPTION
A common situation for us is that somewhere along the line in an
rr recording, we spawn a separate process that does a whole bunch
of work, but doesn't share any shared memory with the parent process,
nor does particularly much communication. In an ideal world of course,
rr would detect this kind of situation and record the two tasks in
parallel into the same recording. That seems like a very difficult
task, so this attempts to do the next best thing by letting the user
request this behavior manually.

In particular, any nested rr recording started with
`rr record --nested=separate` will get its own RecordSession, along
with its own recorder thread (and trace compressor threads to its
own thread). Implementation wise, this recorder thread is a thread
of the original rr process (in the sense that it shares its memory
space), but is placed in its own thread group. As a result, its
wait and ptrace state is entirely separate and the two recorders
act essentially as though they are entirely separate processes
(that just happen to share an address space).

This way, I'm hoping to keep this minimally invasive, as each
session is essentially and independent rr process.

Current status: Functional, but a few things remain to be done:
1) The CPU assignment needs to be reset, otherwise there is very
little point to this.
2) Some minor cleanup still.
3) Tests
I'm hoping to get some feedback on the general approach in the
meantime.