### PR TITLE
[GdbServer] Look for missing file in the ld rendezvous

### DIFF
--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -1619,6 +1619,22 @@ struct BaseArch : public wordsize,
     int handle_type;
     uint8_t f_handle[0];
   };
+
+  // This is technically a libc ABI, but we'll just put it here for convenience
+  struct link_map {
+    ptr<void> l_addr;
+    ptr<char> l_name;
+    ptr<void> l_ld;
+    ptr<link_map> l_next;
+    ptr<link_map> l_prev;
+    // More fields that are libc ...
+  };
+
+  struct r_debug {
+    int r_version;
+    ptr<link_map> r_map;
+    // More fields we don't need (and are potentially libc specific)
+  };
 };
 
 struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {


### PR DESCRIPTION
The --serve-files option I recently added is very useful for
debugging traces from a different machine, where the original
file system may not be locally available for rr to read symbols
from (similarly if the local file system has been deleted or
the recording is from the inside of a container that the replayer
may not be able to see). However, for dynamic libraries opened
via symlink, we currently fail to serve them using this mechanism,
since we nowhere record the resolved symlink on the record side.
GDB however, is getting these paths from the ld rendezvous struct,
which does record the path that was open()'ed rather than the
resolved path. This patch is a slightly hacky way to still serve
those files: If we didn't find the correct path in our memory
image, we too look for the ld rendezvous struct and see if the
filename came from any of those entries. If so, it's easy to
look at the memory map corresponding to this library to serve
the corresponding file. This does go a little further into
debugger frontend territory than I'd otherwise like to see rr
go and of course there's various corner cases that this doesn't
handle right, but the GDB frontend is still most people's first
exposure to rr, so I'd like to make it as functional as possible
and in practice this seems to work nicely for all the traces I've
tried.