### PR TITLE
Don't restore mutated memory that intersects output ranges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -997,6 +997,7 @@ set(BASIC_TESTS
   sigprocmask
   sigprocmask_ensure_delivery
   sigprocmask_exec
+  sigprocmask_evil
   sigprocmask_in_syscallbuf_sighandler
   sigprocmask_rr_sigs
   sigprocmask_syscallbuf

--- a/src/test/sigprocmask_evil.c
+++ b/src/test/sigprocmask_evil.c
@@ -1,0 +1,25 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+static void exit_handler(__attribute__((unused)) int sig) {
+  atomic_puts("EXIT-SUCCESS");
+  exit(0);
+}
+
+int main(void) {
+  uint64_t old, new;
+  signal(SIGSEGV, exit_handler);
+  new = (uint64_t)-1;
+  test_assert(0 == syscall(SYS_rt_sigprocmask, 2, &new, NULL, sizeof(new)));
+  test_assert(new == (uint64_t)-1);
+  new = 0x4226;
+  test_assert(0 == syscall(SYS_rt_sigprocmask, 2, &new, NULL, sizeof(new)));
+  test_assert(0 == syscall(SYS_rt_sigprocmask, 0, NULL, &old, sizeof(old)));
+  new = (uint64_t)-1;
+  test_assert(0 == syscall(SYS_rt_sigprocmask, 2, &new, &new, sizeof(new)));
+  test_assert(new == old);
+  test_assert(0 == syscall(SYS_rt_sigprocmask, 2, &new, NULL, sizeof(new)));
+  crash_null_deref();
+  test_assert(0);
+}


### PR DESCRIPTION
This was a bear of a bug to track down, but see the included
test case for a situation in which this happens. Essentially,
if we have an input parameter that intersects an output parameter
and the input parameter has a mutator, our attempt to undo those
mutations after the syscall is done, actually clobbers the syscall
output in the same memory region. This doesn't happen very often,
because those memory regions don't tend to overlap and even if
they do, we're often syscallbuffered, which is a bit more robust
to this. When it does happen though, the result can be quite
mysterious, causing long range, mysterious memory modifications
during record.