### PR TITLE
Add a fast path when only one thread is unblocked

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -628,6 +628,8 @@ void RecordSession::task_continue(const StepState& step_state) {
       // timeslice signal already stashed, no point in generating another one
       // (and potentially slow)
       ticks_request = RESUME_UNLIMITED_TICKS;
+    } else if (scheduler().may_use_unlimited_ticks()) {
+      ticks_request = RESUME_UNLIMITED_TICKS;
     } else {
       ticks_request = (TicksRequest)max<Ticks>(
           0, scheduler().current_timeslice_end() - t->tick_count());
@@ -692,6 +694,9 @@ void RecordSession::task_continue(const StepState& step_state) {
     }
   }
   t->resume_execution(resume, RESUME_NONBLOCKING, ticks_request);
+  if (t->is_running()) {
+    scheduler().started(t);
+  }
 }
 
 /**

--- a/src/Scheduler.h
+++ b/src/Scheduler.h
@@ -153,6 +153,22 @@ public:
 
   void in_stable_exit(RecordTask* t);
 
+  /**
+   * In unlimited ticks mode, only one task is runnable while every other task
+   * is blocked in the kernel. Check whether we're in that situation.
+   */
+  bool may_use_unlimited_ticks();
+
+  /**
+   * Let the scheduler know that the passed task has started running
+   */
+  void started(RecordTask*) {
+    if (may_use_unlimited_ticks()) {
+      unlimited_ticks_mode = true;
+    }
+    ntasks_running++;
+  }
+
 private:
   // Tasks sorted by priority.
   typedef std::set<std::pair<int, RecordTask*>> TaskPrioritySet;
@@ -242,6 +258,9 @@ private:
 
   bool enable_poll;
   bool last_reschedule_in_high_priority_only_interval;
+
+  bool unlimited_ticks_mode;
+  size_t ntasks_running;
 };
 
 } // namespace rr

--- a/src/Task.h
+++ b/src/Task.h
@@ -622,10 +622,11 @@ public:
 
   /**
    * Block until the status of this changes. wait() expects the wait to end
-   * with the process in a stopped() state. If interrupt_after_elapsed > 0,
-   * interrupt the task after that many seconds have elapsed.
+   * with the process in a stopped() state. If interrupt_after_elapsed >= 0,
+   * interrupt the task after that many seconds have elapsed. If
+   * interrupt_after_elapsed == 0.0, the interrupt will happen immediately.
    */
-  void wait(double interrupt_after_elapsed = 0);
+  void wait(double interrupt_after_elapsed = -1);
   /**
    * Return true if the status of this has changed, but don't
    * block.

--- a/src/util.h
+++ b/src/util.h
@@ -5,6 +5,7 @@
 
 #include <signal.h>
 #include <stdio.h>
+#include <math.h>
 
 #include <array>
 #include <map>
@@ -485,6 +486,13 @@ enum NestedBehavior {
 };
 
 std::string find_exec_stub(SupportedArch arch);
+
+static inline struct timeval to_timeval(double t) {
+  struct timeval v;
+  v.tv_sec = (time_t)floor(t);
+  v.tv_usec = (int)floor((t - v.tv_sec) * 1000000);
+  return v;
+}
 
 } // namespace rr
 


### PR DESCRIPTION
If there's only one thread that can currently make forward progress,
there's really no reason to try to schedule a time slice interrupt,
since the only thing we could possibly do is re-schedule it. Since
time slice interrupts can have noticable performance overhead for
well-syscallbuffered traces, it's worth trying to avoid this.
This commit does just that, by adding a "turbo mode" to the scheduler
where it runs just one task with unlimited ticks, but listens for
events from all tracees. As soon as the first event comes in,
it switches the tracee back into regular mode and continues on
as usual. This approach appears to work quite well, and gives
a runtime of 444s on the benchmark from #2512 (assuming one
additional optimization, which will be in a separate commit).