### PR TITLE
Bump default scheduler intervals 5x

### DIFF
--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -75,9 +75,9 @@ public:
    * around 10. Somewhat arbitrarily guessing ~4cycles/insn on average
    * (fair amount of pointer chasing), that implies for a nominal 2GHz CPU
    * 50,000 ticks per millisecond. We choose the default max ticks to give us
-   * 10ms timeslices, i.e. 500,000 ticks.
+   * 50ms timeslices, i.e. 2,500,000 ticks.
    */
-  enum { DEFAULT_MAX_TICKS = 500000 };
+  enum { DEFAULT_MAX_TICKS = 2500000 };
   /**
    * Don't allow max_ticks to get above this value.
    */


### PR DESCRIPTION
For workloads that are single-active-thread'ed well-syscallbuffered,
I'm consistently seeing the overhead from timeslicing to be quite noticable.
That was the case in #2473, and I'm seeing the same behavior with another,
longer benchmark I'm currently looking at. Here's some results for that benchmark
together with another optimization ("`pwrite`") I'm looking at that increases the amount of
syscallbuffering in this trace (if there's frequent non-buffered syscalls, the timeslice
doesn't really matter). This 5x increase does quite well, cutting about 130s
(30% of baseline) off the record time, but even higher time slices perform even better.
That said, I don't think bumping this even further here is a good idea. I'm gonna look into
some changes to the Scheduler to see if we can avoid setting a timeslice at all, if there's
only one runnable thread.

```
Record times for LinearAlgebra/triangular
baseline: 427s

master: 700s
pwrite: 630s
pwrite+timeslice5x: 493s
timeslice20x: 478s
pwrite+timeslice20x: 451s
pwrite+timeslice100x: 446s
```