### PR TITLE
More thoroughly handle exit event race

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -781,6 +781,8 @@ set(BASIC_TESTS
   fork_brk
   fork_child_crash
   fork_many
+  futex_exit_race
+  futex_exit_race_sigsegv
   futex_pi
   futex_priorities
   fxregs

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -185,6 +185,12 @@ public:
 
   virtual TraceStream* trace_stream() override { return &trace_out; }
 
+  /**
+   * Like kill_all_tasks, but makes sure to record the exits of the task we
+   * killed.
+   */
+  void kill_all_record_tasks();
+
 private:
   RecordSession(const std::string& exe_path,
                 const std::vector<std::string>& argv,

--- a/src/Scheduler.cc
+++ b/src/Scheduler.cc
@@ -549,6 +549,7 @@ Scheduler::Rescheduled Scheduler::reschedule(Switchable switchable) {
       LOG(debug) << "  and running; waiting for state change";
       while (true) {
         if (unlimited_ticks_mode) {
+          LOG(debug) << "Using unlimited ticks mode";
           // Unlimited ticks mode means that there is only one non-blocked task.
           // We run it without a timeslice to avoid unnecessary switches to the
           // tracer. However, this does mean we need to be on the look out for

--- a/src/Task.h
+++ b/src/Task.h
@@ -169,8 +169,10 @@ public:
   /**
    * Kill this task and wait for it to exit.
    * N.B.: If may_reap() is false, this may hang.
+   * Returns the WaitStatus of the task at exit (usually SIGKILL, but may not
+   * be if we raced with another exit reason).
    */
-  void kill();
+  WaitStatus kill();
 
   /**
    * This must be in an emulated syscall, entered through

--- a/src/test/futex_exit_race.c
+++ b/src/test/futex_exit_race.c
@@ -1,0 +1,46 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+static int futex(int* uaddr, int op, int val, const struct timespec* timeout,
+                 int* uaddr2, int val2) {
+  return syscall(SYS_futex, uaddr, op, val, timeout, uaddr2, val2);
+}
+
+static void* do_thread(void* futex_addr) {
+  futex(futex_addr, FUTEX_WAIT, 0, NULL, NULL, 0);
+  return NULL;
+}
+
+#define NUM_THREADS 20
+
+int main(void) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  int* futex_addr = (int*)mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+                               MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+  *futex_addr = 0;
+
+  if (fork() == 0) {
+    pthread_t threads[NUM_THREADS];
+    for (int i = 0; i < NUM_THREADS; ++i) {
+      pthread_create(&threads[i], NULL, do_thread, futex_addr);
+    }
+    // Give the thredas a chance to run and block in the futex call
+    for (int i = 0; i < 2*NUM_THREADS; ++i) {
+      sched_yield();
+    }
+    futex(futex_addr, FUTEX_WAKE, NUM_THREADS + 1, NULL, NULL, 0);
+    syscall(SYS_exit_group, 10);
+    test_assert(0);
+  }
+
+  atomic_puts("EXIT-SUCCESS");
+  int ret = futex(futex_addr, FUTEX_WAIT, 0, NULL, NULL, 0);
+  // Minimize the number of instructions/syscalls between the return of that
+  // futex call, to try to race the kernel to the cleanup of the child's
+  // threads. In that spirit,  we don't assert ret here.
+  // Rather, if the futex call failed, then `ret` will be non-zero, so we will
+  // see that in the exit code.
+  _exit(ret);
+  test_assert(0);
+}

--- a/src/test/futex_exit_race_sigsegv.c
+++ b/src/test/futex_exit_race_sigsegv.c
@@ -1,0 +1,48 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+static int futex(int* uaddr, int op, int val, const struct timespec* timeout,
+                 int* uaddr2, int val2) {
+  return syscall(SYS_futex, uaddr, op, val, timeout, uaddr2, val2);
+}
+
+static void* do_thread(void* futex_addr) {
+  futex(futex_addr, FUTEX_WAIT, 0, NULL, NULL, 0);
+  crash_null_deref();
+  return NULL;
+}
+
+#define NUM_THREADS 20
+
+int main(void) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  int* futex_addr = (int*)mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+                               MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+  *futex_addr = 0;
+
+  if (fork() == 0) {
+    pthread_t threads[NUM_THREADS];
+    for (int i = 0; i < NUM_THREADS; ++i) {
+      pthread_create(&threads[i], NULL, do_thread, futex_addr);
+    }
+    // Give the thredas a chance to run and block in the futex call
+    for (int i = 0; i < 2*NUM_THREADS; ++i) {
+      sched_yield();
+    }
+    futex(futex_addr, FUTEX_WAKE, NUM_THREADS + 1, NULL, NULL, 0);
+    // Never returns - let one of the threads crash
+    futex(futex_addr, FUTEX_WAIT, 0, NULL, NULL, 0);
+    test_assert(0);
+  }
+
+  atomic_puts("EXIT-SUCCESS");
+  int ret = futex(futex_addr, FUTEX_WAIT, 0, NULL, NULL, 0);
+  // Minimize the number of instructions/syscalls between the return of that
+  // futex call, to try to race the kernel to the cleanup of the child's
+  // threads. In that spirit,  we don't assert ret here.
+  // Rather, if the futex call failed, then `ret` will be non-zero, so we will
+  // see that in the exit code.
+  _exit(ret);
+  test_assert(0);
+}


### PR DESCRIPTION
When I originall wrote this code, I had somewhat optimistically
added an assertion that we would only see the race in the case
of external fatal signals, in the exepectation that we would
see stable exit events in time to record proper exit events.
However, if there is a large number of threads waiting to exit,
it's quite possible for the kernel to not deliver us those
notifications until we're already trying to kill the tasks.
In principle it's a simple matter to change the assertion.
However, I also noticed that in this case, we don't write
any exit task events, which I know can confuse external tooling,
so let's refactor this whole thing to have RecordSession have
it's own copy of the killing code (half of it was already
record specific anyway), and properly record exit events
for everything that dies.

Also adds a test that tries to provoke these kinds of races.