### PR TITLE
Emulate /sys/devices/system/cpu/online

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,6 +475,7 @@ set(RR_SOURCES
   src/Session.cc
   src/SourcesCommand.cc
   src/StdioMonitor.cc
+  src/SysCpuMonitor.cc
   src/Task.cc
   src/ThreadGroup.cc
   src/ThreadDb.cc
@@ -1039,6 +1040,7 @@ set(BASIC_TESTS
   sysemu_singlestep
   sysfs
   sysinfo
+  sys_cpu_online
   tgkill
   thread_yield
   timer

--- a/src/FileMonitor.h
+++ b/src/FileMonitor.h
@@ -33,6 +33,7 @@ public:
     ProcMem,
     Stdio,
     VirtualPerfCounter,
+    SysCpu
   };
 
   virtual Type type() { return Base; }

--- a/src/SysCpuMonitor.cc
+++ b/src/SysCpuMonitor.cc
@@ -1,0 +1,57 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include <sstream>
+
+#include "SysCpuMonitor.h"
+#include "RecordTask.h"
+#include "RecordSession.h"
+#include "Scheduler.h"
+
+#include "log.h"
+
+using namespace std;
+
+namespace rr {
+
+SysCpuMonitor::SysCpuMonitor(Task*, const string&) {
+}
+
+static string make_cpu_online_data(RecordTask* t) {
+  const cpu_set_t cpus = t->session().scheduler().pretend_affinity_mask();
+  int real_ncpus = sysconf(_SC_NPROCESSORS_CONF);
+  bool last_was_set = false;
+  std::stringstream result;
+  bool first = true;
+  for (int i = 0; i < real_ncpus; ++i) {
+    bool this_is_set = CPU_ISSET(i, &cpus);
+    if (this_is_set) {
+      if (!last_was_set) {
+        if (!first) {
+          result << ",";
+        }
+        first = false;
+        result << i;
+      }
+      if (!CPU_ISSET(i+1, &cpus)) {
+        if (last_was_set) {
+          result << "-" << i;
+        }
+      }
+    }
+    last_was_set = this_is_set;
+  }
+  result << "\n";
+  return result.str();
+}
+
+bool SysCpuMonitor::emulate_read(
+  RecordTask* t, const vector<Range>& ranges,
+  LazyOffset &lazy_offset, uint64_t* result) {
+  string data = make_cpu_online_data(t);
+  int64_t offset = lazy_offset.retrieve(false);
+  *result = t->write_ranges(ranges, (uint8_t*)data.data() + offset,
+    offset > (ssize_t)data.size() ? 0 : data.size() - offset);
+  return true;
+}
+
+} // namespace rr

--- a/src/SysCpuMonitor.h
+++ b/src/SysCpuMonitor.h
@@ -1,0 +1,28 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#ifndef RR_SYS_CPU_MONITOR_H_
+#define RR_SYS_CPU_MONITOR_H_
+
+#include "FileMonitor.h"
+#include "TaskishUid.h"
+
+namespace rr {
+
+/**
+ * A FileMonitor to intercept /sys/devices/system/cpu/online (and potentially
+ * other files in that directory in the future) in order to pretend to the
+ * tracee that it only has the CPUs that rr is willing to give it
+ */
+class SysCpuMonitor : public FileMonitor {
+public:
+  SysCpuMonitor(Task* t, const std::string& pathname);
+
+  virtual Type type() override { return SysCpu; }
+
+  bool emulate_read(RecordTask* t, const std::vector<Range>& ranges,
+                    LazyOffset&, uint64_t* result);
+};
+
+} // namespace rr
+
+#endif /* RR_SYS_CPU_MONITOR_H_ */

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -2504,6 +2504,23 @@ void Task::write_bytes_helper(remote_ptr<void> addr, ssize_t buf_size,
   }
 }
 
+size_t Task::write_ranges(const vector<FileMonitor::Range>& ranges,
+                          void* data, size_t size) {
+  uint8_t* p = static_cast<uint8_t*>(data);
+  size_t s = size;
+  size_t result = 0;
+  for (auto& r : ranges) {
+    size_t bytes = min(s, r.length);
+    write_bytes_helper(r.data, bytes, p);
+    s -= bytes;
+    result += bytes;
+    if (s == 0) {
+      break;
+    }
+  }
+  return result;
+}
+
 const TraceStream* Task::trace_stream() const {
   if (session().as_record()) {
     return &session().as_record()->trace_writer();

--- a/src/Task.h
+++ b/src/Task.h
@@ -681,6 +681,9 @@ public:
                        static_cast<const void*>(val), ok);
   }
 
+  uint64_t write_ranges(const std::vector<FileMonitor::Range>& ranges,
+                        void* data, size_t size);
+
   /**
    * Don't use these helpers directly; use the safer and more
    * convenient variants above.

--- a/src/VirtualPerfCounterMonitor.cc
+++ b/src/VirtualPerfCounterMonitor.cc
@@ -100,21 +100,6 @@ bool VirtualPerfCounterMonitor::emulate_fcntl(RecordTask* t, uint64_t* result) {
   return true;
 }
 
-static size_t write_ranges(RecordTask* t,
-                           const vector<FileMonitor::Range>& ranges, void* data,
-                           size_t size) {
-  uint8_t* p = static_cast<uint8_t*>(data);
-  size_t s = size;
-  size_t result = 0;
-  for (auto& r : ranges) {
-    size_t bytes = min(s, r.length);
-    t->write_bytes_helper(r.data, bytes, p);
-    s -= bytes;
-    result += bytes;
-  }
-  return result;
-}
-
 bool VirtualPerfCounterMonitor::emulate_read(RecordTask* t,
                                              const vector<Range>& ranges,
                                              LazyOffset&, uint64_t* result) {
@@ -122,7 +107,7 @@ bool VirtualPerfCounterMonitor::emulate_read(RecordTask* t,
   if (target) {
     int64_t val;
     val = target->tick_count() - initial_ticks;
-    *result = write_ranges(t, ranges, &val, sizeof(val));
+    *result = t->write_ranges(ranges, &val, sizeof(val));
   } else {
     *result = 0;
   }

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -684,6 +684,10 @@ inline static int is_proc_fd_dir(const char* filename) {
   return strprefix("/fd", fd_bit - 3);
 }
 
+inline static int is_sys_cpu_online_file(const char* filename) {
+  return streq("/sys/devices/system/cpu/online", filename);
+}
+
 /**
  * Returns nonzero if an attempted open() of |filename| can be syscall-buffered.
  * When this returns zero, the open must be forwarded to the rr process.
@@ -695,7 +699,7 @@ inline static int allow_buffered_open(const char* filename) {
   return filename &&
          !is_blacklisted_filename(filename) && !is_gcrypt_deny_file(filename) &&
          !is_terminal(filename) && !is_proc_mem_file(filename) &&
-         !is_proc_fd_dir(filename);
+         !is_proc_fd_dir(filename) && !is_sys_cpu_online_file(filename);
 }
 
 #endif /* RR_PRELOAD_INTERFACE_H_ */

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -38,6 +38,7 @@
 #include "ReplayTask.h"
 #include "SeccompFilterRewriter.h"
 #include "StdioMonitor.h"
+#include "SysCpuMonitor.h"
 #include "ThreadGroup.h"
 #include "TraceStream.h"
 #include "VirtualPerfCounterMonitor.h"
@@ -995,6 +996,8 @@ static void handle_opened_files(ReplayTask* t, int flags) {
       file_monitor = new ProcMemMonitor(t, o.path);
     } else if (is_proc_fd_dir(o.path.c_str())) {
       file_monitor = new ProcFdDirMonitor(t, o.path);
+    } else if (is_sys_cpu_online_file(o.path.c_str())) {
+      file_monitor = new SysCpuMonitor(t, o.path);
     } else if (flags & O_DIRECT) {
       file_monitor = new FileMonitor();
     } else {

--- a/src/test/sys_cpu_online.c
+++ b/src/test/sys_cpu_online.c
@@ -1,0 +1,32 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+int main(int argc, char* argv[] __attribute__((unused))) {
+  long ncpus = sysconf(_SC_NPROCESSORS_ONLN);
+
+  // We test this both with and without the preload library
+  test_assert(ncpus == 1);
+
+  if (argc > 1) {
+    atomic_puts("EXIT-SUCCESS");
+    return 0;
+  }
+
+  // Test reading /sys/devices/system/cpu/online directly, making sure that
+  // rr properly emulates the fd position
+  int fd = open("/sys/devices/system/cpu/online", O_RDONLY);
+  test_assert(fd >= 0);
+
+  char result[1024];
+  size_t nread = read(fd, &result, sizeof(result));
+  test_assert(nread > 0);
+  nread = read(fd, &result, sizeof(result));
+  test_assert(nread == 0);
+  close(fd);
+
+  char* execv_argv[] = {"/proc/self/exe", "--inner", NULL};
+  // NULL here drops LD_PRELOAD
+  execve("/proc/self/exe", execv_argv, NULL);
+  test_assert(0 && "Should not have returned");
+}


### PR DESCRIPTION
Glibc uses this to implement sysconf(_SC_NPROCESSORS_ONLN). With this
commit, the tracee sees the results we want, even if the preload library
is not available, (e.g. because the tracee dropped the evnironment).
Also includes a minor bugfix where we weren't emulating the advancement
of the fd ptr during an emulated read (which, with this FileMonitor would
cause an infinite loop).

Fixes #2453