### PR TITLE
Hack around unkillable container-inits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -882,6 +882,7 @@ set(BASIC_TESTS
   pause
   perf_event
   personality
+  pid_ns_segv
   pthread_rwlocks
   poll_sig_race
   ppoll

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -212,7 +212,7 @@ private:
   void runnable_state_changed(RecordTask* t, StepState* step_state,
                               RecordResult* step_result,
                               bool can_consume_wait_status);
-  void signal_state_changed(RecordTask* t, StepState* step_state);
+  bool signal_state_changed(RecordTask* t, StepState* step_state);
   void syscall_state_changed(RecordTask* t, StepState* step_state);
   void desched_state_changed(RecordTask* t);
   bool prepare_to_inject_signal(RecordTask* t, StepState* step_state);

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -540,6 +540,9 @@ public:
    */
   void did_reach_zombie();
 
+  // Is this task a container init? (which has special signal behavior)
+  bool is_container_init() { return own_namespace_rec_tid == 1; }
+
 private:
   /* Retrieve the tid of this task from the tracee and store it */
   void update_own_namespace_tid();

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -100,6 +100,10 @@ void Task::detach() {
   LOG(debug) << "task " << tid << " (rec:" << rec_tid << ") is dying ...";
 
   fallible_ptrace(PTRACE_DETACH, nullptr, nullptr);
+
+  // Not really, but there's also no reason to actually try to reap it,
+  // since we detached.
+  was_reaped = true;
 }
 
 bool Task::may_reap() {


### PR DESCRIPTION
The kernel changes the behavior of deterministic fatal signals
for container inits when a ptracer is attached. In regular course
container inits are protected from non-deterministic fatal signals,
but not from deterministic fatal signals. Three years ago, the kernel
was changed [1] such that if a ptracer is attached, container init
is also protected from deterministic fatal signals (since ptrace generated
SIGTRAPs go through the same code path). Unfortunately, this means
that a SEGV inside the container init, will not kill the container
init while we're attached. I don't see anyway to work around this.
The only thing I can come up with is to quickly detach and hope for
the best. I think that's mostly ok, since deterministic signals are
also coredumping, so they won't cause a cleartid race, but it's certainly
not ideal. There is a very pathological corner case, where another task
we run changes the executable memory of the task we just returned to,
causing it to no longer generate the faulting signal, but, this is
already enough of a corner case that I'm not super worried about it.
I also hope to get this fixed in the kernel, which will make this
problem even more rare.

[1] https://github.com/torvalds/linux/commit/eb61b5911