### PR TITLE
enter_syscall: Slightly strengthen an assertion

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -728,7 +728,7 @@ void Task::enter_syscall() {
         session().is_replaying()) {
       continue;
     }
-    ASSERT(this, session().is_recording())
+    ASSERT(this, session().is_recording() && !is_deterministic_signal(this))
         << " got unexpected signal " << signal_name(stop_sig());
     if (stop_sig() == session().as_record()->syscallbuf_desched_sig()) {
       continue;


### PR DESCRIPTION
When hacking on rr, I find it common to end up in a situation where
the tracee segfaults here, which causes the tracer to enter an infinite
loop of stashing the SIGSEGV signal and re-attempting the syscall only
to receive the same result. To prevent this particular failure mode,
strengthen the unexpected-signal assertion here to fail on
unexpected, deterministic signals (non-deterministic signals get stashed
as usual).