### PR TITLE
Fix argument to record_exit_event

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -201,7 +201,7 @@ static bool handle_ptrace_exit_event(RecordTask* t) {
     t->proceed_to_exit(may_wait_exit);
   }
   record_exit_trace_event(t, exit_status);
-  t->record_exit_event();
+  t->record_exit_event(exit_status.fatal_sig());
   if (t->do_ptrace_exit_stop(exit_status)) {
     // Keep the RecordTask alive until the ptracer reaps it
     t->waiting_for_reap = true;


### PR DESCRIPTION
The child tid does not get cleared for coredumping fatal sigs.
I had thought about this case, but neglected to add it to the
test, so I missed that I had failed to actually pass it through.

Fixes #2472