### PR TITLE
Also emulate /proc/stat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,7 @@ set(RR_SOURCES
   src/PerfCounters.cc
   src/ProcFdDirMonitor.cc
   src/ProcMemMonitor.cc
+  src/ProcStatMonitor.cc
   src/PsCommand.cc
   src/RecordCommand.cc
   src/RecordSession.cc
@@ -1040,7 +1041,6 @@ set(BASIC_TESTS
   sysemu_singlestep
   sysfs
   sysinfo
-  sys_cpu_online
   tgkill
   thread_yield
   timer
@@ -1199,6 +1199,7 @@ set(TESTS_WITH_PROGRAM
   string_instructions_watch
   syscallbuf_fd_disabling
   syscallbuf_signal_blocking_read
+  sysconf_onln
   target_fork
   target_process
   term_nonmain

--- a/src/FileMonitor.h
+++ b/src/FileMonitor.h
@@ -33,7 +33,8 @@ public:
     ProcMem,
     Stdio,
     VirtualPerfCounter,
-    SysCpu
+    SysCpu,
+    ProcStat
   };
 
   virtual Type type() { return Base; }

--- a/src/ProcStatMonitor.cc
+++ b/src/ProcStatMonitor.cc
@@ -1,0 +1,64 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <algorithm>
+
+#include "ProcStatMonitor.h"
+#include "RecordTask.h"
+#include "RecordSession.h"
+#include "Scheduler.h"
+
+#include "log.h"
+#include "util.h"
+
+using namespace std;
+
+namespace rr {
+
+// Skip any lines that contain CPUs not in our cpu mask
+static void filter_proc_stat(string& data, const cpu_set_t& active) {
+  string::iterator pos = data.begin();
+  while (pos + 4 < data.end()) {
+    const char *cur_data = &*pos;
+    static char cpu_str[] = "cpu";
+    if (memcmp(cur_data, cpu_str, sizeof(cpu_str)-1) == 0 && isdigit(*(cur_data + 3))) {
+      unsigned long cpu = strtoul((char*)cur_data + 3, NULL, 10);
+      if (!CPU_ISSET(cpu, &active)) {
+        pos = data.erase(pos, ++std::find(pos, data.end(), '\n'));
+        continue;
+      }
+    }
+    pos = ++std::find(pos, data.end(), '\n');
+  }
+}
+
+ProcStatMonitor::ProcStatMonitor(Task* t, const string&) {
+  if (t->session().is_replaying())
+    return;
+  // Grab all the data now and buffer it for later access. This matches what the
+  // kernel does (execpt that it does the buffering on first access) and is
+  // required to give userspace code a consistent view of the file.
+  std::ifstream proc_stat("/proc/stat");
+  if (!proc_stat.is_open()) {
+    FATAL() << "Failed to process /proc/stat";
+  }
+  data = string(
+    (std::istreambuf_iterator<char>(proc_stat)),
+    (std::istreambuf_iterator<char>()));
+  const cpu_set_t cpus = static_cast<RecordTask*>(t)->session().scheduler().pretend_affinity_mask();
+  filter_proc_stat(data, cpus);
+}
+
+bool ProcStatMonitor::emulate_read(
+  RecordTask* t, const vector<Range>& ranges,
+  LazyOffset& lazy_offset, uint64_t* result) {
+  int64_t offset = lazy_offset.retrieve(false);
+  *result = t->write_ranges(ranges, (uint8_t*)data.data() + offset,
+    (offset > (ssize_t)data.size()) ? 0 : data.size() - offset);
+  return true;
+}
+
+} // namespace rr

--- a/src/ProcStatMonitor.h
+++ b/src/ProcStatMonitor.h
@@ -1,0 +1,31 @@
+/* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#ifndef RR_PROC_STAT_MONITOR_H_
+#define RR_PROC_STAT_MONITOR_H_
+
+#include "FileMonitor.h"
+
+namespace rr {
+
+/**
+ * A FileMonitor to intercept /proc/stat in order to pretend to the
+ * tracee that it only has the CPUs that rr is willing to give it.
+ * This is necessary on top of the SysCpuMonitor, because some versions
+ * of glibc have bugs that cause it to fail to parse the
+ * /sys/devices/system/cpu/online format, causing them to fallback to /proc/stat
+ */
+class ProcStatMonitor : public FileMonitor {
+public:
+  ProcStatMonitor(Task* t, const std::string& pathname);
+
+  virtual Type type() override { return ProcStat; }
+
+  bool emulate_read(RecordTask* t, const std::vector<Range>& ranges,
+                    LazyOffset&, uint64_t* result);
+private:
+  std::string data;
+};
+
+} // namespace rr
+
+#endif /* RR_PROC_STAT_MONITOR_H_ */

--- a/src/SysCpuMonitor.cc
+++ b/src/SysCpuMonitor.cc
@@ -46,7 +46,7 @@ static string make_cpu_online_data(RecordTask* t) {
 
 bool SysCpuMonitor::emulate_read(
   RecordTask* t, const vector<Range>& ranges,
-  LazyOffset &lazy_offset, uint64_t* result) {
+  LazyOffset& lazy_offset, uint64_t* result) {
   string data = make_cpu_online_data(t);
   int64_t offset = lazy_offset.retrieve(false);
   *result = t->write_ranges(ranges, (uint8_t*)data.data() + offset,

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -688,6 +688,10 @@ inline static int is_sys_cpu_online_file(const char* filename) {
   return streq("/sys/devices/system/cpu/online", filename);
 }
 
+inline static int is_proc_stat_file(const char* filename) {
+  return streq("/proc/stat", filename);
+}
+
 /**
  * Returns nonzero if an attempted open() of |filename| can be syscall-buffered.
  * When this returns zero, the open must be forwarded to the rr process.
@@ -699,7 +703,8 @@ inline static int allow_buffered_open(const char* filename) {
   return filename &&
          !is_blacklisted_filename(filename) && !is_gcrypt_deny_file(filename) &&
          !is_terminal(filename) && !is_proc_mem_file(filename) &&
-         !is_proc_fd_dir(filename) && !is_sys_cpu_online_file(filename);
+         !is_proc_fd_dir(filename) && !is_sys_cpu_online_file(filename) &&
+         !is_proc_stat_file(filename);
 }
 
 #endif /* RR_PRELOAD_INTERFACE_H_ */

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -68,6 +68,7 @@
 #include "MmappedFileMonitor.h"
 #include "ProcFdDirMonitor.h"
 #include "ProcMemMonitor.h"
+#include "ProcStatMonitor.h"
 #include "RecordSession.h"
 #include "RecordTask.h"
 #include "Scheduler.h"
@@ -5199,6 +5200,9 @@ static string handle_opened_file(RecordTask* t, int fd, int flags) {
   } else if (is_sys_cpu_online_file(pathname.c_str())) {
     LOG(info) << "Installing SysCpuMonitor for " << fd;
     file_monitor = new SysCpuMonitor(t, pathname);
+  } else if (is_proc_stat_file(pathname.c_str())) {
+    LOG(info) << "Installing ProcStatMonitor for " << fd;
+    file_monitor = new ProcStatMonitor(t, pathname);
   } else if (flags & O_DIRECT) {
     // O_DIRECT can impose unknown alignment requirements, in which case
     // syscallbuf records will not be properly aligned and will cause I/O

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -34,6 +34,7 @@
 #include "MmappedFileMonitor.h"
 #include "ProcFdDirMonitor.h"
 #include "ProcMemMonitor.h"
+#include "ProcStatMonitor.h"
 #include "ReplaySession.h"
 #include "ReplayTask.h"
 #include "SeccompFilterRewriter.h"
@@ -998,6 +999,8 @@ static void handle_opened_files(ReplayTask* t, int flags) {
       file_monitor = new ProcFdDirMonitor(t, o.path);
     } else if (is_sys_cpu_online_file(o.path.c_str())) {
       file_monitor = new SysCpuMonitor(t, o.path);
+    } else if (is_proc_stat_file(o.path.c_str())) {
+      file_monitor = new ProcStatMonitor(t, o.path);
     } else if (flags & O_DIRECT) {
       file_monitor = new FileMonitor();
     } else {

--- a/src/test/sysconf_onln.run
+++ b/src/test/sysconf_onln.run
@@ -1,0 +1,8 @@
+source `dirname $0`/util.sh
+record $TESTNAME "--expected-cpus=1"
+replay
+check EXIT-SUCCESS
+RECORD_ARGS="--num-cores=2"
+record $TESTNAME "--expected-cpus=2"
+replay
+check EXIT-SUCCESS


### PR DESCRIPTION
As I mentioned in #2453, it turns out glibc has a bug in its
parser for /sys/devices/system/cpu/online, so it'll occasionally
fall back to /proc/stat (whenever the chosen sets of cpus is
non-contiguous).