### PR TITLE
Fix syscallbuf for quotactl

### DIFF
--- a/src/preload/syscallbuf.c
+++ b/src/preload/syscallbuf.c
@@ -2654,7 +2654,7 @@ static long sys_quotactl(const struct syscall_info* call) {
   if (!start_commit_buffered_syscall(syscallno, ptr, WONT_BLOCK)) {
     return traced_raw_syscall(call);
   }
-  ret = untraced_syscall4(syscallno, cmd, special, id, addr);
+  ret = untraced_syscall4(syscallno, cmd, special, id, buf2);
   if (buf2 && ret >= 0 && !buffer_hdr()->failed_during_preparation) {
     local_memcpy(addr, buf2, sizeof(*buf2));
   }


### PR DESCRIPTION
Found by inspection - all my machines are using btrfs as a home device,
so the test doesn't run. Perhaps someone with a machine where this
actually runs can add some sanity checks to the quotactl test that
would have caught us writing garbage here.