### PR TITLE
Get rid of RR_RESERVED_ROOT_DIR_FD

### DIFF
--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -196,6 +196,14 @@ public:
   ScopedFd retrieve_fd(int fd);
 
   /**
+   * Arranges for 'fd' to be transmitted to the tracee and returns
+   * a file descriptor in the tracee that corresponds to the same file
+   * description.
+   * Returns a negative value if the process dies or has died.
+   */
+  int send_fd(const ScopedFd &fd);
+
+  /**
    * Remotely invoke in |t| the specified syscall with the given
    * arguments.  The arguments must of course be valid in |t|,
    * and no checking of that is done by this function.
@@ -236,6 +244,7 @@ private:
   }
 
   template <typename Arch> ScopedFd retrieve_fd_arch(int fd);
+  template <typename Arch> int send_fd_arch(const ScopedFd &fd);
 
   Task* t;
   Registers initial_regs;

--- a/src/ReplayTask.cc
+++ b/src/ReplayTask.cc
@@ -47,10 +47,8 @@ void ReplayTask::init_buffers_arch(remote_ptr<void> map_hint) {
     if (args.cloned_file_data_fd >= 0) {
       cloned_file_data_fd_child = args.cloned_file_data_fd;
       string clone_file_name = trace_reader().file_data_clone_file_name(tuid());
-      AutoRestoreMem name(remote, clone_file_name.c_str());
-      int fd = remote.infallible_syscall(syscall_number_for_openat(arch()),
-                                         RR_RESERVED_ROOT_DIR_FD, name.get(),
-                                         O_RDONLY | O_CLOEXEC);
+      ScopedFd clone_file(clone_file_name.c_str(), O_RDONLY);
+      int fd = remote.send_fd(clone_file);
       if (fd != cloned_file_data_fd_child) {
         long ret =
             remote.infallible_syscall(syscall_number_for_dup3(arch()), fd,

--- a/src/ScopedFd.h
+++ b/src/ScopedFd.h
@@ -46,6 +46,11 @@ public:
     fd = -1;
   }
 
+  static ScopedFd openat(const ScopedFd &dir, const char* pathname,
+                         int flags, mode_t mode = 0) {
+    return ScopedFd(::openat(dir.get(), pathname, flags, mode));
+  }
+
 private:
   int fd;
 };

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1228,10 +1228,10 @@ struct BaseArch : public wordsize,
   RR_VERIFY_TYPE(sched_param);
 
   static void* cmsg_data(cmsghdr* cmsg) { return cmsg + 1; }
-  static size_t cmsg_align(size_t len) {
+  static constexpr size_t cmsg_align(size_t len) {
     return (len + sizeof(size_t) - 1) & ~(sizeof(size_t) - 1);
   }
-  static size_t cmsg_space(size_t len) {
+  static constexpr size_t cmsg_space(size_t len) {
     return cmsg_align(sizeof(cmsghdr)) + cmsg_align(len);
   }
   static size_t cmsg_len(size_t len) {

--- a/src/test/protect_rr_fds.c
+++ b/src/test/protect_rr_fds.c
@@ -20,8 +20,8 @@ int main(int argc, char* argv[]) {
 
   /* Various spawning APIs try to close all open file descriptors before
      exec --- via direct close(), or by setting CLOEXEC. Check that
-     those don't interfere with rr by closing RR_RESERVED_ROOT_DIR_FD
-     or some other essential file descriptor. */
+     those don't interfere with rr by closing one of our essential
+     file descriptors. */
   test_assert(0 == getrlimit(RLIMIT_NOFILE, &nofile));
   if (nofile.rlim_cur == RLIM_INFINITY || nofile.rlim_cur > MAX_FDS) {
     fd_limit = MAX_FDS;

--- a/src/util.cc
+++ b/src/util.cc
@@ -1424,8 +1424,8 @@ static ScopedFd create_memfd_file(const string &real_name) {
 }
 
 static void replace_char(string& s, char c, char replacement) {
-  size_t i;
-  while (string::npos != (i = s.find(c))) {
+  size_t i = 0;
+  while (string::npos != (i = s.find(c, i))) {
     s[i] = replacement;
   }
 }

--- a/src/util.h
+++ b/src/util.h
@@ -381,6 +381,11 @@ struct TempFile {
  */
 TempFile create_temporary_file(const char* pattern);
 
+/**
+ * Opens a temporary file backed by RAM.
+ */
+ScopedFd open_memory_file(const std::string &name);
+
 void good_random(void* out, size_t out_len);
 
 std::vector<std::string> current_env();


### PR DESCRIPTION
Admittedly, this change is primarily motivated by a philisophical
objection to RR_RESERVED_ROOT_DIR_FD, rather than any great practical
need. It just seems to me that if the tracee went through all the
trouble of hiding the real root, then we shouldn't just give it an
easy way to get it back. Of course, I'm not suggesting that this
would be the only issue with running an external rr tracer on a
sanboxed process without compromising that sandbox's security
guarantees - I'm sure there's many others. However, this one's
a pretty obvious one, so I'd like to remove it if possible.

That said, there are a couple of minor practical benefits:
- It's more robust to weird setups (weird mount setups, tmp being
  a symlink).
- It's more robust when recording programs that change uid
- As a result, we can get rid of a few fallbacks that would only
  get used if we happened to be in one of these weird setups (e.g.
  where we would fail to map the rr page).
- We can use memfd in more cases. This is a slightly benefit if /tmp
  happens to not be a tmpfs, which happens occasionally.
- There was a note in the code that things could fail in the nesting
  scenario if somebody chroot'ed between the outer and the inner rr
  (e.g. by recording a container that itself launched an rr process).
  That should work fine now.
- We avoid a corner case where after a setuid, some files in the trace
  directory would have the wrong uid.

None of these are particularly important, but together, I find
them convincing enough that I think this is worth doing (I happened
to need the send_fd functionality this depends upon for an
unrelated change, which made doing this quite easy).

The one place where this is slightly annoying is in open_mem_fd, because
we now need to send an fd and then get a new fd back. However, that
only needs to happen if rr fails to open /proc/<pid>/mem. A comment
in the code says that Ubuntu kernels have this behavior. However,
I was unable to reproduce on current Ubuntu kernels. It's also
counterbalanced by allowing us to do slightly fewer syscalls elsewhere.
And lastly, with pidfd_getfd and related functionality, these kinds
of file transfers might in the future be quite a bit faster anyway.