### PR TITLE
disable FORTIFY_SOURCE in preload for better binary compatibility with other libc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ set(RR_FLAGS_RELEASE "-Wall -Wextra -UDEBUG -DNDEBUG")
 
 # The folowing settings are the defaults for the OTHER build type.
 # Flags used to build the preload library. MUST have debuginfo enabled. SHOULD be optimized.
-set(PRELOAD_COMPILE_FLAGS "${RR_FLAGS_RELEASE} -fno-stack-protector -g3")
+set(PRELOAD_COMPILE_FLAGS "${RR_FLAGS_RELEASE} -fno-stack-protector -g3 -U_FORTIFY_SOURCE")
 # Flags used to build Brotli. SHOULD be optimized. MUST NOT error on warnings.
 set(BROTLI_COMPILE_FLAGS ${RR_FLAGS_RELEASE})
 # Flags used to build tests. MUST have -DDEBUG and debuginfo enabled, MUST NOT be optimized.


### PR DESCRIPTION
It would be great if rr could support applications compiled against other libc's, such as musl. Unfortunately, one immediate problem is that rr's preload library relies on certain glibc symbols that may not be otherwise available: `__pthread_mutex_lock`, `__pthread_mutex_trylock`, `__sysconf`, and `__sprintf_chk`. For now, fix the latter by disabling the `FORTIFY_SOURCE` macro which introduces it.

```
rr: Saving execution to trace directory `<snip>'.
Error relocating /usr/local/bin/../lib/rr/librrpreload.so: __sysconf: symbol not found
Error relocating /usr/local/bin/../lib/rr/librrpreload.so: __pthread_mutex_lock: symbol not found
Error relocating /usr/local/bin/../lib/rr/librrpreload.so: __pthread_mutex_trylock: symbol not found
```