### PR TITLE
Change return type of write_ranges to uint64_t.

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -2513,8 +2513,8 @@ void Task::write_bytes_helper(remote_ptr<void> addr, ssize_t buf_size,
   }
 }
 
-size_t Task::write_ranges(const vector<FileMonitor::Range>& ranges,
-                          void* data, size_t size) {
+uint64_t Task::write_ranges(const vector<FileMonitor::Range>& ranges,
+                            void* data, size_t size) {
   uint8_t* p = static_cast<uint8_t*>(data);
   size_t s = size;
   size_t result = 0;

--- a/src/Task.h
+++ b/src/Task.h
@@ -683,7 +683,7 @@ public:
                        static_cast<const void*>(val), ok);
   }
 
-  size_t write_ranges(const std::vector<FileMonitor::Range>& ranges,
+  uint64_t write_ranges(const std::vector<FileMonitor::Range>& ranges,
                         void* data, size_t size);
 
   /**


### PR DESCRIPTION
Follow up to #2528.

> Should probably be uint64_t consistently (sorry about that), since 32-bit applications can still write 64-bit files and this refers to a file size.

@Keno suggested that the return type be consistently set as `uint64_t` instead of `size_t`.