### PR TITLE
Fix accidental removal of breakpoints after vfork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1318,6 +1318,7 @@ set(TESTS_WITHOUT_PROGRAM
   term_trace_cpu
   unwind_on_signal
   vfork_exec
+  vfork_break_parent
   watch_code
   watchpoint_cond
   when

--- a/src/test/vfork.c
+++ b/src/test/vfork.c
@@ -2,6 +2,11 @@
 
 #include "util.h"
 
+static void breakpoint(void) {
+  int break_here = 1;
+  (void)break_here;
+}
+
 int main(int argc, char* argv[]) {
   const char* exe;
   pid_t child;
@@ -19,6 +24,8 @@ int main(int argc, char* argv[]) {
 
   test_assert(child == waitpid(child, &status, 0));
   test_assert(WIFEXITED(status) && 0 == WEXITSTATUS(status));
+
+  breakpoint();
 
   atomic_puts("vforker-EXIT-SUCCESS");
   return 0;

--- a/src/test/vfork_break_parent.py
+++ b/src/test/vfork_break_parent.py
@@ -1,0 +1,9 @@
+from util import *
+
+send_gdb('b breakpoint')
+expect_gdb('Breakpoint 1')
+
+send_gdb('c')
+expect_gdb('Breakpoint 1, breakpoint')
+
+ok()

--- a/src/test/vfork_break_parent.run
+++ b/src/test/vfork_break_parent.run
@@ -1,0 +1,7 @@
+source `dirname $0`/util.sh
+
+save_exe simple$bitness
+saved_exe="simple$bitness-$nonce"
+
+record vfork$bitness "$saved_exe"
+debug vfork_break_parent


### PR DESCRIPTION
Just treat it like any old clone(CLONE_VM) call.
Fixes #2475.