### PR TITLE
Make sure perf fds don't leak into detached clones

### DIFF
--- a/src/AutoRemoteSyscalls.cc
+++ b/src/AutoRemoteSyscalls.cc
@@ -440,7 +440,7 @@ static long child_recvmsg(AutoRemoteSyscalls& remote, int child_sock) {
 static int recvmsg_socket(ScopedFd& sock) {
   fd_message<NativeArch> msg;
   struct msghdr *msgp = (struct msghdr*)&msg.msg;
-  if (0 > recvmsg(sock, msgp, 0)) {
+  if (0 > recvmsg(sock, msgp, MSG_CMSG_CLOEXEC)) {
     FATAL() << "Failed to receive fd";
   }
 

--- a/src/PerfCounters.cc
+++ b/src/PerfCounters.cc
@@ -283,13 +283,13 @@ static ScopedFd start_counter(pid_t tid, int group_fd,
     *disabled_txcp = false;
   }
   attr->pinned = group_fd == -1;
-  int fd = syscall(__NR_perf_event_open, attr, tid, -1, group_fd, 0);
+  int fd = syscall(__NR_perf_event_open, attr, tid, -1, group_fd, PERF_FLAG_FD_CLOEXEC);
   if (0 >= fd && errno == EINVAL && attr->type == PERF_TYPE_RAW &&
       (attr->config & IN_TXCP)) {
     // The kernel might not support IN_TXCP, so try again without it.
     struct perf_event_attr tmp_attr = *attr;
     tmp_attr.config &= ~IN_TXCP;
-    fd = syscall(__NR_perf_event_open, &tmp_attr, tid, -1, group_fd, 0);
+    fd = syscall(__NR_perf_event_open, &tmp_attr, tid, -1, group_fd, PERF_FLAG_FD_CLOEXEC);
     if (fd >= 0) {
       if (disabled_txcp) {
         *disabled_txcp = true;

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3732,7 +3732,8 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
       RecordTask* target = t->session().find_task((pid_t)regs.arg2_signed());
       int cpu = regs.arg3_signed();
       unsigned long flags = regs.arg5();
-      if (target && cpu == -1 && !flags) {
+      int allowed_perf_flags = PERF_FLAG_FD_CLOEXEC;
+      if (target && cpu == -1 && !(flags & ~allowed_perf_flags)) {
         auto attr =
             t->read_mem(remote_ptr<struct perf_event_attr>(regs.arg1()));
         if (VirtualPerfCounterMonitor::should_virtualize(attr)) {
@@ -3740,7 +3741,9 @@ static Switchable rec_prepare_syscall_arch(RecordTask* t,
           // Turn this into an inotify_init() syscall. This just gives us an
           // allocated fd. Syscalls using this fd will be emulated (except for
           // close()).
-          r.set_original_syscallno(Arch::inotify_init);
+          r.set_original_syscallno(Arch::inotify_init1);
+          int in_flags = (flags & PERF_FLAG_FD_CLOEXEC) ? O_CLOEXEC : 0;
+          r.set_arg1(in_flags);
           t->set_regs(r);
         }
       }
@@ -5433,12 +5436,13 @@ static void rec_process_syscall_arch(RecordTask* t,
     }
 
     case Arch::perf_event_open:
-      if (t->regs().original_syscallno() == Arch::inotify_init) {
+      if (t->regs().original_syscallno() == Arch::inotify_init1) {
         ASSERT(t, !t->regs().syscall_failed());
         int fd = t->regs().syscall_result_signed();
         Registers r = t->regs();
         r.set_original_syscallno(
             syscall_state.syscall_entry_registers.original_syscallno());
+        r.set_arg1(syscall_state.syscall_entry_registers.arg1());
         t->set_regs(r);
         auto attr =
             t->read_mem(remote_ptr<struct perf_event_attr>(t->regs().arg1()));

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -1175,7 +1175,8 @@ static void rep_process_syscall_arch(ReplayTask* t, ReplayTraceStep* step,
       int cpu = trace_regs.arg3_signed();
       unsigned long flags = trace_regs.arg5();
       int fd = trace_regs.syscall_result_signed();
-      if (target && cpu == -1 && !flags) {
+      int allowed_perf_flags = PERF_FLAG_FD_CLOEXEC;
+      if (target && cpu == -1 && !(flags & ~allowed_perf_flags)) {
         auto attr =
             t->read_mem(remote_ptr<struct perf_event_attr>(trace_regs.arg1()));
         if (VirtualPerfCounterMonitor::should_virtualize(attr)) {


### PR DESCRIPTION
(by marking them CLOEXEC). Also make sure that the clone duping
respects cloexec flags that were present in the original task.