### PR TITLE
Properly handle event ordering constraints for core dump signals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -762,6 +762,7 @@ set(BASIC_TESTS
   exit_with_syscallbuf_signal
   fadvise
   fanotify
+  fatal_sigsegv_thread
   fcntl_dupfd
   fault_in_code_page
   fcntl_misc

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -163,8 +163,8 @@ public:
    */
   bool is_waiting_for(RecordTask* t);
 
-  virtual bool is_waiting_for_reap() const override {
-    return waiting_for_reap;
+  virtual bool already_exited() const override {
+    return waiting_for_reap || waiting_for_zombie;
   }
 
   /**
@@ -534,6 +534,12 @@ public:
 
   void maybe_restore_original_syscall_registers();
 
+  /**
+   * The task reached zombie state. Do whatever processing is necessary (reaping
+   * it, emulating ptrace stops, etc.)
+   */
+  void did_reach_zombie();
+
 private:
   /* Retrieve the tid of this task from the tracee and store it */
   void update_own_namespace_tid();
@@ -718,6 +724,9 @@ public:
 
   // This task is just waiting to be reaped.
   bool waiting_for_reap;
+
+  // This task is waiting to reach zombie state
+  bool waiting_for_zombie;
 };
 
 } // namespace rr

--- a/src/Scheduler.cc
+++ b/src/Scheduler.cc
@@ -215,6 +215,11 @@ bool Scheduler::is_task_runnable(RecordTask* t, bool* by_waitpid) {
     return true;
   }
 
+  if (t->waiting_for_zombie) {
+    LOG(debug) << "  " << t->tid << " is waiting to become a zombie";
+    return false;
+  }
+
   if (t->emulated_stop_type != NOT_STOPPED) {
     if (t->is_signal_pending(SIGCONT)) {
       // We have to do this here. RecordTask::signal_delivered can't always

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -216,19 +216,11 @@ void Session::kill_all_tasks() {
      */
     for (auto &v : task_map) {
       Task* t = v.second;
-      if (t->is_waiting_for_reap()) {
-        /* We've already seeing the PTRACE_EXIT_EVENT for this task.
-         * We were just waiting for one of the other traced tasks, to
-         * reap it, but that ain't gonna happen, now. It'll get deleted
-         * below
-         */
-        continue;
-      }
       bool is_group_leader = t->tid == t->real_tgid();
       if (pass == 0 ? is_group_leader : !is_group_leader)
           continue;
       t->kill();
-      if (is_recording()) {
+      if (is_recording() && !t->already_exited()) {
         static_cast<RecordTask*>(t)->record_exit_event(SIGKILL);
       }
     }

--- a/src/Task.h
+++ b/src/Task.h
@@ -158,7 +158,7 @@ public:
   /**
    * Advance the task to its exit state if it's not already there.
    */
-  void proceed_to_exit();
+  void proceed_to_exit(bool wait = true);
 
   /**
    * Kill this task and wait for it to exit.
@@ -411,7 +411,7 @@ public:
   /**
    * Return true if this task is dead and just waiting to be reaped.
    */
-  virtual bool is_waiting_for_reap() const { return false; }
+  virtual bool already_exited() const { return false; }
 
   /**
    * Read |N| bytes from |child_addr| into |buf|, or don't

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -5538,7 +5538,11 @@ static void rec_process_syscall_arch(RecordTask* t,
           }
         }
         if (tracee->waiting_for_reap) {
-          delete tracee;
+          if (tracee->waiting_for_zombie) {
+            tracee->waiting_for_reap = false;
+          } else {
+            delete tracee;
+          }
         }
       }
       break;

--- a/src/test/fatal_sigsegv_thread.c
+++ b/src/test/fatal_sigsegv_thread.c
@@ -1,0 +1,40 @@
+#include "util.h"
+
+static void *run_thread(__attribute__((unused)) void* p) {
+    crash_null_deref();
+    return NULL;
+}
+
+static void* no_nothing_thread(__attribute__((unused)) void* p) {
+  while (1) {
+    sched_yield();
+  }
+  return NULL;
+}
+
+#define NUSELESS 10
+
+int main(__attribute__((unused)) int argc,
+         __attribute__((unused)) const char** argv) {
+
+    pid_t child;
+    if ((child = fork()) == 0) {
+        pthread_t thread;
+        pthread_t useless_threads[NUSELESS];
+        for (int i = 0; i < NUSELESS; ++i) {
+            pthread_create(&useless_threads[i], NULL, no_nothing_thread, NULL);
+        }
+
+        pthread_create(&thread, NULL, run_thread, NULL);
+        pthread_join(thread, NULL);
+        test_assert(0 && "Should not reach here");
+    }
+
+    int status;
+    test_assert(child == waitpid(child, &status, 0));
+    test_assert(WIFSIGNALED(status) && WTERMSIG(status) == SIGSEGV);
+
+    atomic_puts("EXIT-SUCCESS");
+    return 0;
+}
+


### PR DESCRIPTION
The order of events for coredumping signals is extremely confusing,
so I got it slightly wrong. This commit attempts to remidy that.
For my future reference, here are some breadcrumbs of how the
event ordering works for coredumping signals:

1) The thread that receives the coredumping signal will block (without
further event after the injection), until all other threads have passed
their exit events [1]
2) After passing their own exit events, all other threads will block until
the coredump is complete (equivalently until all threads have passed their
exit events). Note that in this state, these tasks are also ignoring SIGKILL.
3) Once the coredump is complete, each task may proceed. The first task to
its exit events, the other tasks to their zombie state.

Of course hidden zombie state applies for exits by thread group leaders.

[1] https://github.com/torvalds/linux/blob/7e63420847ae5f1036e4f7c42f0b3282e73efbc2/fs/coredump.c#L457
[2] https://github.com/torvalds/linux/blob/7e63420847ae5f1036e4f7c42f0b3282e73efbc2/kernel/exit.c#L461-L466