### PR TITLE
Fix various vfork issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1226,6 +1226,7 @@ set(TESTS_WITH_PROGRAM
   vdso_clock_gettime_stack
   vdso_time_stack
   vfork
+  vfork_read_clone_stress
   vsyscall_reverse_next
   wait_for_all
   watchpoint

--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -204,6 +204,12 @@ public:
   int send_fd(const ScopedFd &fd);
 
   /**
+   * `send_fd` the given file descriptor, making sure that it ends up as fd
+   * `dup_to`, (dup'ing it there and closing the original if necessary)
+   */
+  void infallible_send_fd_dup(const ScopedFd& our_fd, int dup_to);
+
+  /**
    * Remotely invoke in |t| the specified syscall with the given
    * arguments.  The arguments must of course be valid in |t|,
    * and no checking of that is done by this function.

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -1598,7 +1598,8 @@ void GdbServer::serve_replay(const ConnectionFlags& flags) {
   }
   debuggee_tguid = t->thread_group()->tguid();
 
-  FrameTime first_run_event = t->vm()->first_run_event();
+  FrameTime first_run_event = std::max(t->vm()->first_run_event(),
+    t->thread_group()->first_run_event());
   if (first_run_event) {
     timeline.set_reverse_execution_barrier_event(first_run_event);
   }

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -672,6 +672,10 @@ void RecordSession::task_continue(const StepState& step_state) {
     t->vm()->set_first_run_event(trace_writer().time());
   }
 
+  if (!t->thread_group()->first_run_event()) {
+    t->thread_group()->set_first_run_event(trace_writer().time());
+  }
+
   TicksRequest ticks_request;
   ResumeRequest resume;
   if (step_state.continue_type == CONTINUE_SYSCALL) {

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1209,7 +1209,7 @@ RecordTask* RecordSession::revive_task_for_exec(pid_t rec_tid) {
     FATAL() << "Can't find old task for execve";
   }
   ASSERT(t, rec_tid == t->tgid());
-  pid_t own_namespace_tid = t->thread_group()->real_tgid_own_namespace;
+  pid_t own_namespace_tid = t->thread_group()->tgid_own_namespace;
 
   LOG(debug) << "Changing task tid from " << t->tid << " to " << rec_tid;
 

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -464,8 +464,8 @@ template <typename Arch> void RecordTask::init_buffers_arch() {
 
     if (trace_writer().supports_file_data_cloning() &&
         session().use_read_cloning()) {
-      string clone_file_name = trace_writer().file_data_clone_file_name(tuid());
-      ScopedFd clone_file(clone_file_name.c_str(), O_RDWR | O_CREAT, 0600);
+      cloned_file_data_fname = trace_writer().file_data_clone_file_name(tuid());
+      ScopedFd clone_file(cloned_file_data_fname.c_str(), O_RDWR | O_CREAT, 0600);
       int cloned_file_data = remote.send_fd(clone_file.get());
       ASSERT(this, cloned_file_data >= 0);
       int free_fd = find_free_file_descriptor(tid);

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -288,10 +288,11 @@ TraceWriter& RecordTask::trace_writer() const {
 Task* RecordTask::clone(CloneReason reason, int flags, remote_ptr<void> stack,
                         remote_ptr<void> tls, remote_ptr<int> cleartid_addr,
                         pid_t new_tid, pid_t new_rec_tid, uint32_t new_serial,
-                        Session* other_session) {
+                        Session* other_session, ThreadGroup::shr_ptr new_tg) {
   ASSERT(this, reason == Task::TRACEE_CLONE);
+  ASSERT(this, new_tg == nullptr);
   Task* t = Task::clone(reason, flags, stack, tls, cleartid_addr, new_tid,
-                        new_rec_tid, new_serial, other_session);
+                        new_rec_tid, new_serial, other_session, new_tg);
   if (t->session().is_recording()) {
     RecordTask* rt = static_cast<RecordTask*>(t);
     if (CLONE_CLEARTID & flags) {

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -63,7 +63,8 @@ public:
   Task* clone(CloneReason reason, int flags, remote_ptr<void> stack,
               remote_ptr<void> tls, remote_ptr<int> cleartid_addr,
               pid_t new_tid, pid_t new_rec_tid, uint32_t new_serial,
-              Session* other_session = nullptr) override;
+              Session* other_session = nullptr,
+              ThreadGroup::shr_ptr new_tg = nullptr) override;
   virtual void post_wait_clone(Task* cloned_from, int flags) override;
   virtual void on_syscall_exit(int syscallno, SupportedArch arch,
                                const Registers& regs) override;

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -1737,8 +1737,13 @@ ReplayResult ReplaySession::replay_step(const StepConstraints& constraints) {
   current_step.action = TSTEP_NONE;
 
   ReplayTask* next_task = current_task();
-  if (next_task && !next_task->vm()->first_run_event() && done_initial_exec()) {
-    next_task->vm()->set_first_run_event(trace_frame.time());
+  if (next_task && done_initial_exec()) {
+    if (!next_task->vm()->first_run_event()) {
+      next_task->vm()->set_first_run_event(trace_frame.time());
+    }
+    if (!next_task->thread_group()->first_run_event()) {
+      next_task->thread_group()->set_first_run_event(trace_frame.time());
+    }
   }
   if (next_task) {
     ticks_at_start_of_event = next_task->tick_count();

--- a/src/ReplayTask.cc
+++ b/src/ReplayTask.cc
@@ -46,16 +46,9 @@ void ReplayTask::init_buffers_arch(remote_ptr<void> map_hint) {
 
     if (args.cloned_file_data_fd >= 0) {
       cloned_file_data_fd_child = args.cloned_file_data_fd;
-      string clone_file_name = trace_reader().file_data_clone_file_name(tuid());
-      ScopedFd clone_file(clone_file_name.c_str(), O_RDONLY);
-      int fd = remote.send_fd(clone_file);
-      if (fd != cloned_file_data_fd_child) {
-        long ret =
-            remote.infallible_syscall(syscall_number_for_dup3(arch()), fd,
-                                      cloned_file_data_fd_child, O_CLOEXEC);
-        ASSERT(this, ret == cloned_file_data_fd_child);
-        remote.infallible_syscall(syscall_number_for_close(arch()), fd);
-      }
+      cloned_file_data_fname = trace_reader().file_data_clone_file_name(tuid());
+      ScopedFd clone_file(cloned_file_data_fname.c_str(), O_RDONLY);
+      remote.infallible_send_fd_dup(clone_file, cloned_file_data_fd_child);
       fds->add_monitor(this, cloned_file_data_fd_child, new PreserveFileMonitor());
     }
   }

--- a/src/ReplayTimeline.cc
+++ b/src/ReplayTimeline.cc
@@ -80,7 +80,7 @@ bool ReplayTimeline::less_than(const Mark& m1, const Mark& m2) {
 ReplayTimeline::ReplayTimeline(std::shared_ptr<ReplaySession> session)
     : current(std::move(session)),
       breakpoints_applied(false),
-      reverse_execution_barrier_event(0) {
+      reverse_execution_barrier_event_(0) {
   current->set_visible_execution(false);
 }
 
@@ -778,7 +778,7 @@ ReplayResult ReplayTimeline::singlestep_with_breakpoints_disabled() {
 }
 
 bool ReplayTimeline::is_start_of_reverse_execution_barrier_event() {
-  if (current->trace_reader().time() != reverse_execution_barrier_event ||
+  if (current->trace_reader().time() != reverse_execution_barrier_event_ ||
       current->current_step_key().in_execution()) {
     return false;
   }

--- a/src/ReplayTimeline.h
+++ b/src/ReplayTimeline.h
@@ -159,7 +159,10 @@ public:
    * at the beginning of this event.
    */
   void set_reverse_execution_barrier_event(FrameTime event) {
-    reverse_execution_barrier_event = event;
+    reverse_execution_barrier_event_ = event;
+  }
+  FrameTime reverse_execution_barrier_event() {
+    return reverse_execution_barrier_event_;
   }
 
   // State-changing APIs. These may alter state associated with
@@ -498,7 +501,7 @@ private:
       watchpoints;
   bool breakpoints_applied;
 
-  FrameTime reverse_execution_barrier_event;
+  FrameTime reverse_execution_barrier_event_;
 
   /**
    * Checkpoints used to accelerate reverse execution.

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -2114,6 +2114,7 @@ Task::CapturedState Task::capture_state() {
   state.thread_areas = thread_areas_;
   state.desched_fd_child = desched_fd_child;
   state.cloned_file_data_fd_child = cloned_file_data_fd_child;
+  state.cloned_file_data_fname = cloned_file_data_fname;
   state.cloned_file_data_offset =
       cloned_file_data_fd_child >= 0
           ? get_fd_offset(this, cloned_file_data_fd_child)
@@ -2157,7 +2158,11 @@ void Task::copy_state(const CapturedState& state) {
       // All these fields are preserved by the fork.
       desched_fd_child = state.desched_fd_child;
       cloned_file_data_fd_child = state.cloned_file_data_fd_child;
+      cloned_file_data_fname = state.cloned_file_data_fname;
       if (cloned_file_data_fd_child >= 0) {
+        ScopedFd fd(cloned_file_data_fname.c_str(), session().as_record() ?
+          O_RDWR : O_RDONLY);
+        remote.infallible_send_fd_dup(fd, cloned_file_data_fd_child);
         remote.infallible_lseek_syscall(
             cloned_file_data_fd_child, state.cloned_file_data_offset, SEEK_SET);
       }

--- a/src/Task.h
+++ b/src/Task.h
@@ -792,6 +792,8 @@ public:
   int desched_fd_child;
   /* The child's cloned_file_data_fd */
   int cloned_file_data_fd_child;
+  /* The filename opened by the child's cloned_file_data_fd */
+  std::string cloned_file_data_fname;
 
   PerfCounters hpc;
 
@@ -843,6 +845,7 @@ public:
     uint32_t serial;
     int desched_fd_child;
     int cloned_file_data_fd_child;
+    std::string cloned_file_data_fname;
     WaitStatus wait_status;
   };
 

--- a/src/Task.h
+++ b/src/Task.h
@@ -18,6 +18,7 @@
 #include "PropertyTable.h"
 #include "Registers.h"
 #include "TaskishUid.h"
+#include "ThreadGroup.h"
 #include "TraceStream.h"
 #include "WaitStatus.h"
 #include "core.h"
@@ -843,6 +844,7 @@ public:
     ThreadLocals thread_locals;
     pid_t rec_tid;
     uint32_t serial;
+    ThreadGroupUid tguid;
     int desched_fd_child;
     int cloned_file_data_fd_child;
     std::string cloned_file_data_fname;
@@ -935,7 +937,8 @@ protected:
   virtual Task* clone(CloneReason reason, int flags, remote_ptr<void> stack,
                       remote_ptr<void> tls, remote_ptr<int> cleartid_addr,
                       pid_t new_tid, pid_t new_rec_tid, uint32_t new_serial,
-                      Session* other_session = nullptr);
+                      Session* other_session = nullptr,
+                      ThreadGroup::shr_ptr new_tg = nullptr);
 
   /**
    * Internal method called after the first wait() during a clone().
@@ -1031,7 +1034,8 @@ protected:
    */
   Task* os_fork_into(Session* session);
   static Task* os_clone_into(const CapturedState& state,
-                             AutoRemoteSyscalls& remote);
+                             AutoRemoteSyscalls& remote,
+                             ThreadGroup::shr_ptr new_tg);
 
   /**
    * Return the TraceStream that we're using, if in recording or replay.
@@ -1051,6 +1055,7 @@ protected:
   static Task* os_clone(CloneReason reason, Session* session,
                         AutoRemoteSyscalls& remote, pid_t rec_child_tid,
                         uint32_t new_serial, unsigned base_flags,
+                        ThreadGroup::shr_ptr new_tg = nullptr,
                         remote_ptr<void> stack = nullptr,
                         remote_ptr<int> ptid = nullptr,
                         remote_ptr<void> tls = nullptr,

--- a/src/ThreadGroup.cc
+++ b/src/ThreadGroup.cc
@@ -20,6 +20,7 @@ ThreadGroup::ThreadGroup(Session* session, ThreadGroup* parent, pid_t tgid,
       received_sigframe_SIGSEGV(false),
       session_(session),
       parent_(parent),
+      first_run_event_(0),
       serial(serial) {
   LOG(debug) << "creating new thread group " << tgid
              << " (real tgid:" << real_tgid << ")";

--- a/src/ThreadGroup.cc
+++ b/src/ThreadGroup.cc
@@ -9,12 +9,11 @@
 
 namespace rr {
 
-ThreadGroup::ThreadGroup(Session* session, ThreadGroup* parent, pid_t tgid,
-                         pid_t real_tgid, pid_t real_tgid_own_namespace,
+ThreadGroup::ThreadGroup(Session* session, ThreadGroup* parent,
+                         pid_t tgid, pid_t tgid_own_namespace,
                          uint32_t serial)
     : tgid(tgid),
-      real_tgid(real_tgid),
-      real_tgid_own_namespace(real_tgid_own_namespace),
+      tgid_own_namespace(tgid_own_namespace),
       dumpable(true),
       execed(false),
       received_sigframe_SIGSEGV(false),
@@ -22,12 +21,15 @@ ThreadGroup::ThreadGroup(Session* session, ThreadGroup* parent, pid_t tgid,
       parent_(parent),
       first_run_event_(0),
       serial(serial) {
-  LOG(debug) << "creating new thread group " << tgid
-             << " (real tgid:" << real_tgid << ")";
+  LOG(debug) << "creating new thread group " << tgid;
   if (parent) {
     parent->children_.insert(this);
   }
   session->on_create(this);
+}
+
+ThreadGroup::shr_ptr ThreadGroup::shared_from_this() {
+  return (*tasks.begin())->thread_group();
 }
 
 ThreadGroup::~ThreadGroup() {

--- a/src/ThreadGroup.h
+++ b/src/ThreadGroup.h
@@ -23,20 +23,23 @@ class ThreadDb;
  * Tracks a group of tasks with an associated ID, set from the
  * original "thread group leader", the child of |fork()| which became
  * the ancestor of all other threads in the group.  Each constituent
- * task must own a reference to this.
+ * task must own a reference to this. `ThreadGroup` represents the state
+ * of the thread grouping during record. During replay, we put each task
+ * into its own thread group.
  */
 class ThreadGroup : public HasTaskSet {
 public:
-  ThreadGroup(Session* session, ThreadGroup* parent, pid_t tgid,
-              pid_t real_tgid, pid_t real_tgid_own_namespace,
+  ThreadGroup(Session* session, ThreadGroup* parent,
+              pid_t tgid, pid_t thid_own_namespace,
               uint32_t serial);
   ~ThreadGroup();
 
   typedef std::shared_ptr<ThreadGroup> shr_ptr;
 
+  /* The id of this thread group (== pid of the thread group leader)
+   * (during record) */
   const pid_t tgid;
-  const pid_t real_tgid;
-  const pid_t real_tgid_own_namespace;
+  const pid_t tgid_own_namespace;
 
   WaitStatus exit_status;
 
@@ -50,6 +53,8 @@ public:
 
   FrameTime first_run_event() { return first_run_event_; }
   void set_first_run_event(FrameTime time) { first_run_event_ = time; }
+
+  shr_ptr shared_from_this();
 
   // We don't allow tasks to make themselves undumpable. If they try,
   // record that here and lie about it if necessary.

--- a/src/ThreadGroup.h
+++ b/src/ThreadGroup.h
@@ -12,6 +12,7 @@
 #include "HasTaskSet.h"
 #include "TaskishUid.h"
 #include "WaitStatus.h"
+#include "TraceFrame.h"
 
 namespace rr {
 
@@ -47,6 +48,9 @@ public:
 
   ThreadGroupUid tguid() const { return ThreadGroupUid(tgid, serial); }
 
+  FrameTime first_run_event() { return first_run_event_; }
+  void set_first_run_event(FrameTime time) { first_run_event_ = time; }
+
   // We don't allow tasks to make themselves undumpable. If they try,
   // record that here and lie about it if necessary.
   bool dumpable;
@@ -67,6 +71,8 @@ private:
   ThreadGroup* parent_;
 
   std::set<ThreadGroup*> children_;
+
+  FrameTime first_run_event_;
 
   uint32_t serial;
 };

--- a/src/test/vfork_read_clone_stress.c
+++ b/src/test/vfork_read_clone_stress.c
@@ -1,0 +1,43 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+// Global to protecte them from the compiler potentially
+// smashing them, thinking they're unused
+volatile int fd;
+volatile void* buf;
+volatile int counter;
+volatile int counter2 = 0;
+
+int main(void) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  int scratch_size = 512 * page_size;
+  fd = open("tempfile", O_RDWR | O_CREAT | O_TRUNC, 0700);
+  buf = mmap(NULL, scratch_size, PROT_READ | PROT_WRITE,
+                   MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+  test_assert(fd >= 0);
+
+  /* First, initialize the file, so the syscall buffer will attempt to
+     clone it in each thread */
+  int ret = write(fd, (void*)buf, scratch_size);
+  test_assert(ret == scratch_size);
+
+  for (counter = 0; counter < 20; ++counter) {
+    // Make sure the clone fd ends up having a different number in each task
+    open("/dev/null", O_RDONLY);
+    if (!vfork()) {
+      continue;
+    }
+    atomic_printf("child %d\n", getpid());
+    ret = lseek(fd, 0, SEEK_SET);
+    test_assert(ret == 0);
+    ret = read(fd, (void*)buf, scratch_size);
+    test_assert(ret == scratch_size);
+    if (++counter2 == counter) {
+      atomic_puts("EXIT-SUCCESS");
+    }
+    _exit(0);
+    break;
+  }
+  _exit(0);
+}

--- a/src/test/vfork_read_clone_stress.py
+++ b/src/test/vfork_read_clone_stress.py
@@ -1,0 +1,13 @@
+from util import *
+import re
+
+send_gdb('handle SIGKILL stop')
+
+send_gdb('c')
+expect_gdb('SIGKILL')
+
+send_gdb('rc')
+expect_gdb('Program stopped.')
+
+send_gdb('c')
+ok()

--- a/src/test/vfork_read_clone_stress.run
+++ b/src/test/vfork_read_clone_stress.run
@@ -1,0 +1,6 @@
+source `dirname $0`/util.sh
+
+record $TESTNAME
+TARGET_PID=$(grep 'child ' record.out | awk '{print $2}' | tail -n 5 | head -n 1)
+echo Targeting recorded pid $TARGET_PID ...
+debug vfork_read_clone_stress "-f $TARGET_PID"


### PR DESCRIPTION
This fixes #2540 and two other issues I found using the test I wrote for that issue. Details are in the commit messages, but the gist is that we need to rid ourselves of the assumption that FdTable/AddressSpace/ThreadGroups are all the same task set. I originally had a fourth commit that I thought was required, but turns out I had just written a bad test. I'm including it here for posterity. We might need it in the future, but at least for the moment, the code generated by the compiler seems to not cause issues (whereas including it might increase trace size unnecessarily and potentially cause unforeseen problems of its own).

```
commit 2e8ce978619d58991b826cdcf5fafbb560c26401
Author: Keno Fischer <keno@juliacomputing.com>
Date:   Thu May 7 02:51:21 2020 -0400

    Protect syscallbuf alt stack while in vfork

    The other task could smash it while we're not looking. While that
    task does have it's own syscallbuf alt stack, it will be running
    on the old task's alt stack as soon as it returns from the kernel.
    Whether or not that stack will be usable for a second return depends
    on the compiler, which we can't rely on.

diff --git a/src/record_syscall.cc b/src/record_syscall.cc
index d129608a..727f2a4f 100644
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2768,6 +2768,24 @@ static void prepare_clone(RecordTask* t, TaskSyscallState& syscall_state) {
     flags = SIGCHLD;
   }

+  // If we're vfork'ing, the two tasks will share the same stack. The libc
+  // is careful about not relying on the stack while inside vfork (not even
+  // for the return address), but the syscallbuf is not, so if we're in the
+  // syscallbuf, we need to protect our alt stack.
+  if (t->is_in_syscallbuf()) {
+    // Currently, we don't have a syscall hook that matches the libc clone.
+    // If we ever do, we'd have to handle that specially here.
+    ASSERT(t, flags & CLONE_VFORK);
+    remote_ptr<void> syscallbuf_stack_low = t->syscallbuf_alt_stack() - page_size();
+    remote_ptr<void> syscallbuf_stack_high = t->syscallbuf_alt_stack();
+    remote_ptr<void> sp = t->regs().sp();
+    ASSERT(t, syscallbuf_stack_low <= sp && sp <= syscallbuf_stack_high);
+    // The kernel doesn't look at this memory at all,
+    // so IN_OUT is a bit of a lie, but it has the correct behavior.
+    syscall_state.mem_ptr_parameter(syscallbuf_stack_low,
+      ParamSize(sp-syscallbuf_stack_low), IN_OUT);
+  }
+
```