### PR TITLE
Make failing to dup the desched fd non-fatal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1050,6 +1050,7 @@ set(BASIC_TESTS
   truncate_temp
   tun
   two_signals_with_mask
+  ulimit_low
   uname
   unjoined_thread
   unshare

--- a/src/preload/syscallbuf.c
+++ b/src/preload/syscallbuf.c
@@ -471,11 +471,15 @@ static int open_desched_event_counter(size_t nr_descheds, pid_t tid) {
   }
   fd = privileged_traced_fcntl(tmp_fd, F_DUPFD_CLOEXEC,
                                RR_DESCHED_EVENT_FLOOR_FD);
-  if (0 > fd) {
-    fatal("Failed to dup desched fd");
-  }
-  if (privileged_untraced_close(tmp_fd)) {
-    fatal("Failed to close tmp_fd");
+  if (fd > 0) {
+    if (privileged_untraced_close(tmp_fd)) {
+      fatal("Failed to close tmp_fd");
+    }
+  } else {
+    // We may be unable to find an fd above the RR_DESCHED_EVENT_FLOOR_FD (e.g
+    // because of a low ulimit). In that case, just use the tmp_fd we already
+    // have.
+    fd = tmp_fd;
   }
   if (privileged_untraced_fcntl(fd, F_SETFL, FASYNC)) {
     fatal("Failed to fcntl(FASYNC) the desched counter");

--- a/src/test/ulimit_low.c
+++ b/src/test/ulimit_low.c
@@ -1,0 +1,31 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+static void* do_thread(__attribute__((unused)) void* p) {
+  atomic_puts("EXIT-SUCCESS");
+  return NULL;
+}
+
+int main(void) {
+  pthread_t thread;
+  struct rlimit limit;
+  test_assert(0 == getrlimit(RLIMIT_NOFILE, &limit));
+
+  // Set a low rlimit
+  limit.rlim_cur = 30;
+  test_assert(0 == setrlimit(RLIMIT_NOFILE, &limit));
+
+  pid_t child;
+  // Test both forking and thread creation under the low ulimit
+  if ((child = fork()) == 0) {
+    pthread_create(&thread, NULL, do_thread, NULL);
+    pthread_join(thread, NULL);
+    return 0;
+  }
+
+  int status;
+  test_assert(child == waitpid(child, &status, 0));
+  test_assert(WIFEXITED(status) && WEXITSTATUS(status) == 0);
+  return 0;
+}


### PR DESCRIPTION
We try to avoid using the low fds to avoid disrupting the tracee (e.g.
the tracee may want to reserve a portion of fd space for its exclusive
management and get confused if we put an fd there). However, if we can't
use a high fd (e.g. because of a ulimit), then this shouldn't be fatal,
since it's not a problem if the tracee doesn't indiscriminately close
file descriptors. We could probably do better in the future, but for
now, let's just close the immediate failure mode with low ulimits.

Part of #2521