### PR TITLE
Improve robustness to process death during clone

### DIFF
--- a/src/AutoRemoteSyscalls.cc
+++ b/src/AutoRemoteSyscalls.cc
@@ -544,7 +544,10 @@ int64_t AutoRemoteSyscalls::infallible_lseek_syscall(int fd, int64_t offset,
   }
 }
 
-void AutoRemoteSyscalls::check_syscall_result(long ret, int syscallno) {
+void AutoRemoteSyscalls::check_syscall_result(long ret, int syscallno, bool allow_death) {
+  if (allow_death && ret == -ESRCH) {
+    return;
+  }
   if (-4096 < ret && ret < 0) {
     string extra_msg;
     if (is_open_syscall(syscallno, arch())) {

--- a/src/AutoRemoteSyscalls.h
+++ b/src/AutoRemoteSyscalls.h
@@ -162,6 +162,17 @@ public:
   }
 
   template <typename... Rest>
+  long infallible_syscall_if_alive(int syscallno, Rest... args) {
+    Registers callregs = regs();
+    // The first syscall argument is called "arg 1", so
+    // our syscall-arg-index template parameter starts
+    // with "1".
+    long ret = syscall_helper<1>(syscallno, callregs, args...);
+    check_syscall_result(ret, syscallno, true);
+    return ret;
+  }
+
+  template <typename... Rest>
   remote_ptr<void> infallible_syscall_ptr(int syscallno, Rest... args) {
     Registers callregs = regs();
     long ret = syscall_helper<1>(syscallno, callregs, args...);
@@ -231,7 +242,7 @@ public:
 private:
   void setup_path(bool enable_singlestep_path);
 
-  void check_syscall_result(long ret, int syscallno);
+  void check_syscall_result(long ret, int syscallno, bool allow_death=false);
 
   /**
    * "Recursively" build the set of syscall registers in

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1872,7 +1872,10 @@ void RecordTask::set_tid_addr(remote_ptr<int> tid_addr) {
 void RecordTask::update_own_namespace_tid() {
   AutoRemoteSyscalls remote(this);
   own_namespace_rec_tid =
-      remote.infallible_syscall(syscall_number_for_gettid(arch()));
+      remote.infallible_syscall_if_alive(syscall_number_for_gettid(arch()));
+  if (own_namespace_rec_tid == -ESRCH) {
+    own_namespace_rec_tid = -1;
+  }
 }
 
 void RecordTask::tgkill(int sig) {

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -722,7 +722,10 @@ TraceTaskEvent TraceReader::read_task_event(FrameTime* time) {
       r.type_ = TraceTaskEvent::CLONE;
       auto clone = task.getClone();
       r.parent_tid_ = i32_to_tid(clone.getParentTid());
-      r.own_ns_tid_ = i32_to_tid(clone.getOwnNsTid());
+      // The record task could have died before we were able to compute this,
+      // which we handle fine (since we'll see the exit event right away),
+      // but we can't use i32_to_tid, which will assert if the tid is invalid.
+      r.own_ns_tid_ = (pid_t)clone.getOwnNsTid();
       r.clone_flags_ = clone.getFlags();
       LOG(debug) << "Reading event for " << task.getFrameTime()
                  << ": parent=" << r.parent_tid_ << " tid=" << r.tid_;


### PR DESCRIPTION
This happens on aarch64 for me on existing tests that test
races between coredumping signals/group exits and other system
calls. For some reason, the aarch64 kernel appears to take a
while to actually shoot down these other tasks. In particular
a clone could still go through, but then die when we try to
initialize it. I suspect the same could happen on x86 also
and of course there's always the chance of getting an external
SIGKILL, so we might as well be robust to it.