### PR TITLE
Support vsyscall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1061,6 +1061,7 @@ set(BASIC_TESTS
   vfork_shared
   video_capture
   vm_readv_writev
+  vsyscall
   wait
   wait_sigstop
   write_race

--- a/src/Event.h
+++ b/src/Event.h
@@ -112,6 +112,8 @@ struct PatchSyscallEvent {
   // come before). We assume the trace has put us in the correct place
   // and don't try to execute any code to reach this event.
   bool patch_after_syscall;
+  // It true, this patch is for the caller of a vsyscall entry point
+  bool patch_vsyscall;
 };
 
 struct SyscallbufFlushEvent {
@@ -358,6 +360,7 @@ struct Event {
   static Event patch_syscall() {
     auto ev = Event(EV_PATCH_SYSCALL);
     ev.PatchSyscall().patch_after_syscall = false;
+    ev.PatchSyscall().patch_vsyscall = false;
     return ev;
   }
   static Event sched() { return Event(EV_SCHED); }

--- a/src/Monkeypatcher.h
+++ b/src/Monkeypatcher.h
@@ -64,6 +64,14 @@ public:
    */
   bool try_patch_syscall(RecordTask* t, bool entering_syscall = true);
 
+  /**
+   * Try to patch the vsyscall-entry pattern occurring right before ret_addr
+   * to instead point into the corresponding entry points in the vdso.
+   * Returns true if the patching succeeded, false if it doesn't. The tasks
+   * registers are left unmodified.
+   */
+  bool try_patch_vsyscall_caller(RecordTask *t, remote_code_ptr ret_addr);
+
   void init_dynamic_syscall_patching(
       RecordTask* t, int syscall_patch_hook_count,
       remote_ptr<syscall_patch_hook> syscall_patch_hooks);

--- a/src/ReplaySession.h
+++ b/src/ReplaySession.h
@@ -62,6 +62,9 @@ enum ReplayTraceStepType {
   /* Replay until we exit the next syscall, then patch it. */
   TSTEP_PATCH_AFTER_SYSCALL,
 
+  /* Replay until we hit the ip recorded in the event, then patch the vsyscall caller. */
+  TSTEP_PATCH_VSYSCALL,
+
   /* Exit the task */
   TSTEP_EXIT_TASK,
 
@@ -344,6 +347,7 @@ private:
   Completion patch_next_syscall(ReplayTask* t,
                                 const StepConstraints& constraints,
                                 bool before_syscall);
+  Completion patch_vsyscall(ReplayTask* t, const StepConstraints& constraints);
   void check_approaching_ticks_target(ReplayTask* t,
                                       const StepConstraints& constraints,
                                       BreakStatus& break_status);

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -428,7 +428,9 @@ void TraceWriter::write_frame(RecordTask* t, const Event& ev,
       event.setInstructionTrap(Void());
       break;
     case EV_PATCH_SYSCALL:
-      if (ev.PatchSyscall().patch_after_syscall) {
+      if (ev.PatchSyscall().patch_vsyscall) {
+        event.setPatchVsyscall(Void());
+      } else if (ev.PatchSyscall().patch_after_syscall) {
         event.setPatchAfterSyscall(Void());
       } else {
         event.setPatchSyscall(Void());
@@ -561,6 +563,10 @@ TraceFrame TraceReader::read_frame() {
       break;
     case trace::Frame::Event::PATCH_SYSCALL:
       ret.ev = Event::patch_syscall();
+      break;
+    case trace::Frame::Event::PATCH_VSYSCALL:
+      ret.ev = Event::patch_syscall();
+      ret.ev.PatchSyscall().patch_vsyscall = true;
       break;
     case trace::Frame::Event::PATCH_AFTER_SYSCALL:
       ret.ev = Event::patch_syscall();

--- a/src/assembly_templates.py
+++ b/src/assembly_templates.py
@@ -177,6 +177,16 @@ templates = {
     ),
     'X86EndBr': AssemblyTemplate(
         RawBytes(0xf3, 0x0f, 0x1e, 0xfb)
+    ),
+    'X64VSyscallEntry': AssemblyTemplate(
+        RawBytes(0x48, 0xc7, 0xc0), # movq $[addr], %rax
+        Field('addr', 4),
+        RawBytes(0xff, 0xd0) # callq *%rax
+    ),
+    'X64VSyscallReplacement': AssemblyTemplate(
+        RawBytes(0x48, 0xc7, 0xc0), # movq $[syscallno], %rax
+        Field('syscallno', 4),
+        RawBytes(0x0f, 0x05) # syscall
     )
 }
 
@@ -190,7 +200,7 @@ def generate_match_method(byte_array, template):
     field_names = [f.name for f in fields]
     args = ', ' + ', '.join("%s* %s" % (t, n) for t, n in zip(field_types, field_names)) \
            if fields else ''
-    
+
     s.write('  static bool match(const uint8_t* buffer %s) {\n' % (args,))
     offset = 0
     for chunk in template.chunks:
@@ -213,7 +223,7 @@ def generate_substitute_method(byte_array, template):
     field_names = [f.name for f in fields]
     args = ', ' + ', '.join("%s %s" % (t, n) for t, n in zip(field_types, field_names)) \
            if fields else ''
-    
+
     s.write('  static void substitute(uint8_t* buffer %s) {\n' % (args,))
     offset = 0
     for chunk in template.chunks:

--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -172,7 +172,17 @@ ssize_t movrm_instruction_length(SupportedArch arch) {
     case x86_64:
       return 3;
     default:
-      DEBUG_ASSERT(0 && "Need to define syscall instruction length");
+      DEBUG_ASSERT(0 && "Need to define movrm instruction length");
+      return 0;
+  }
+}
+
+ssize_t vsyscall_entry_length(SupportedArch arch) {
+  switch (arch) {
+    case x86_64:
+      return 9;
+    default:
+      DEBUG_ASSERT(0 && "Vsyscall is only used on x86_64");
       return 0;
   }
 }

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1991,6 +1991,12 @@ std::vector<uint8_t> syscall_instruction(SupportedArch arch);
 ssize_t syscall_instruction_length(SupportedArch arch);
 
 /**
+ * Return the length of the vsyscall invocation pattern. Currently,
+ * we only support patterns of the form movq %addr, %rax; callq *%rax.
+ */
+ssize_t vsyscall_entry_length(SupportedArch arch);
+
+/**
  * Return the length of the mov (m),r instruction we use to cause intentional,
  * conditional, memory traps.
  */

--- a/src/remote_code_ptr.h
+++ b/src/remote_code_ptr.h
@@ -56,6 +56,9 @@ public:
   remote_code_ptr increment_by_movrm_insn_length(SupportedArch arch) const {
     return remote_code_ptr(ptr + movrm_instruction_length(arch));
   }
+  remote_code_ptr decrement_by_vsyscall_entry_length(SupportedArch arch) const {
+    return remote_code_ptr(ptr - rr::vsyscall_entry_length(arch));
+  }
 
   template <typename T> remote_ptr<T> to_data_ptr() const {
     return remote_ptr<T>(to_data_ptr_value());

--- a/src/rr_trace.capnp
+++ b/src/rr_trace.capnp
@@ -260,5 +260,6 @@ struct Frame {
       }
     }
     patchAfterSyscall @26: Void;
+    patchVsyscall @27: Void;
   }
 }

--- a/src/test/vsyscall.c
+++ b/src/test/vsyscall.c
@@ -1,0 +1,61 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+#ifdef __x86_64__
+
+static long gettimeofday_vsyscall(struct timeval* tv, struct timezone* tz)
+{
+  long ret;
+  __asm__ __volatile(
+    "movq $0xffffffffff600000, %%rax\n\t"
+    "callq *%%rax\n\t" : "=a"(ret) : "D"(tv), "S"(tz) : "cc", "memory");
+  return ret;
+}
+
+static time_t time_vsyscall(time_t* t)
+{
+  time_t ret;
+  __asm__ __volatile(
+    "movq $0xffffffffff600400, %%rax\n\t"
+    "callq *%%rax\n\t" : "=a"(ret) : "D"(t) : "cc", "memory");
+  return ret;
+}
+
+static long getcpu_vsyscall(unsigned* cpu, unsigned* node, void* tcache)
+{
+  long ret;
+  __asm__ __volatile(
+    "movq $0xffffffffff600800, %%rax\n\t"
+    "callq *%%rax\n\t" : "=a"(ret) : "D"(cpu), "S"(node), "d"(tcache) : "cc", "memory");
+  return ret;
+}
+#endif
+
+int main(void) {
+  // x86_64 only
+#ifdef __x86_64__
+  // gettimeofday
+  struct timeval tv = { 0, 0 };
+  test_assert(gettimeofday_vsyscall(&tv, NULL) == 0);
+  test_assert(tv.tv_sec != 0);
+
+  // time
+  time_t tim;
+  time_t ret = (time_t)time_vsyscall(&tim);
+  test_assert(ret == tim);
+
+  // getcpu
+  unsigned* cpu;
+  unsigned* node;
+  ALLOCATE_GUARD(cpu, -1);
+  ALLOCATE_GUARD(node, -1);
+  test_assert(0 == getcpu_vsyscall(cpu, node, NULL));
+  test_assert(*cpu <= 0xffffff);
+  test_assert(*node <= 0xffffff);
+  VERIFY_GUARD(cpu);
+  VERIFY_GUARD(node);
+#endif
+  atomic_puts("EXIT-SUCCESS");
+  return 0;
+}


### PR DESCRIPTION
[vsyscall] is a legacy mechanism on x86_64 used to accelerate three
specific syscalls (gettimeofday, time and getcpu) by giving them
well-defined user space entrypoints that code can jump to. This
mechanism was deprecated in 2011 due to functionality limitations
and security considerations of having code mapped at fixed, known
addresses. It was replaced by vdso and on subsequent kernels,
vsyscall started being emulated by intercepting page faults to
these addresses. From the rr perspective, vsyscalls look quite odd.
We get a seccomp trap, but no other kind of syscall trap. We also
can't change any registers or do much of anything else other
than decidign to skip the syscall. Most critically, since we don't
get syscall traps for these, PTRACE_SYSEMU does not stop for
them during replay. As a result, we don't see them at all there
unless we do something special during record. This tries to do
the simplest possible thing: Assume the caller has a fixed vsyscall
entry pattern of:
```
movq $[addr], %rax
callq *%rax
```
which appears to be true of all callers we have encountered so
far. We then simply patch these into using a syscall instruction instead.
We won't end up being able to syscall buffer these calls as
a result, so they may be a bit slow, but the kernel was emulating
these anyway with a page-fault based slow path. More sophisticated
approaches are possible (e.g. patching it to use the syscall buffer,
or adding special support in replay to intercept the vsyscall without
monkey patching, but at this point that doesn't appear worth it
given that this is a deprecated, legacy feature).