### PR TITLE
Fix confusion between paths outside/inside mount ns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -846,11 +846,11 @@ set(BASIC_TESTS
   mmap_shared_write
   mmap_shared_write_fork
   mmap_short_file
-  mmap_tmpfs
   mmap_write_complex
   mmap_zero_size_fd
   modify_ldt
   mount_ns_exec
+  mount_ns_exec2
   mprotect
   mprotect_heterogenous
   mprotect_none
@@ -1153,6 +1153,7 @@ set(TESTS_WITH_PROGRAM
   mmap_replace_most_mappings
   mmap_shared_prot
   mmap_shared_write_exec_race
+  mmap_tmpfs
   mmap_write
   mmap_write_private
   mprotect_growsdown

--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -225,6 +225,7 @@ static remote_ptr<uint8_t> allocate_extended_jump(
                    &recorded);
       t->vm()->mapping_flags_of(addr) |= AddressSpace::Mapping::IS_PATCH_STUBS;
       t->trace_writer().write_mapped_region(t, recorded, recorded.fake_stat(),
+                                            recorded.fsname(),
                                             vector<TraceRemoteFd>(),
                                             TraceWriter::PATCH_MAPPING);
     }

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -446,7 +446,7 @@ template <typename Arch> void RecordTask::init_buffers_arch() {
     desched_fd = remote.retrieve_fd(desched_fd_child);
 
     auto record_in_trace = trace_writer().write_mapped_region(
-        this, syscallbuf_km, syscallbuf_km.fake_stat(),
+        this, syscallbuf_km, syscallbuf_km.fake_stat(), syscallbuf_km.fsname(),
         vector<TraceRemoteFd>(),
         TraceWriter::RR_BUFFER_MAPPING);
     ASSERT(this, record_in_trace == TraceWriter::DONT_RECORD_IN_TRACE);
@@ -1920,6 +1920,7 @@ bool RecordTask::post_vm_clone(CloneReason reason, int flags, Task* origin) {
     auto mode = trace_writer().write_mapped_region(
       this, preload_thread_locals_mapping,
       preload_thread_locals_mapping.fake_stat(),
+      preload_thread_locals_mapping.fsname(),
       vector<TraceRemoteFd>(),
       TraceWriter::RR_BUFFER_MAPPING);
     ASSERT(this, mode == TraceWriter::DONT_RECORD_IN_TRACE);

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -272,6 +272,12 @@ void Task::dump(FILE* out) const {
   }
 }
 
+std::string Task::proc_fd_path(int fd) {
+  char path[PATH_MAX];
+  snprintf(path, sizeof(path) - 1, "/proc/%d/fd/%d", tid, fd);
+  return path;
+}
+
 struct stat Task::stat_fd(int fd) {
   char path[PATH_MAX];
   snprintf(path, sizeof(path) - 1, "/proc/%d/fd/%d", tid, fd);

--- a/src/Task.h
+++ b/src/Task.h
@@ -201,6 +201,11 @@ public:
   Ticks tick_count() { return ticks; }
 
   /**
+   * Return the path of this fd as /proc/<pid>/<fd>
+   */
+  std::string proc_fd_path(int fd);
+
+  /**
    * Stat |fd| in the context of this task's fd table.
    */
   struct stat stat_fd(int fd);

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -198,6 +198,7 @@ public:
    */
   RecordInTrace write_mapped_region(RecordTask* t, const KernelMapping& map,
                                     const struct stat& stat,
+                                    const std::string &file_name,
                                     const std::vector<TraceRemoteFd>& extra_fds,
                                     MappingOrigin origin = SYSCALL_MAPPING,
                                     bool skip_monitoring_mapped_fd = false);

--- a/src/record_signal.cc
+++ b/src/record_signal.cc
@@ -197,7 +197,7 @@ static bool try_grow_map(RecordTask* t, siginfo_t* si) {
       t->vm()->map(t, new_start, it->map.start() - new_start, it->map.prot(),
                    it->map.flags() | MAP_ANONYMOUS, 0, string(),
                    KernelMapping::NO_DEVICE, KernelMapping::NO_INODE);
-  t->trace_writer().write_mapped_region(t, km, km.fake_stat(), vector<TraceRemoteFd>());
+  t->trace_writer().write_mapped_region(t, km, km.fake_stat(), km.fsname(), vector<TraceRemoteFd>());
   // No need to flush syscallbuf here. It's safe to map these pages "early"
   // before they're really needed.
   t->record_event(Event::grow_map(), RecordTask::DONT_FLUSH_SYSCALLBUF);

--- a/src/test/mmap_tmpfs.run
+++ b/src/test/mmap_tmpfs.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+unset RR_TRUST_TEMP_FILES
+compare_test EXIT-SUCCESS

--- a/src/test/mount_ns_exec.c
+++ b/src/test/mount_ns_exec.c
@@ -14,7 +14,8 @@ int main(int argc, char* argv[]) {
   test_assert(0 == mount("none", "mountpoint", "tmpfs", 0, NULL));
 
   struct stat buf;
-  stat("/proc/self/exe", &buf);
+  int ret = stat("/proc/self/exe", &buf);
+  test_assert(ret != -1);
   int src_fd = open("/proc/self/exe", O_RDONLY);
   test_assert(src_fd != -1);
   int dst_fd = open("mountpoint/the_copy", O_WRONLY | O_CREAT, 0700);

--- a/src/test/mount_ns_exec2.c
+++ b/src/test/mount_ns_exec2.c
@@ -1,0 +1,65 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "nsutils.h"
+#include "util.h"
+
+int main(int argc, char* argv[]) {
+  if (argc > 1 && strcmp(argv[1], "in_copy") == 0) {
+    // Try to do an mmap call, just to stress that code path
+    int selffd = open("/proc/self/exe", O_RDONLY);
+    test_assert(selffd != -1);
+    void *addr = mmap(NULL, 4096, PROT_READ, MAP_PRIVATE, selffd, 4096);
+    test_assert(addr != MAP_FAILED);
+    check_data(addr, 4096);
+    atomic_puts("EXIT-SUCCESS");
+    return 0;
+  }
+
+  if (-1 == try_setup_ns(CLONE_NEWNS)) {
+    atomic_puts("EXIT-SUCCESS");
+    return 0;
+  }
+
+  char exe_buf[PATH_MAX+1];
+  memset(exe_buf, 0, sizeof(exe_buf));
+  ssize_t nread = readlink("/proc/self/exe", exe_buf, sizeof(exe_buf)-1);
+  test_assert(nread != -1);
+
+  char *exe_name = strrchr(exe_buf, '/');
+  *exe_name = '\0';
+  exe_name += 1;
+
+  test_assert(0 == mkdir("mountpoint", 0700));
+
+  int mountpoint_fd = open("mountpoint", O_PATH);
+  test_assert(mountpoint_fd != -1);
+
+  // Copy the exe to the mountpoint as well to make sure rr doesn't
+  // accidentally pick up the wrong one to put in the trace
+  struct stat buf;
+  int ret = stat("/proc/self/exe", &buf);
+  test_assert(ret != -1);
+  int src_fd = open("/proc/self/exe", O_RDONLY);
+  test_assert(src_fd != -1);
+  int dst_fd = openat(mountpoint_fd, exe_name, O_WRONLY | O_CREAT, 0700);
+  test_assert(dst_fd != -1);
+  off_t offset = 0;
+  // Only send the first 4096 bytes, so we really crash if somebody tries to
+  // Use that file instead
+  test_assert(sendfile(dst_fd, src_fd, &offset, 4096) == 4096);
+  close(src_fd);
+  fsync(dst_fd);
+  close(dst_fd);
+  close(mountpoint_fd);
+
+  test_assert(0 == mount(exe_buf, "mountpoint", "none", MS_BIND, NULL));
+
+  char exe_path[PATH_MAX];
+  ssize_t n = snprintf(exe_path, sizeof(exe_path), "mountpoint/%s", exe_name);
+  test_assert(n > 0 && n < (ssize_t)sizeof(exe_path));
+
+  char* const new_argv[] = { exe_path, "in_copy", NULL };
+  execve(exe_path, new_argv, environ);
+  test_assert(0);
+  return 1;
+}

--- a/src/test/util.h
+++ b/src/test/util.h
@@ -179,8 +179,13 @@ inline static pid_t sys_gettid(void) { return syscall(SYS_gettid); }
  * replay.
  */
 inline static void check_data(void* buf, size_t len) {
-  syscall(SYS_write, RR_MAGIC_SAVE_DATA_FD, buf, len);
-  atomic_printf("Wrote %zu bytes to magic fd\n", len);
+  ssize_t ret = syscall(SYS_write, RR_MAGIC_SAVE_DATA_FD, buf, len);
+  if (ret == -1 && errno == EBADF) {
+    atomic_printf("Failed to write to RR_MAGIC_SAVE_DATA_FD. Not running under rr?\n");
+  } else {
+    test_assert(ret == (ssize_t)len);
+    atomic_printf("Wrote %zu bytes to magic fd\n", len);
+  }
 }
 
 /**

--- a/src/util.h
+++ b/src/util.h
@@ -143,6 +143,7 @@ SignalDeterministic is_deterministic_signal(Task* t);
  * necessarily safe to skip copying!
  */
 bool should_copy_mmap_region(const KernelMapping& mapping,
+                             const std::string &file_name,
                              const struct stat& stat);
 
 /**
@@ -467,7 +468,6 @@ void sleep_time(double t);
  * Normalize a file name by lexically resolving `.`,`..`,`//`
  */
 void normalize_file_name(std::string& s);
-
 
 } // namespace rr
 


### PR DESCRIPTION
In a few places we were accessing paths we obtained from inside
a mount namespace and tried to use them as if they were valid
outside the mount namespace. This usually worked by accident,
since the files inside the mount namespace were either the
same (if not much mounting had happened yet), or didn't
exist in the host file system. However, it's not hard to
get into a situation where this isn't the case (see the included
test), which would cause an un-replayable recording. With
this patch we try harder to only ever access such tracee
files through the various /proc magic files that paper over
mount namespace differences.