### PR TITLE
An alternative approach to nested detaching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1159,6 +1159,7 @@ set(TESTS_WITH_PROGRAM
   mprotect_growsdown
   mprotect_syscallbuf_overflow
   mutex_pi_stress
+  nested_detach_wait
   overflow_branch_counter
   patch_page_end
   patch_40_80_f6_81
@@ -1276,6 +1277,7 @@ set(TESTS_WITHOUT_PROGRAM
   hardlink_mmapped_files
   hbreak
   mprotect_step
+  nested_detach
   parent_no_break_child_bkpt
   parent_no_stop_child_crash
   post_exec_fpu_regs

--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -288,7 +288,7 @@ void AddressSpace::map_rr_page(AutoRemoteSyscalls& remote) {
 
   {
     ScopedFd page(path.c_str(), O_RDONLY);
-    ASSERT(t, page.is_open());
+    ASSERT(t, page.is_open()) << "Failed to open rr_page file " << path;
     long child_fd = remote.send_fd(page.get());
     ASSERT(t, child_fd >= 0);
     remote.infallible_mmap_syscall(rr_page_start(), rr_page_size(), prot, flags,

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -785,6 +785,8 @@ public:
   remote_code_ptr stopping_breakpoint_table() { return stopping_breakpoint_table_; }
   int stopping_breakpoint_table_entry_size() { return stopping_breakpoint_table_entry_size_; }
 
+  // Also sets brk_ptr.
+  void map_rr_page(AutoRemoteSyscalls& remote);
   void unmap_all_but_rr_page(AutoRemoteSyscalls& remote);
 
 private:
@@ -812,9 +814,6 @@ private:
   void populate_address_space(Task* t);
 
   void unmap_internal(Task* t, remote_ptr<void> addr, ssize_t num_bytes);
-
-  // Also sets brk_ptr.
-  void map_rr_page(AutoRemoteSyscalls& remote);
 
   bool update_watchpoint_value(const MemoryRange& range,
                                Watchpoint& watchpoint);

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -785,6 +785,8 @@ public:
   remote_code_ptr stopping_breakpoint_table() { return stopping_breakpoint_table_; }
   int stopping_breakpoint_table_entry_size() { return stopping_breakpoint_table_entry_size_; }
 
+  void unmap_all_but_rr_page(AutoRemoteSyscalls& remote);
+
 private:
   struct Breakpoint;
   typedef std::map<remote_code_ptr, Breakpoint> BreakpointMap;

--- a/src/AutoRemoteSyscalls.cc
+++ b/src/AutoRemoteSyscalls.cc
@@ -485,6 +485,11 @@ ScopedFd AutoRemoteSyscalls::retrieve_fd(int fd) {
 }
 
 template <typename Arch> int AutoRemoteSyscalls::send_fd_arch(const ScopedFd &our_fd) {
+  if (!our_fd.is_open()) {
+    return -EBADF;
+  }
+
+  LOG(debug) << "Sending fd " << our_fd.get() << " via socket fd " << task()->session().tracee_socket_fd().get();
   sendmsg_socket(task()->session().tracee_socket_fd(), our_fd.get());
 
   long child_syscall_result =

--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -220,6 +220,14 @@ public:
    */
   pid_t new_tid() { return new_tid_; }
 
+  /* Do the open/mmap/close dance for a particular file */
+  void finish_direct_mmap(remote_ptr<void> rec_addr, size_t length,
+                          int prot, int flags,
+                          const std::string& backing_file_name,
+                          int backing_file_open_flags,
+                          off64_t backing_offset_pages,
+                          struct stat& real_file, std::string& real_file_name);
+
 private:
   void setup_path(bool enable_singlestep_path);
 

--- a/src/DiversionSession.cc
+++ b/src/DiversionSession.cc
@@ -123,12 +123,7 @@ DiversionSession::DiversionResult DiversionSession::diversion_step(
     return result;
   }
 
-  // Disable syscall buffering during diversions
-  if (t->preload_globals) {
-    t->write_mem(REMOTE_PTR_FIELD(t->preload_globals, in_diversion),
-                 (unsigned char)1);
-  }
-  t->set_syscallbuf_locked(1);
+  t->set_in_diversion(true);
 
   switch (command) {
     case RUN_CONTINUE:

--- a/src/DiversionSession.h
+++ b/src/DiversionSession.h
@@ -29,6 +29,8 @@ class ReplaySession;
  */
 class DiversionSession : public Session {
 public:
+  DiversionSession();
+
   typedef std::shared_ptr<DiversionSession> shr_ptr;
 
   ~DiversionSession();
@@ -53,10 +55,11 @@ public:
 
   virtual DiversionSession* as_diversion() override { return this; }
 
+  void set_tracee_fd_number(int fd_number) { tracee_socket_fd_number = fd_number; }
+  void on_create(Task *t) { this->Session::on_create(t); }
+
 private:
   friend class ReplaySession;
-
-  DiversionSession();
 
   std::shared_ptr<EmuFs> emu_fs;
 };

--- a/src/PsCommand.cc
+++ b/src/PsCommand.cc
@@ -91,6 +91,9 @@ static string find_exit_code(pid_t pid, const vector<TraceTaskEvent>& events,
       }
       DEBUG_ASSERT(status.type() == WaitStatus::FATAL_SIGNAL);
       return to_string(-status.fatal_sig());
+    } else if (e.type() == TraceTaskEvent::DETACH && tid_to_pid[e.tid()] == pid &&
+        count_tids_for_pid(tid_to_pid, pid) == 1) {
+      return string("detach");
     }
     update_tid_to_pid_map(tid_to_pid, e);
   }

--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -87,7 +87,7 @@ RecordCommand RecordCommand::singleton(
     "                             tracee. There can be any number of these.\n"
     "  -w, --wait                 Wait for all child processes to exit, not\n"
     "                             just the initial process.\n"
-    "  --ignore-nested            Directly start child process when running\n"
+    "  --nested=ignore            Directly start child process when running\n"
     "                             under nested rr recording, instead of\n"
     "                             raising an error.\n"
     "  --scarce-fds               Consume 950 fds before recording\n"
@@ -152,7 +152,7 @@ struct RecordFlags {
   bool wait_for_all;
 
   /* Start child process directly if run under nested rr recording */
-  bool ignore_nested;
+  NestedBehavior nested;
 
   bool scarce_fds;
 
@@ -184,7 +184,7 @@ struct RecordFlags {
         chaos(false),
         num_cores(0),
         wait_for_all(false),
-        ignore_nested(false),
+        nested(NESTED_ERROR),
         scarce_fds(false),
         setuid_sudo(false),
         copy_preload_src(false),
@@ -235,7 +235,7 @@ static bool parse_record_arg(vector<string>& args, RecordFlags& flags) {
     { 0, "no-read-cloning", NO_PARAMETER },
     { 1, "no-file-cloning", NO_PARAMETER },
     { 2, "syscall-buffer-size", HAS_PARAMETER },
-    { 3, "ignore-nested", NO_PARAMETER },
+    { 3, "nested", HAS_PARAMETER },
     { 4, "scarce-fds", NO_PARAMETER },
     { 5, "setuid-sudo", NO_PARAMETER },
     { 6, "bind-to-cpu", HAS_PARAMETER },
@@ -312,7 +312,14 @@ static bool parse_record_arg(vector<string>& args, RecordFlags& flags) {
       flags.syscall_buffer_size = opt.int_value * 1024;
       break;
     case 3:
-      flags.ignore_nested = true;
+      if (opt.value == "default" || opt.value == "error") {
+        flags.nested = NESTED_ERROR;
+      } else if (opt.value == "ignore") {
+        flags.nested = NESTED_IGNORE;
+      } else {
+        LOG(warn) << "Unknown nesting behavior `" << opt.value << "`";
+        flags.nested = NESTED_ERROR;
+      }
       break;
     case 4:
       flags.scarce_fds = true;
@@ -698,11 +705,11 @@ int RecordCommand::run(vector<string>& args) {
   }
 
   if (running_under_rr()) {
-    if (flags.ignore_nested) {
+    if (flags.nested == NESTED_IGNORE) {
       exec_child(args);
     }
     fprintf(stderr, "rr: cannot run rr recording under rr. Exiting.\n"
-                    "Use `rr record --ignore-nested` to start the child "
+                    "Use `rr record --nested=ignore` to start the child "
                     "process directly.\n");
     return 1;
   }

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2036,10 +2036,11 @@ RecordSession::RecordSession(const std::string& exe_path,
     FATAL() << "RR_CALL_BASE is incorrect";
   }
 
+  do_bind_cpu(trace_out);
   ScopedFd error_fd = create_spawn_task_error_pipe();
   RecordTask* t = static_cast<RecordTask*>(
       Task::spawn(*this, error_fd, &tracee_socket_fd(),
-                  &tracee_socket_fd_number, trace_out,
+                  &tracee_socket_fd_number,
                   exe_path, argv, envp));
   // CPU affinity has been set.
   trace_out.setup_cpuid_records(has_cpuid_faulting(), disable_cpuid_features_);

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1944,6 +1944,19 @@ static string lookup_by_path(const string& name) {
   }
 
   vector<string> env = current_env();
+
+  // Have extra_env override anything already in the environment
+  for (string extra : extra_env) {
+    string extra_var = extra.substr(0, extra.find('='));
+    auto it = env.begin();
+    for (; it != env.end(); ++it) {
+      if (it->find(extra_var) != 0) {
+        continue;
+      }
+      it = env.erase(it);
+      break;
+    }
+  }
   env.insert(env.end(), extra_env.begin(), extra_env.end());
 
   string full_path = lookup_by_path(argv[0]);

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -170,6 +170,8 @@ public:
   RecordTask* find_task(pid_t rec_tid) const;
   RecordTask* find_task(const TaskUid& tuid) const;
 
+  void on_proxy_detach(RecordTask *t, pid_t new_tid);
+
   /**
    * This gets called when we detect that a task has been revived from the
    * dead with a PTRACE_EVENT_EXEC. See ptrace man page under "execve(2) under

--- a/src/Registers.cc
+++ b/src/Registers.cc
@@ -624,7 +624,8 @@ bool Registers::syscall_may_restart() const {
 ostream& operator<<(ostream& stream, const Registers& r) {
   stream << "{ args:(" << HEX(r.arg1()) << "," << HEX(r.arg2()) << ","
          << HEX(r.arg3()) << "," << HEX(r.arg4()) << "," << HEX(r.arg5()) << ","
-         << r.arg6() << ") orig_syscall:" << r.original_syscallno() << " }";
+         << r.arg6() << ") orig_syscall:" << r.original_syscallno() <<
+         "syscallno: " << r.syscallno() << " }";
   return stream;
 }
 

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -296,11 +296,12 @@ Task* ReplaySession::new_task(pid_t tid, pid_t rec_tid, uint32_t serial,
   vector<string> argv;
   vector<string> env;
 
+  session->do_bind_cpu(session->trace_in);
   ScopedFd error_fd = session->create_spawn_task_error_pipe();
   ReplayTask* t = static_cast<ReplayTask*>(
       Task::spawn(*session, error_fd, &session->tracee_socket_fd(),
                   &session->tracee_socket_fd_number,
-                  session->trace_in, exe_path, argv, env,
+                  exe_path, argv, env,
                   session->trace_reader().peek_frame().tid()));
   session->on_create(t);
 

--- a/src/ScopedFd.h
+++ b/src/ScopedFd.h
@@ -38,7 +38,7 @@ public:
     return result;
   }
 
-  bool is_open() { return fd >= 0; }
+  bool is_open() const { return fd >= 0; }
   void close() {
     if (fd >= 0) {
       ::close(fd);

--- a/src/Session.h
+++ b/src/Session.h
@@ -357,6 +357,10 @@ public:
     return SYS_rrcall_notify_stap_semaphore_removed - RR_CALL_BASE + rrcall_base_;
   }
 
+  /* Bind the current process to the a CPU as specified in the session options
+     or trace */
+  void do_bind_cpu(TraceStream &trace);
+
 protected:
   Session();
   virtual ~Session();

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -2991,4 +2991,5 @@ static void run_initial_child(Session& session, const ScopedFd& error_fd,
 void* Task::preload_thread_locals() {
   return preload_thread_locals_local_addr(*as);
 }
+
 }

--- a/src/Task.h
+++ b/src/Task.h
@@ -835,6 +835,15 @@ public:
    */
   void set_syscallbuf_locked(bool locked);
 
+  // Disable syscall buffering during diversions
+  void set_in_diversion(bool in_diversion) {
+    if (preload_globals) {
+      write_mem(REMOTE_PTR_FIELD(preload_globals, in_diversion),
+                (unsigned char)in_diversion);
+    }
+    set_syscallbuf_locked(in_diversion);
+  }
+
   /**
    * Like |fallible_ptrace()| but infallible for most purposes.
    * Errors other than ESRCH are treated as fatal. Returns false if

--- a/src/Task.h
+++ b/src/Task.h
@@ -855,6 +855,8 @@ public:
     return was_reaped;
   }
 
+  void os_exec_stub(SupportedArch arch);
+
   virtual ~Task();
 
 protected:

--- a/src/Task.h
+++ b/src/Task.h
@@ -1009,7 +1009,7 @@ protected:
    */
   static Task* spawn(Session& session, ScopedFd& error_fd,
                      ScopedFd* sock_fd_out, int* tracee_socket_fd_number_out,
-                     TraceStream& trace, const std::string& exe_path,
+                     const std::string& exe_path,
                      const std::vector<std::string>& argv,
                      const std::vector<std::string>& envp, pid_t rec_tid = -1);
 

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -679,6 +679,9 @@ void TraceWriter::write_task_event(const TraceTaskEvent& event) {
     case TraceTaskEvent::EXIT:
       task.initExit().setExitStatus(event.exit_status().get());
       break;
+    case TraceTaskEvent::DETACH:
+      task.initDetach();
+      break;
     case TraceTaskEvent::NONE:
       DEBUG_ASSERT(0 && "Writing NONE TraceTaskEvent");
       break;
@@ -733,6 +736,9 @@ TraceTaskEvent TraceReader::read_task_event(FrameTime* time) {
     case trace::TaskEvent::Which::EXIT:
       r.type_ = TraceTaskEvent::EXIT;
       r.exit_status_ = WaitStatus(task.getExit().getExitStatus());
+      break;
+    case trace::TaskEvent::Which::DETACH:
+      r.type_ = TraceTaskEvent::DETACH;
       break;
     default:
       DEBUG_ASSERT(0 && "Unknown TraceEvent type");

--- a/src/TraceTaskEvent.h
+++ b/src/TraceTaskEvent.h
@@ -24,7 +24,8 @@ public:
     NONE,
     CLONE, // created by clone(2), fork(2), vfork(2) syscalls
     EXEC,
-    EXIT
+    EXIT,
+    DETACH
   };
 
   TraceTaskEvent(Type type = NONE, pid_t tid = 0) : type_(type), tid_(tid) {}
@@ -48,6 +49,10 @@ public:
   static TraceTaskEvent for_exit(pid_t tid, WaitStatus exit_status) {
     TraceTaskEvent result(EXIT, tid);
     result.exit_status_ = exit_status;
+    return result;
+  }
+  static TraceTaskEvent for_detach(pid_t tid) {
+    TraceTaskEvent result(DETACH, tid);
     return result;
   }
 

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -204,6 +204,12 @@ static inline const char* extract_file_name(const char* s) {
  * presence of absence of rr.
  */
 #define SYS_rrcall_check_presence (RR_CALL_BASE + 8)
+/**
+ * Requests that rr detach from this process and re-create outside of its
+ * process tree, such that it may run without seccomp.
+ */
+#define SYS_rrcall_detach_teleport (RR_CALL_BASE + 9)
+
 
 /* Define macros that let us compile a struct definition either "natively"
  * (when included by preload.c) or as a template over Arch for use by rr.

--- a/src/rr_trace.capnp
+++ b/src/rr_trace.capnp
@@ -149,6 +149,9 @@ struct TaskEvent {
     exit :group {
       exitStatus @7 :Int32;
     }
+    detach :group {
+      none @9 :Void;
+    }
   }
 }
 

--- a/src/test/ignore_nested.c
+++ b/src/test/ignore_nested.c
@@ -3,7 +3,7 @@
 // This simply execs the commands passed to it on
 // the command line without passing through the
 // environment. The runner uses this to test
-// --ignore-nested in the absence of RR_UNDER_RR
+// --nested=ignore in the absence of RR_UNDER_RR
 // environment variable.
 int main(int argc, char *argv[]) {
     if (argc > 1 && strcmp(argv[1], "--inner") == 0) {

--- a/src/test/ignore_nested.run
+++ b/src/test/ignore_nested.run
@@ -1,4 +1,4 @@
 source `dirname $0`/util.sh
-record $TESTNAME "$(which rr) record --ignore-nested $PWD/$TESTNAME-$nonce --inner"
+record $TESTNAME "$(which rr) record --nested=ignore $PWD/$TESTNAME-$nonce --inner"
 replay
 check 'EXIT-SUCCESS'

--- a/src/test/nested_detach.run
+++ b/src/test/nested_detach.run
@@ -1,0 +1,12 @@
+source `dirname $0`/util.sh
+RECORD_ARGS="--env=_RR_TRACE_DIR=$workdir/inner"
+save_exe simple$bitness
+just_record $(which rr) "record --nested=detach $PWD/simple$bitness-$nonce"
+# Replay outer
+replay
+check_record
+# Replay inner
+cd inner
+workdir=$PWD
+replay
+check_replay_token EXIT-SUCCESS

--- a/src/test/nested_detach_wait.c
+++ b/src/test/nested_detach_wait.c
@@ -1,0 +1,23 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(int argc, char *argv[]) {
+  pid_t child = fork();
+  if (argc > 1 && strcmp(argv[1], "--inner") == 0) {
+      atomic_puts("EXIT-SUCCESS");
+      return 0;
+  }
+  test_assert(argc >= 2);
+
+  if (!child) {
+    execve(argv[1], &argv[1], environ); // Should not return
+    test_assert(0);
+  }
+
+  int status;
+  wait(&status);
+  test_assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+  atomic_puts("EXIT-WAITED");
+  return 0;
+}

--- a/src/test/nested_detach_wait.run
+++ b/src/test/nested_detach_wait.run
@@ -1,0 +1,13 @@
+source `dirname $0`/util.sh
+
+mkdir $workdir/inner
+RECORD_ARGS="--env=_RR_TRACE_DIR=$workdir/inner"
+record $TESTNAME "$(which rr) record --nested=detach $PWD/$TESTNAME-$nonce --inner"
+# Replay outer
+replay
+check_record EXIT-WAITED
+# Replay inner
+cd $workdir/inner
+workdir=$PWD
+replay
+check_replay_token EXIT-SUCCESS

--- a/src/util.cc
+++ b/src/util.cc
@@ -1860,7 +1860,6 @@ void sleep_time(double t) {
   nanosleep(&ts, NULL);
 }
 
-
 static bool is_component(const char* p, const char* component) {
   while (*component) {
     if (*p != *component) {
@@ -1901,6 +1900,16 @@ void normalize_file_name(string& s)
     ++out;
   }
   s.resize(out);
+}
+
+std::string find_exec_stub(SupportedArch arch) {
+  string exe_path = resource_path() + "bin/";
+  if (arch == x86 && NativeArch::arch() == x86_64) {
+    exe_path += "rr_exec_stub_32";
+  } else {
+    exe_path += "rr_exec_stub";
+  }
+  return exe_path;
 }
 
 } // namespace rr

--- a/src/util.cc
+++ b/src/util.cc
@@ -3,6 +3,7 @@
 #include "util.h"
 
 #include <arpa/inet.h>
+#include <dirent.h>
 #include <elf.h>
 #include <execinfo.h>
 #include <fcntl.h>
@@ -1900,6 +1901,19 @@ void normalize_file_name(string& s)
     ++out;
   }
   s.resize(out);
+}
+
+std::vector<int> read_all_proc_fds(pid_t tid)
+{
+  std::vector<int> ret;
+  char buf[1000];
+  sprintf(buf, "/proc/%d/fd", tid);
+  DIR *fddir = opendir(buf);
+  DEBUG_ASSERT(fddir != nullptr);
+  while (struct dirent *dir = readdir(fddir)) {
+    ret.push_back(atoi(dir->d_name));
+  }
+  return ret;
 }
 
 std::string find_exec_stub(SupportedArch arch) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -1127,10 +1127,10 @@ double monotonic_now_sec() {
   return (double)tp.tv_sec + (double)tp.tv_nsec / 1e9;
 }
 
-bool running_under_rr() {
+bool running_under_rr(bool cache) {
   static bool rr_under_rr = false;
   static bool rr_check_done = false;
-  if (!rr_check_done) {
+  if (!rr_check_done || !cache) {
     rr_check_done = true;
     int ret = syscall(SYS_rrcall_check_presence, 0, 0, 0, 0, 0, 0);
     DEBUG_ASSERT(ret == 0 || (ret == -1 && errno == ENOSYS));

--- a/src/util.cc
+++ b/src/util.cc
@@ -1742,6 +1742,38 @@ ssize_t pwrite_all_fallible(int fd, const void* buf, size_t size, off_t offset) 
   return written;
 }
 
+ssize_t copy_file_range_all(int from_fd, off_t from_offset, int to_fd,
+                            off_t to_offset, size_t len)
+{
+  char buf[4096];
+  size_t nwritten = 0;
+  while (true) {
+    ssize_t to_read = std::min(len - nwritten, sizeof(buf));
+    if (to_read == 0) {
+      break;
+    }
+    ssize_t read_ret = ::pread64(from_fd, buf, to_read, from_offset);
+    if (read_ret < 0) {
+      return read_ret;
+    }
+    else if (read_ret == 0) {
+      // We expected to read everything, but came up short, probably because
+      // what we tried to read wasn't mapped - let's call this EIO.
+      return -EIO;
+    }
+    from_offset += read_ret;
+    ssize_t write_ret = pwrite_all_fallible(to_fd, buf, read_ret, to_offset);
+    if (write_ret < 0) {
+      return write_ret;
+    } else if (write_ret < read_ret) {
+      return -EIO;
+    }
+    to_offset += write_ret;
+    nwritten += write_ret;
+  }
+  return nwritten;
+}
+
 bool is_directory(const char* path) {
   struct stat buf;
   if (stat(path, &buf) < 0) {

--- a/src/util.h
+++ b/src/util.h
@@ -478,7 +478,8 @@ void normalize_file_name(std::string& s);
 
 enum NestedBehavior {
   NESTED_ERROR,
-  NESTED_IGNORE
+  NESTED_IGNORE,
+  NESTED_DETACH
 };
 
 std::string find_exec_stub(SupportedArch arch);

--- a/src/util.h
+++ b/src/util.h
@@ -267,6 +267,8 @@ double monotonic_now_sec();
 
 bool running_under_rr(bool cache = true);
 
+std::vector<int> read_all_proc_fds(pid_t tid);
+
 std::vector<std::string> read_proc_status_fields(pid_t tid, const char* name,
                                                  const char* name2 = nullptr,
                                                  const char* name3 = nullptr);

--- a/src/util.h
+++ b/src/util.h
@@ -265,7 +265,7 @@ std::string resource_path();
  */
 double monotonic_now_sec();
 
-bool running_under_rr();
+bool running_under_rr(bool cache = true);
 
 std::vector<std::string> read_proc_status_fields(pid_t tid, const char* name,
                                                  const char* name2 = nullptr,

--- a/src/util.h
+++ b/src/util.h
@@ -469,6 +469,11 @@ void sleep_time(double t);
  */
 void normalize_file_name(std::string& s);
 
+enum NestedBehavior {
+  NESTED_ERROR,
+  NESTED_IGNORE
+};
+
 } // namespace rr
 
 #endif /* RR_UTIL_H_ */

--- a/src/util.h
+++ b/src/util.h
@@ -431,6 +431,11 @@ void write_all(int fd, const void* buf, size_t size);
 /* Like pwrite64(2) but we try to write all bytes by looping on short writes. */
 ssize_t pwrite_all_fallible(int fd, const void* buf, size_t size, off_t offset);
 
+/* Like copy_file_range(2), but slower, because it buffers through this process
+  and without being completely broken on memfds. Also doesn't do short reads/writes.
+  XXX: It would be nice to fix this in the kernel. */
+ssize_t copy_file_range_all(int from_fd, off_t from_offset, int to_fd, off_t to_offset, size_t len);
+
 /* Returns true if |path| is an accessible directory. Returns false if there
  * was an error.
  */

--- a/src/util.h
+++ b/src/util.h
@@ -479,6 +479,8 @@ enum NestedBehavior {
   NESTED_IGNORE
 };
 
+std::string find_exec_stub(SupportedArch arch);
+
 } // namespace rr
 
 #endif /* RR_UTIL_H_ */


### PR DESCRIPTION
This is an alternative approach to achieving the same goal as #2471, but without introducing any threading. The thought here is quite simple: In an ideal world, we would simply ptrace detach from the nested rr process and everything would magically work. That doesn't work because of the seccomp filter, which will immediately kill our tracee (and even if we kept attached and handled its events, it would cause performace problems) and which we can't remove. My original original thought (before #2471) was just to patch the kernel to mitigate this, but after pushback from the kernel maintainers (who didn't like my approach to that) and our CI team (who didn't want to run a patched kernel) I came up with the alternative in #2471. This PR goes back to the original detaching idea, but using rr magic to fake the ability to remove the seccomp filter from a process. This is done by forking off the exec stub from the parent rr and then simply copying over all mappings, file descriptors, etc. from our tracee to this new stub process and then letting that stub process run wild. The process' pid will change, but other than that, the process is basically the same and in particular without the pesky seccomp filter it's free to go off and start its own recording as if it was a vanilla rr process. It also has a nice upgrade path if we ever do get the kernel feature that lets us turn off seccomp for one of our tracees. As for the original process, once it's been copied, I just let it die. I'm planning to keep it around as a zombie and have rr emulate any tracee wait requests for the old pid. That's not too onerous, since we already emulate waits for ptrace. However, I haven't implemented this part yet.

There's a couple of additional benefits over #2471:
- It works fine if the nested rr is a different rr build than the outer rr
- It could be used for detaching, even if we don't want to record the resulting child. E.g. if our tracee wants to spawn a helper program that's expensive, but not particularly interesting to record (e.g. in Julia we sometimes spin off processes that go and download some missing library - we don't care about recording those processes).

This PR is very rough - just enough to validate that it works -, but I wanted to make sure the direction seems sane before cleaning it up and finishing the implementation. No need to review in detail at this point, but the main logic is in the new `Task::dup_from` and `do_detach_teleport` if you're curious.