### PR TITLE
Add a mechanism for rr processes to coordinate CPU usage

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2058,7 +2058,7 @@ RecordSession::RecordSession(const std::string& exe_path,
                              const string& output_trace_dir,
                              const TraceUuid* trace_id,
                              bool use_audit)
-    : trace_out(argv[0], choose_cpu(bind_cpu), output_trace_dir, ticks_semantics_),
+    : trace_out(argv[0], output_trace_dir, ticks_semantics_),
       scheduler_(*this),
       trace_id(trace_id),
       disable_cpuid_features_(disable_cpuid_features),
@@ -2083,6 +2083,7 @@ RecordSession::RecordSession(const std::string& exe_path,
     FATAL() << "RR_CALL_BASE is incorrect";
   }
 
+  trace_out.set_bound_cpu(choose_cpu(bind_cpu, cpu_lock));
   do_bind_cpu(trace_out);
   ScopedFd error_fd = create_spawn_task_error_pipe();
   RecordTask* t = static_cast<RecordTask*>(

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -712,7 +712,7 @@ void Session::do_bind_cpu(TraceStream &trace) {
     // tracees, since this seems to help performance.
     if (!set_cpu_affinity(cpu_index)) {
       if (has_cpuid_faulting() && !is_recording()) {
-        cpu_index = choose_cpu(BIND_CPU);
+        cpu_index = choose_cpu(BIND_CPU, cpu_lock);
         if (!set_cpu_affinity(cpu_index)) {
           FATAL() << "Can't bind to requested CPU " << cpu_index
                   << " even after we re-selected it";

--- a/src/Session.h
+++ b/src/Session.h
@@ -388,6 +388,8 @@ protected:
   TaskMap task_map;
   ThreadGroupMap thread_group_map;
 
+  ScopedFd cpu_lock;
+
   // If non-null, data required to finish initializing the tasks of this
   // session.
   std::unique_ptr<CloneCompletion> clone_completion;

--- a/src/Task.h
+++ b/src/Task.h
@@ -891,7 +891,8 @@ public:
    * readable from the other end of the pipe whose write end is error_fd.
    */
   static Task* spawn(Session& session, ScopedFd& error_fd,
-                     ScopedFd* sock_fd_out, int* tracee_socket_fd_number_out,
+                     ScopedFd* sock_fd_out,
+                     int* tracee_socket_fd_number_out,
                      const std::string& exe_path,
                      const std::vector<std::string>& argv,
                      const std::vector<std::string>& envp, pid_t rec_tid = -1);

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -190,8 +190,9 @@ private:
 };
 
 TraceStream::TraceStream(const string& trace_dir, FrameTime initial_time)
-    : trace_dir(real_path(trace_dir))
-    , global_time(initial_time)
+    : trace_dir(real_path(trace_dir)),
+      bind_to_cpu(-1),
+      global_time(initial_time)
    {}
 
 string TraceStream::file_data_clone_file_name(const TaskUid& tuid) {
@@ -1202,7 +1203,6 @@ static string make_trace_dir(const string& exe_path, const string& output_trace_
 #define STR(x) STR_HELPER(x)
 
 TraceWriter::TraceWriter(const std::string& file_name,
-                         int bind_to_cpu,
                          const string& output_trace_dir,
                          TicksSemantics ticks_semantics_)
     : TraceStream(make_trace_dir(file_name, output_trace_dir),
@@ -1213,7 +1213,6 @@ TraceWriter::TraceWriter(const std::string& file_name,
       mmap_count(0),
       has_cpuid_faulting_(false) {
   this->ticks_semantics_ = ticks_semantics_;
-  this->bind_to_cpu = bind_to_cpu;
 
   for (Substream s = SUBSTREAM_FIRST; s < SUBSTREAM_COUNT; ++s) {
     writers[s] = unique_ptr<CompressedWriter>(new CompressedWriter(

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -232,7 +232,7 @@ public:
    * The trace name is determined by |file_name| and _RR_TRACE_DIR (if set)
    * or by setting -o=<OUTPUT_TRACE_DIR>.
    */
-  TraceWriter(const std::string& file_name, int bind_to_cpu,
+  TraceWriter(const std::string& file_name,
               const string& output_trace_dir, TicksSemantics ticks_semantics_);
 
   /**

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -142,6 +142,9 @@ TESTDIR="${SRCDIR}/src/test"
 # binaries into the trace.
 export RR_TRUST_TEMP_FILES=1
 
+# Have rr processes coordinate to not oversubscribe CPUs
+export _RR_CPU_LOCK_FILE="/tmp/rr-test-cpu-lock"
+
 # Set options to find rr and resource files in the expected places.
 export PATH="${OBJDIR}/bin:${PATH}"
 GLOBAL_OPTIONS="${GLOBAL_OPTIONS} --resource-path=${OBJDIR}"

--- a/src/util.h
+++ b/src/util.h
@@ -418,8 +418,10 @@ size_t trapped_instruction_len(TrappedInstruction insn);
  */
 enum BindCPU { BIND_CPU = -2, UNBOUND_CPU = -1 };
 
-/* Convert a BindCPU to a specific CPU number */
-int choose_cpu(BindCPU bind_cpu);
+/* Convert a BindCPU to a specific CPU number. If possible, the cpu_lock_fd_out
+   will be set to an fd that holds an advisory fcntl lock for the chosen CPU
+   for coordination with other rr processes */
+int choose_cpu(BindCPU bind_cpu, ScopedFd& cpu_lock_fd_out);
 
 /* Updates an IEEE 802.3 CRC-32 least significant bit first from each byte in
  * |buf|.  Pre- and post-conditioning is not performed in this function and so


### PR DESCRIPTION
When running lots of parallel rr instances, it's quite easy for
these to stomp on each other and try to bind to the same CPU.
If that happens, performance tanks for the two rr processes
running on the same CPU. This can be easily observed in the test
suite. On my machine, with an otherwise idle machine, the test suite
currently takes between 165 and 220s depending on how the schedule
happens to work out. With this patch, it takes consistently between
155 and 160s.

The way this works is by creating a lock file (by default in the
_RR_TRACE_DIR, but overwritable by environment variable), where each
process will lock the n-th byte if it has bound itself to the n-th
CPU. When choosing a random CPU, rr will try to acquire this lock
and if it fails try another CPU (until it has tried every CPU twice,
at which point it gives up and uses a random one). I considered a
few mechanisms for this by fcntl advisory locks seemed best, since
they only need one file and the kernel is guaranteed to release them
when the process dies, independent of how that happened (unlike say
the cleartid mechanism which doesn't get released if the process
died by a coredumping signal).