### PR TITLE
Give an intelligent error if rr is broken by an external seccomp filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1184,6 +1184,7 @@ set(TESTS_WITH_PROGRAM
   reverse_step_threads
   reverse_step_threads_break
   search
+  seccomp_blocks_rr
   seccomp_signals
   segfault
   shared_map

--- a/src/test/seccomp_blocks_rr.c
+++ b/src/test/seccomp_blocks_rr.c
@@ -1,0 +1,42 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+static void install_filter(void) {
+  struct sock_filter filter[] = {
+    /* Load system call number from 'seccomp_data' buffer into accumulator */
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+    /* Jump forward 1 instruction if system call number is less than 1000 */
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, 1000, 0, 1),
+    /* Error out with EPERM */
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | (EPERM & SECCOMP_RET_DATA)),
+    /* Allow other syscalls */
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW)
+  };
+  struct sock_fprog prog = {
+    .len = (unsigned short)(sizeof(filter) / sizeof(filter[0])),
+    .filter = filter,
+  };
+  int ret;
+
+  ret = syscall(RR_seccomp, SECCOMP_SET_MODE_FILTER, 0, &prog);
+  if (ret == -1 && errno == ENOSYS) {
+    ret = prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog);
+  }
+  test_assert(ret == 0);
+}
+
+int main(int argc, char* argv[]) {
+  if (argc > 1 && !strcmp(argv[1], "--inner")) {
+    atomic_puts("EXIT-SUCCESS");
+    return 0;
+  }
+
+  test_assert(0 == prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0));
+  test_assert(1 == prctl(PR_GET_NO_NEW_PRIVS, 0, 0, 0, 0));
+  install_filter();
+  test_assert(2 == prctl(PR_GET_SECCOMP));
+
+  execve(argv[1], &argv[1], environ); // Should not return
+  test_assert(0);
+}

--- a/src/test/seccomp_blocks_rr.run
+++ b/src/test/seccomp_blocks_rr.run
@@ -1,0 +1,22 @@
+source `dirname $0`/util.sh
+RR_EXE="$TESTNAME $(which $RR_EXE)"
+RECORD_ARGS="--nested=ignore"
+save_exe "$TESTNAME"
+record $TESTNAME --inner
+
+function expect_record_fail {
+    if [[ $(cat record.err) == "" ]]; then
+        echo "Test '$TESTNAME' FAILED: record should have failed, but it succeeded."
+        exit 1
+    fi
+    echo "  (record failed as expected)"
+}
+
+echo We have $LIB_ARG
+if [[ "" == "$LIB_ARG" || "-b" == "$LIB_ARG" ]]; then
+    expect_record_fail
+    exit 0
+fi
+
+replay
+check EXIT-SUCCESS

--- a/src/test/util.sh
+++ b/src/test/util.sh
@@ -178,6 +178,8 @@ if [[ ! -d $TESTDIR ]]; then
     fatal FAILED: TESTDIR "($TESTDIR)" not found.
 fi
 
+RR_EXE=rr
+
 # Our test programs intentionally crash a lot. Don't generate coredumps for them.
 ulimit -c 0
 
@@ -222,7 +224,7 @@ function skip_if_syscall_buf {
 
 function just_record { exe="$1"; exeargs=$2;
     _RR_TRACE_DIR="$workdir" test-monitor $TIMEOUT record.err \
-        rr $GLOBAL_OPTIONS record $LIB_ARG $RECORD_ARGS "$exe" $exeargs 1> record.out 2> record.err
+        $RR_EXE $GLOBAL_OPTIONS record $LIB_ARG $RECORD_ARGS "$exe" $exeargs 1> record.out 2> record.err
 }
 
 function save_exe { exe=$1;
@@ -255,12 +257,12 @@ function record_async_signal { sig=$1; delay_secs=$2; exe=$3; exeargs=$4;
 
 function replay { replayflags=$1
     _RR_TRACE_DIR="$workdir" test-monitor $TIMEOUT replay.err \
-        rr $GLOBAL_OPTIONS replay -a $replayflags 1> replay.out 2> replay.err
+        $RR_EXE $GLOBAL_OPTIONS replay -a $replayflags 1> replay.out 2> replay.err
 }
 
 function do_ps { psflags=$1
     _RR_TRACE_DIR="$workdir" \
-        rr $GLOBAL_OPTIONS ps $psflags
+        $RR_EXE $GLOBAL_OPTIONS ps $psflags
 }
 
 #  debug <expect-script-name> [replay-args]
@@ -269,7 +271,7 @@ function do_ps { psflags=$1
 function debug { expectscript=$1; replayargs=$2
     _RR_TRACE_DIR="$workdir" test-monitor $TIMEOUT debug.err \
         python3 $TESTDIR/$expectscript.py \
-        rr $GLOBAL_OPTIONS replay -o-n -x $TESTDIR/test_setup.gdb $replayargs
+        $RR_EXE $GLOBAL_OPTIONS replay -o-n -x $TESTDIR/test_setup.gdb $replayargs
     if [[ $? == 0 ]]; then
         passed
     else
@@ -408,7 +410,7 @@ function debug_test {
 
 # Return the number of events in the most recent local recording.
 function count_events {
-    local events=$(rr $GLOBAL_OPTIONS dump -r latest-trace | wc -l)
+    local events=$($RR_EXE $GLOBAL_OPTIONS dump -r latest-trace | wc -l)
     # The |simple| test is just about the simplest possible C program,
     # and has around 180 events (when recorded on a particular
     # developer's machine).  If we count a number of events


### PR DESCRIPTION
If an external syscall filter vetos unknown syscalls (in particular those
above 1000, used by rr), recording will currently silently proceed (but
without the syscallbuf enabled), but the recording will be broken and
will fail with the `!syscall_bp_vm` assertion during replay. This
happens because we don't see a seccomp trap for the init syscall during
recording (because it gets veto'd by the external seccomp filter),
but we do see the syscall during replay (because PTRACE_SYSEMU will
still stop there). Instead of creating the broken recording, give
an intelligible error message, so the user can explicitly opt into
`-n` (which is adjusted to no longer call the init syscall).

Long term, it might be more sensible to switch these private, internals
syscalls to use a different mechanism instead (e.g. a debugger trap)
to protect them from over-aggressive seccomp filters.