### PR TITLE
Fix patching _dl_runtime_resolve when compiled with IBT

### DIFF
--- a/src/assembly_templates.py
+++ b/src/assembly_templates.py
@@ -172,6 +172,12 @@ templates = {
         RawBytes(0xe9),                   # jmp $relative_addr
         Field('relative_addr', 4),
     ),
+    'X64EndBr': AssemblyTemplate(
+        RawBytes(0xf3, 0x0f, 0x1e, 0xfa)
+    ),
+    'X86EndBr': AssemblyTemplate(
+        RawBytes(0xf3, 0x0f, 0x1e, 0xfb)
+    )
 }
 
 def byte_array_name(name):


### PR DESCRIPTION
If the compiler had IBT support when the libc was compiled,
then these functions will start with an `endbr64` instruction.
Handle that in the Monkeypatcher.