### PR TITLE
Syscall buffer pwrite calls to /proc/<pid>/mem

### DIFF
--- a/src/DumpCommand.cc
+++ b/src/DumpCommand.cc
@@ -116,9 +116,11 @@ static void dump_syscallbuf_data(TraceReader& trace, FILE* out,
   while (record_ptr < end_ptr) {
     auto record = reinterpret_cast<const struct syscallbuf_record*>(record_ptr);
     // Buffered syscalls always use the task arch
-    fprintf(out, "  { syscall:'%s', ret:0x%lx, size:0x%lx }\n",
+    fprintf(out, "  { syscall:'%s', ret:0x%lx, size:0x%lx%s%s }\n",
             syscall_name(record->syscallno, frame.regs().arch()).c_str(),
-            (long)record->ret, (long)record->size);
+            (long)record->ret, (long)record->size,
+            record->desched ? ", desched:1" : "",
+            record->replay_assist ? ", replay_assist:1" : "");
     if (record->size < sizeof(*record)) {
       fprintf(stderr, "Malformed trace file (bad record size)\n");
       notifying_abort();

--- a/src/FileMonitor.h
+++ b/src/FileMonitor.h
@@ -11,6 +11,7 @@ class Task;
 #include <memory>
 #include <vector>
 
+#include "preload/preload_interface.h"
 #include "util.h"
 
 namespace rr {
@@ -119,6 +120,10 @@ public:
    * if desired.
    */
   virtual void filter_getdents(RecordTask*) {}
+
+  virtual enum syscallbuf_fd_classes get_syscallbuf_class() {
+    return FD_CLASS_TRACED;
+  }
 };
 
 } // namespace rr

--- a/src/ProcMemMonitor.cc
+++ b/src/ProcMemMonitor.cc
@@ -6,7 +6,8 @@
 
 #include "AutoRemoteSyscalls.h"
 #include "RecordSession.h"
-#include "RecordTask.h"
+#include "ReplaySession.h"
+#include "ReplayTask.h"
 #include "log.h"
 
 using namespace std;
@@ -32,16 +33,33 @@ ProcMemMonitor::ProcMemMonitor(Task* t, const string& pathname) {
 
 void ProcMemMonitor::did_write(Task* t, const std::vector<Range>& ranges,
                                LazyOffset& lazy_offset) {
-  if (t->session().is_replaying() || ranges.empty()) {
+  if (ranges.empty()) {
     return;
   }
-  auto* target = static_cast<RecordTask*>(t->session().find_task(tuid));
+  int64_t offset = lazy_offset.retrieve(true);
+
+  // In prior versions of rr, we recorded this directly into the trace.
+  // If so, there's nothing to do here.
+  if (t->session().is_replaying() && t->session().as_replay()->explicit_proc_mem()) {
+    return;
+  }
+
+  if (t->session().is_recording()) {
+    // Nothing to do now (though we may have just recorded the offset)
+    return;
+  }
+
+  auto* target = static_cast<ReplayTask*>(t->session().find_task(tuid));
   if (!target) {
     return;
   }
-  int64_t offset = lazy_offset.retrieve(false);
+
   for (auto& r : ranges) {
-    target->record_remote(remote_ptr<void>(offset), r.length);
+    auto bytes = t->read_mem(r.data.cast<uint8_t>(), r.length);
+    remote_ptr<uint8_t> target_addr = offset;
+    target->write_mem(target_addr, bytes.data(), r.length);
+    target->vm()->maybe_update_breakpoints(target, target_addr,
+                                           r.length);
     offset += r.length;
   }
 }

--- a/src/ProcMemMonitor.h
+++ b/src/ProcMemMonitor.h
@@ -25,6 +25,10 @@ public:
   virtual void did_write(Task* t, const std::vector<Range>& ranges,
                          LazyOffset& lazy_offset) override;
 
+  virtual enum syscallbuf_fd_classes get_syscallbuf_class() override {
+    return FD_CLASS_PROC_MEM;
+  }
+
 private:
   // 0 if this doesn't object doesn't refer to a tracee's proc-mem.
   TaskUid tuid;

--- a/src/ReplaySession.h
+++ b/src/ReplaySession.h
@@ -314,6 +314,8 @@ public:
 
   virtual int cpu_binding(TraceStream& trace) const override;
 
+  bool explicit_proc_mem() { return trace_in.explicit_proc_mem(); }
+
 private:
   ReplaySession(const std::string& dir, const Flags& flags);
   ReplaySession(const ReplaySession& other);

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -635,6 +635,7 @@ void Task::on_syscall_exit_arch(int syscallno, const Registers& regs) {
         fds->erase_task(this);
         fds = fds->clone();
         fds->insert_task(this);
+        vm()->fd_tables_changed();
       }
       return;
 
@@ -2360,6 +2361,7 @@ bool Task::post_vm_clone(CloneReason reason, int flags, Task* origin) {
   if (!(CLONE_SHARE_VM & flags)) {
     created_preload_thread_locals_mapping = this->as->post_vm_clone(this);
   }
+  this->as->fd_tables_changed();
 
   if (reason == TRACEE_CLONE) {
     setup_preload_thread_locals_from_clone(origin);

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -1325,6 +1325,7 @@ void TraceWriter::close(CloseStatus status, const TraceUuid* uuid) {
     x86data.setXcr0(xcr0());
   }
 
+  header.setExplicitProcMem(false);
   // Add a random UUID to the trace metadata. This lets tools identify a trace
   // easily.
   if (!uuid) {
@@ -1466,6 +1467,7 @@ TraceReader::TraceReader(const string& dir)
   preload_thread_locals_recorded_ = header.getPreloadThreadLocalsRecorded();
   ticks_semantics_ = from_trace_ticks_semantics(header.getTicksSemantics());
   rrcall_base_ = header.getRrcallBase();
+  explicit_proc_mem_ = header.getExplicitProcMem();
   Data::Reader uuid = header.getUuid();
   uuid_ = unique_ptr<TraceUuid>(new TraceUuid());
   if (uuid.size() != sizeof(uuid_->bytes)) {
@@ -1513,6 +1515,7 @@ TraceReader::TraceReader(const TraceReader& other)
   preload_thread_locals_recorded_ = other.preload_thread_locals_recorded_;
   rrcall_base_ = other.rrcall_base_;
   arch_ = other.arch_;
+  explicit_proc_mem_ = other.explicit_proc_mem_;
 }
 
 TraceReader::~TraceReader() {}

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -420,6 +420,9 @@ public:
 
   SupportedArch arch() const { return arch_; }
 
+  // Whether the /proc/<pid>/mem calls were explicitly recorded in this trace
+  bool explicit_proc_mem() const { return explicit_proc_mem_; }
+
 private:
   CompressedReader& reader(Substream s) { return *readers[s]; }
   const CompressedReader& reader(Substream s) const { return *readers[s]; }
@@ -435,6 +438,7 @@ private:
   bool preload_thread_locals_recorded_;
   int rrcall_base_;
   SupportedArch arch_;
+  bool explicit_proc_mem_;
 };
 
 extern std::string trace_save_dir();

--- a/src/generate_rr_page.py
+++ b/src/generate_rr_page.py
@@ -22,6 +22,10 @@ def write_rr_page(f, is_64, is_arm, is_replay):
             0x0, 0x0, 0x80, 0xd2, # movz x0, #0
             0xc0, 0x03, 0x5f, 0xd6, # ret
         ])
+        trap_bytes = bytearray([
+            0x0, 0x0, 0x20, 0xd4, # brk #0
+            0xc0, 0x03, 0x5f, 0xd6, # ret
+        ])
     else:
         if is_64:
             bytes = bytearray([
@@ -35,6 +39,11 @@ def write_rr_page(f, is_64, is_arm, is_replay):
             ])
         nocall_bytes = bytearray([
             0x31, 0xc0, # xor %eax,%eax
+            0xc3, # ret
+        ])
+        trap_bytes = bytearray([
+            0x90, # nop
+            0xcc, # int3
             0xc3, # ret
         ])
 
@@ -66,6 +75,12 @@ def write_rr_page(f, is_64, is_arm, is_replay):
     # privileged untraced record-only
     if is_replay:
         f.write(nocall_bytes)
+    else:
+        f.write(bytes)
+
+    # untraced replay assist
+    if is_replay:
+        f.write(trap_bytes)
     else:
         f.write(bytes)
 

--- a/src/preload/syscallbuf.c
+++ b/src/preload/syscallbuf.c
@@ -306,8 +306,9 @@ static int privileged_traced_perf_event_open(struct perf_event_attr* attr,
                                     group_fd, flags);
 }
 
-static int privileged_traced_raise(int sig) {
-  return privileged_traced_syscall2(SYS_kill, privileged_traced_getpid(), sig);
+static __attribute__((noreturn)) void privileged_traced_raise(int sig) {
+  privileged_traced_syscall2(SYS_kill, privileged_traced_getpid(), sig);
+  __builtin_unreachable();
 }
 
 static ssize_t privileged_traced_write(int fd, const void* buf, size_t count) {
@@ -407,6 +408,33 @@ static long untraced_syscall_base(int syscallno, long a0, long a1, long a2,
   untraced_replayed_syscall3(no, a0, a1, 0)
 #define untraced_replayed_syscall1(no, a0) untraced_replayed_syscall2(no, a0, 0)
 #define untraced_replayed_syscall0(no) untraced_replayed_syscall1(no, 0)
+
+static long __attribute__((unused))
+untraced_replay_assist_syscall_base(int syscallno, long a0, long a1, long a2,
+                                    long a3, long a4, long a5,
+                                    void* syscall_instruction)  {
+  struct syscallbuf_record* rec = (struct syscallbuf_record*)buffer_last();
+  rec->replay_assist = 1;
+  return untraced_syscall_base(syscallno, a0, a1, a2, a3, a4, a5, syscall_instruction);
+}
+
+#define untraced_replay_assist_syscall6(no, a0, a1, a2, a3, a4, a5)            \
+  untraced_replay_assist_syscall_base(                                         \
+                        no, (uintptr_t)a0, (uintptr_t)a1, (uintptr_t)a2,       \
+                        (uintptr_t)a3, (uintptr_t)a4, (uintptr_t)a5,           \
+                        RR_PAGE_SYSCALL_UNTRACED_REPLAY_ASSIST)
+#define untraced_replay_assist_syscall5(no, a0, a1, a2, a3, a4)                \
+  untraced_replay_assist_syscall6(no, a0, a1, a2, a3, a4, 0)
+#define untraced_replay_assist_syscall4(no, a0, a1, a2, a3)                    \
+  untraced_replay_assist_syscall5(no, a0, a1, a2, a3, 0)
+#define untraced_replay_assist_syscall3(no, a0, a1, a2)                        \
+  untraced_replay_assist_syscall4(no, a0, a1, a2, 0)
+#define untraced_replay_assist_syscall2(no, a0, a1)                            \
+  untraced_replay_assist_syscall3(no, a0, a1, 0)
+#define untraced_replay_assist_syscall1(no, a0)                                \
+  untraced_replay_assist_syscall2(no, a0, 0)
+#define untraced_replay_assist_syscall0(no)                                    \
+  untraced_replay_assist_syscall1(no, 0)
 
 #define privileged_untraced_syscall6(no, a0, a1, a2, a3, a4, a5)               \
   _raw_syscall(no, (uintptr_t)a0, (uintptr_t)a1, (uintptr_t)a2, (uintptr_t)a3, \
@@ -734,6 +762,7 @@ static void __attribute__((constructor)) init_process(void) {
   params.globals = &globals;
 
   globals.breakpoint_value = (uint64_t)-1;
+  globals.fdt_uniform = 1;
   params.breakpoint_instr_addr = &do_breakpoint_fault_addr;
   params.breakpoint_mode_sentinel = -1;
 
@@ -815,14 +844,24 @@ static void* prep_syscall(void) {
   return buffer_last() + sizeof(struct syscallbuf_record);
 }
 
-static int is_bufferable_fd(int fd) {
+static enum syscallbuf_fd_classes fd_class(int fd) {
   if (fd < 0) {
-    return 1;
+    return FD_CLASS_INVALID;
   }
-  if (fd >= SYSCALLBUF_FDS_DISABLED_SIZE) {
+  if (fd >= SYSCALLBUF_FDS_DISABLED_SIZE - 1) {
     fd = SYSCALLBUF_FDS_DISABLED_SIZE - 1;
   }
-  return !globals.syscallbuf_fds_disabled[fd];
+  return globals.syscallbuf_fd_class[fd];
+}
+
+static int is_bufferable_fd(int fd) {
+  switch (fd_class(fd)) {
+    case FD_CLASS_INVALID:
+    case FD_CLASS_UNTRACED:
+      return 1;
+    default:
+      return 0;
+  }
 }
 
 /**
@@ -869,6 +908,24 @@ static void disarm_desched_event(void) {
 /* (Negative numbers so as to not be valid syscall numbers, in case
  * the |int| arguments below are passed in the wrong order.) */
 enum { MAY_BLOCK = -1, WONT_BLOCK = -2 };
+
+static int fd_write_blocks(int fd) {
+  if (!globals.fdt_uniform) {
+    // If we're not uniform, it is possible for this fd to be untraced in one
+    // of the other tasks that share this fd table. Always assume it could block.
+    return MAY_BLOCK;
+  }
+  switch (fd_class(fd)) {
+    case FD_CLASS_UNTRACED:
+    case FD_CLASS_TRACED:
+      return MAY_BLOCK;
+    case FD_CLASS_INVALID:
+    case FD_CLASS_PROC_MEM:
+      return WONT_BLOCK;
+  }
+  fatal("Unknown or corrupted fd class");
+}
+
 static int start_commit_buffered_syscall(int syscallno, void* record_end,
                                          int blockness) {
   void* record_start;
@@ -2856,7 +2913,7 @@ static long sys_write(const struct syscall_info* call) {
 
   assert(syscallno == call->no);
 
-  if (!start_commit_buffered_syscall(syscallno, ptr, MAY_BLOCK)) {
+  if (!start_commit_buffered_syscall(syscallno, ptr, fd_write_blocks(fd))) {
     return traced_raw_syscall(call);
   }
 
@@ -2876,16 +2933,23 @@ static long sys_pwrite64(const struct syscall_info* call) {
   size_t count = call->args[2];
   off_t offset = call->args[3];
 
-  void* ptr = prep_syscall_for_fd(fd);
-  long ret;
-
+  enum syscallbuf_fd_classes cls = fd_class(fd);
+  if (cls == FD_CLASS_TRACED) {
+    return traced_raw_syscall(call);
+  }
+  void* ptr = prep_syscall();
   assert(syscallno == call->no);
 
-  if (!start_commit_buffered_syscall(syscallno, ptr, MAY_BLOCK)) {
+  if (!start_commit_buffered_syscall(syscallno, ptr, fd_write_blocks(fd))) {
     return traced_raw_syscall(call);
   }
 
-  ret = untraced_syscall4(syscallno, fd, buf, count, offset);
+  long ret;
+  if (cls == FD_CLASS_PROC_MEM) {
+    ret = untraced_replay_assist_syscall4(syscallno, fd, buf, count, offset);
+  } else {
+    ret = untraced_syscall4(syscallno, fd, buf, count, offset);
+  }
 
   return commit_raw_syscall(syscallno, ptr, ret);
 }
@@ -2907,7 +2971,7 @@ static long sys_writev(const struct syscall_info* call) {
 
   assert(syscallno == call->no);
 
-  if (!start_commit_buffered_syscall(syscallno, ptr, MAY_BLOCK)) {
+  if (!start_commit_buffered_syscall(syscallno, ptr, fd_write_blocks(fd))) {
     return traced_raw_syscall(call);
   }
 

--- a/src/rr_trace.capnp
+++ b/src/rr_trace.capnp
@@ -63,7 +63,6 @@ struct Header {
   # Base rr syscall number (rrcall_init_preload). Before this was variable,
   # it was 442.
   rrcallBase @9 :Int32 = 442;
-
   nativeArch @10 :Arch = x8664;
   # Architecture specific data, determined by nativeArch
   x86 :group {
@@ -77,6 +76,9 @@ struct Header {
     # 0 means "unknown"; default to everything supported by CPUID EAX=0xd ECX=0
     xcr0 @5 :UInt64;
   }
+  # Whether the version of rr that recorded this, explicitly recorded
+  # modifications made through /proc/<pid>/<mem>
+  explicitProcMem @11 :Bool = true;
 }
 
 # A file descriptor belonging to a task

--- a/src/test/util.h
+++ b/src/test/util.h
@@ -178,7 +178,15 @@ inline static int check_cond(int cond) {
   return cond;
 }
 
-#define test_assert(cond) assert("FAILED: !" && check_cond(cond))
+inline static int atomic_assert(int cond, const char *str) {
+  if (!check_cond(cond)) {
+    atomic_printf("FAILED: !%s\n", str);
+    raise(SIGABRT);
+  }
+  return 1;
+}
+
+#define test_assert(cond) atomic_assert(cond, #cond)
 
 /**
  * Return the calling task's id.


### PR DESCRIPTION
A number of our test cases are very jit heavy, which means the only
syscalls they do are brk/mmap (for allocation), rt_sigprocmask and
pwrite64 to /proc/pid/mem (when commiting newly emitted code. Of these,
brk, mmap and pwrite64 aren't buffered yet, but pwrite64 quite a bit
more common than brk/mmap. This PR improves the state of affairs by allowing
pwrites to /proc/<pid>/mem to be buffered. This is the `pwrite`
optimization I mentioned in #2512, but the high level overview is
that together with #2513, this cuts the total overhead for this
benchmark from around 60% to about 1%. Additionally, it cuts the total
trace size (after removing immutable binaries we already have) from a
few dozen megabytes to a few hundred kilobytes (since we no longer store
what was written in the trace).

The implementation itself is relatively straightforward, but complicated
a bit by compatibility concerns with old recorders. In essence, we use
the fds_disabled array to give each FD another flag, that, if set allows
the syscallbuf code to perform pwrite for this fd even though it is
buffered, as long as it does so through a new `replay assist` syscall
entrypoint. This entrypoint is a syscall during record and a breakpoint
during replay. When replay sees this breakpoing, it emulates a syscall exit
(in this case calling back to the ProcMem monitor) and proceeds on.

Secondly, the ProcMem monitor itself is changed to no longer record modifications
in the trace, but rather to read them from tracee memory directly during
replay.