### PR TITLE
Don't program a ticks target if it's after the syscall

### DIFF
--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -440,9 +440,11 @@ bool ReplaySession::handle_unrecorded_cpuid_fault(
  */
 Completion ReplaySession::cont_syscall_boundary(
     ReplayTask* t, const StepConstraints& constraints) {
-  TicksRequest ticks_request;
-  if (!compute_ticks_request(t, constraints, &ticks_request)) {
-    return INCOMPLETE;
+  TicksRequest ticks_request = RESUME_UNLIMITED_TICKS;
+  if (constraints.ticks_target <= trace_frame.ticks()) {
+    if (!compute_ticks_request(t, constraints, &ticks_request)) {
+      return INCOMPLETE;
+    }
   }
 
   if (constraints.command == RUN_SINGLESTEP_FAST_FORWARD) {


### PR DESCRIPTION
In issue #2509, we saw a case where the ticks target was 98
ticks after the syscall. With 100 being the skid size, this
would cause us to program a ticks target two ticks before the
syscall and then skid into it. Since the syscall is synchronous,
there's no reason to program a ticks interrupt at all if it'll
be hit before the ticks target. Check for that case and avoid
setting the ticks interrupt.

Fixes #2509