### PR TITLE
Fix build with very old glibc headers

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -2915,11 +2915,11 @@ static void run_initial_child(Session& session, const ScopedFd& error_fd,
   }
 
   ret =
-      ptrace(PTRACE_SEIZE, tid, nullptr, (void*)(options | PTRACE_O_EXITKILL));
+      ptrace((__ptrace_request)PTRACE_SEIZE, tid, nullptr, (void*)(options | PTRACE_O_EXITKILL));
   if (ret < 0 && errno == EINVAL) {
     // PTRACE_O_EXITKILL was added in kernel 3.8, and we only need
     // it for more robust cleanup, so tolerate not having it.
-    ret = ptrace(PTRACE_SEIZE, tid, nullptr, (void*)options);
+    ret = ptrace((__ptrace_request)PTRACE_SEIZE, tid, nullptr, (void*)options);
   }
   if (ret) {
     // Note that although the tracee may have died due to some fatal error,

--- a/src/ftrace/ftrace_helper.c
+++ b/src/ftrace/ftrace_helper.c
@@ -20,6 +20,10 @@
 #include <sys/user.h>
 #include <unistd.h>
 
+#ifndef F_GETPIPE_SZ
+#define F_GETPIPE_SZ 1032
+#endif
+
 #ifdef NDEBUG
 #undef NDEBUG
 #endif

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1613,6 +1613,12 @@ struct BaseArch : public wordsize,
       __u32 line_info_cnt;
     };
   };
+
+  struct file_handle {
+    unsigned int handle_bytes;
+    int handle_type;
+    uint8_t f_handle[0];
+  };
 };
 
 struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {

--- a/src/kernel_supplement.h
+++ b/src/kernel_supplement.h
@@ -50,6 +50,23 @@ namespace rr {
 #define PTRACE_SYSEMU_SINGLESTEP 32
 #endif
 
+#ifndef PTRACE_GETREGSET
+#define PTRACE_GETREGSET 0x4204
+#endif
+#ifndef PTRACE_SETREGSET
+#define PTRACE_SETREGSET 0x4205
+#endif
+
+#ifndef PTRACE_SEIZE
+#define PTRACE_SEIZE 0x4206
+#endif
+#ifndef PTRACE_INTERRUPT
+#define PTRACE_INTERRUPT 0x4207
+#endif
+#ifndef PTRACE_LISTEN
+#define PTRACE_LISTEN	0x4208
+#endif
+
 #ifndef PTRACE_GETSIGMASK
 #define PTRACE_GETSIGMASK 0x420a
 #endif
@@ -327,6 +344,14 @@ enum {
   BPF_MAP_GET_NEXT_KEY,
   BPF_PROG_LOAD,
 };
+
+#ifndef O_PATH
+#define O_PATH 040000000
+#endif
+
+#ifndef MAX_HANDLE_SZ
+#define MAX_HANDLE_SZ 128
+#endif
 
 } // namespace rr
 

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -50,10 +50,7 @@ static inline size_t rrstrlen(const char* s) { return strlen(s); }
 #include "../remote_ptr.h"
 #endif
 
-#include <signal.h>
 #include <stdint.h>
-#include <sys/types.h>
-#include <sys/user.h>
 
 static inline int strprefix(const char* s1, const char* s2) {
   while (1) {

--- a/src/preload/syscallbuf.h
+++ b/src/preload/syscallbuf.h
@@ -3,7 +3,7 @@
 #ifndef RR_SYSCALLBUF_H_
 #define RR_SYSCALLBUF_H_
 
-#include <pthread.h>
+struct timespec;
 
 #define RR_HIDDEN __attribute__((visibility("hidden")))
 
@@ -12,9 +12,9 @@ RR_HIDDEN extern struct preload_globals globals;
 RR_HIDDEN extern char impose_syscall_delay;
 RR_HIDDEN extern char impose_spurious_desched;
 
-RR_HIDDEN extern int (*real_pthread_mutex_lock)(pthread_mutex_t* mutex);
-RR_HIDDEN extern int (*real_pthread_mutex_trylock)(pthread_mutex_t* mutex);
-RR_HIDDEN extern int (*real_pthread_mutex_timedlock)(pthread_mutex_t* mutex,
+RR_HIDDEN extern int (*real_pthread_mutex_lock)(void* mutex);
+RR_HIDDEN extern int (*real_pthread_mutex_trylock)(void* mutex);
+RR_HIDDEN extern int (*real_pthread_mutex_timedlock)(void* mutex,
                                                      const struct timespec* abstime);
 
 #endif /* RR_SYSCALLBUF_H_ */

--- a/src/record_signal.cc
+++ b/src/record_signal.cc
@@ -156,9 +156,9 @@ static bool try_grow_map(RecordTask* t, siginfo_t* si) {
     LOG(debug) << "try_grow_map " << addr << ": address would be in guard page";
     return false;
   }
-  struct rlimit stack_limit;
+  struct rlimit64 stack_limit;
   remote_ptr<void> limit_bottom;
-  int ret = prlimit(t->tid, RLIMIT_STACK, NULL, &stack_limit);
+  int ret = syscall(__NR_prlimit64, t->tid, RLIMIT_STACK, NULL, &stack_limit);
   if (ret >= 0 && stack_limit.rlim_cur != RLIM_INFINITY) {
     limit_bottom = ceil_page_size(it->map.end() - stack_limit.rlim_cur);
     if (limit_bottom > addr) {

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -4272,7 +4272,7 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
 
     case Arch::name_to_handle_at: {
       syscall_state.reg_parameter(3,
-                                  sizeof(struct file_handle) + MAX_HANDLE_SZ);
+                                  sizeof(typename Arch::file_handle) + MAX_HANDLE_SZ);
       syscall_state.reg_parameter(4, sizeof(int));
       return ALLOW_SWITCH;
     }


### PR DESCRIPTION
Our system for building universal binaries (https://binarybuilder.org/),
has a bit of a quirky setup where it has very old glibc headers (to
maximize compatibility on old systems, but very new kernel headers).
This commit fixes the build in this environment. There's a few parts
to this:

1) Extra definitions for kernel_supplement.h that the headers don't have
2) Switch prlimit64 to use a raw syscall()
3) Switch the syscallbuf.c file to use linux headers rather than libc headers

The last of these is not strictly required, we could just provide the
missing definitions. However, since the syscallbuf is implementing the
linux ABI rather than the libc ABI, it seems proper that it should be
using the linux headers. That results in a few struct renamings (and
unfortunately, I had to copy in the cmsghdr macros, since linux doesn't
have them in their uapi), but I still think it's overall better.
Additionally, it should make it much easier to port the syscallbuf code
to different libcs (e.g. musl), which sometimes organize their sys/
headers differently. For everybody else, nothing should change, since
the linux/ headers are still distributed with the libc, so they should
be at least as complete as the libc headers.