### PR TITLE
Make return type consistent for write_ranges.

### DIFF
--- a/src/Task.h
+++ b/src/Task.h
@@ -683,7 +683,7 @@ public:
                        static_cast<const void*>(val), ok);
   }
 
-  uint64_t write_ranges(const std::vector<FileMonitor::Range>& ranges,
+  size_t write_ranges(const std::vector<FileMonitor::Range>& ranges,
                         void* data, size_t size);
 
   /**


### PR DESCRIPTION
I am unable to build rr from source on 32-bit machines. It seems that it is caused by the inconsistency in the return type (`size_t` and `uint64_t`) of `rr::Task::write_ranges`.

```
/builddir/build/BUILD/rr-aea765894985bd3a516eb3f42390025f36f81baa/src/Task.cc:2507:8: error: no declaration matches 'size_t rr::Task::write_ranges(const std::vector<rr::FileMonitor::Range>&, void*, size_t)'
 2507 | size_t Task::write_ranges(const vector<FileMonitor::Range>& ranges,
      |        ^~~~
In file included from /builddir/build/BUILD/rr-aea765894985bd3a516eb3f42390025f36f81baa/src/Task.cc:3:
/builddir/build/BUILD/rr-aea765894985bd3a516eb3f42390025f36f81baa/src/Task.h:684:12: note: candidate is: 'uint64_t rr::Task::write_ranges(const std::vector<rr::FileMonitor::Range>&, void*, size_t)'
  684 |   uint64_t write_ranges(const std::vector<FileMonitor::Range>& ranges,
```

After adjusting the return type, I'm able to build rr on 32-bit machines again.