### PR TITLE
Add generic syscall numbers to syscall table

### DIFF
--- a/src/syscalls.py
+++ b/src/syscalls.py
@@ -7,16 +7,17 @@ class BaseSyscall(object):
     """
 
     # Take **kwargs and ignore to make life easier on RegularSyscall.
-    def __init__(self, x86=None, x64=None, **kwargs):
+    def __init__(self, x86=None, x64=None, generic=None, **kwargs):
         assert x86 or x64       # Must exist on one architecture.
         self.x86 = x86
         self.x64 = x64
+        self.generic = generic
         assert len(kwargs) is 0
 
 class RestartSyscall(BaseSyscall):
     """A special class for the restart_syscall syscall."""
-    def __init__(self, x86=None, x64=None):
-        BaseSyscall.__init__(self, x86=x86, x64=x64)
+    def __init__(self, x86=None, x64=None, generic=None):
+        BaseSyscall.__init__(self, x86=x86, x64=x64, generic=None)
 
 class UnsupportedSyscall(BaseSyscall):
     """A syscall that is unsupported by rr.
@@ -25,8 +26,8 @@ class UnsupportedSyscall(BaseSyscall):
     can be displayed in error messages, if nothing else.  They also serve as
     useful documentation.
     """
-    def __init__(self, x86=None, x64=None):
-        BaseSyscall.__init__(self, x86=x86, x64=x64)
+    def __init__(self, x86=None, x64=None, generic=None):
+        BaseSyscall.__init__(self, x86=x86, x64=x64, generic=None)
 
 class InvalidSyscall(UnsupportedSyscall):
     """A syscall that is unsupported by rr and unimplemented by Linux.
@@ -36,7 +37,7 @@ class InvalidSyscall(UnsupportedSyscall):
     of rr's syscall support.
     """
     def __init__(self, x86=None, x64=None):
-        UnsupportedSyscall.__init__(self, x86=x86, x64=x64)
+        UnsupportedSyscall.__init__(self, x86=x86, x64=x64, generic=None)
 
 class RegularSyscall(BaseSyscall):
     """A syscall for which replay information may be recorded automatically.
@@ -75,7 +76,7 @@ class IrregularEmulatedSyscall(BaseSyscall):
 #
 # The exit() function causes normal process termination and the value
 # of status & 0377 is returned to the parent (see wait(2)).
-exit = IrregularEmulatedSyscall(x86=1, x64=60)
+exit = IrregularEmulatedSyscall(x86=1, x64=60, generic=93)
 
 # Obsolete, glibc calls clone() instead.
 # But Google Breakpad uses it!
@@ -87,7 +88,7 @@ fork = IrregularEmulatedSyscall(x86=2, x64=57)
 # into the buffer starting at buf.
 #
 # CHECKED: (trace->recorded_regs.eax > 0)
-read = IrregularEmulatedSyscall(x86=3, x64=0)
+read = IrregularEmulatedSyscall(x86=3, x64=0, generic=63)
 
 #  ssize_t write(int fd, const void *buf, size_t count);
 #
@@ -99,7 +100,7 @@ read = IrregularEmulatedSyscall(x86=3, x64=0)
 #
 # Note: write isn't irregular per se; we hook it to redirect output
 # to stdout/stderr during replay.
-write = IrregularEmulatedSyscall(x86=4, x64=1)
+write = IrregularEmulatedSyscall(x86=4, x64=1, generic=64)
 
 #  int open(const char *pathname, int flags)
 #  int open(const char *pathname, int flags, mode_t mode)
@@ -118,7 +119,7 @@ open = IrregularEmulatedSyscall(x86=5, x64=2)
 # on the file it was associated with, and owned by the process, are
 # removed (regardless of the file descriptor that was used to obtain
 # the lock).
-close = IrregularEmulatedSyscall(x86=6, x64=3)
+close = IrregularEmulatedSyscall(x86=6, x64=3, generic=57)
 
 #  pid_t waitpid(pid_t pid, int *status, int options);
 #
@@ -154,13 +155,13 @@ unlink = EmulatedSyscall(x86=10, x64=87)
 #  int execve(const char *filename, char *const argv[], char *const envp[]);
 #
 # execve() executes the program pointed to by filename.
-execve = IrregularEmulatedSyscall(x86=11, x64=59)
+execve = IrregularEmulatedSyscall(x86=11, x64=59, generic=221)
 
 #  int chdir(const char *path);
 #
 # chdir() changes the current working directory of the calling
 # process to the directory specified in path.
-chdir = EmulatedSyscall(x86=12, x64=80)
+chdir = EmulatedSyscall(x86=12, x64=80, generic=49)
 
 #  time_t time(time_t *t);
 #
@@ -192,12 +193,12 @@ lseek = EmulatedSyscall(x86=19, x64=8)
 # getpid() returns the process ID of the calling process.  (This is
 # often used by routines that generate unique temporary
 # filenames.)
-getpid = EmulatedSyscall(x86=20, x64=39)
+getpid = EmulatedSyscall(x86=20, x64=39, generic=172)
 
-mount = EmulatedSyscall(x86=21, x64=165)
+mount = EmulatedSyscall(x86=21, x64=165, generic=40)
 umount = EmulatedSyscall(x86=22)
-setuid = EmulatedSyscall(x86=23, x64=105)
-getuid = EmulatedSyscall(x86=24, x64=102)
+setuid = EmulatedSyscall(x86=23, x64=105, generic=146)
+getuid = EmulatedSyscall(x86=24, x64=102, generic=174)
 stime = UnsupportedSyscall(x86=25)
 
 #  long ptrace(enum __ptrace_request request, pid_t pid,
@@ -208,7 +209,7 @@ stime = UnsupportedSyscall(x86=25)
 # (the "tracee"), and examine and change the tracee's memory and
 # registers.  It is primarily used to implement breakpoint debugging
 # and system call tracing.
-ptrace = IrregularEmulatedSyscall(x86=26, x64=101)
+ptrace = IrregularEmulatedSyscall(x86=26, x64=101, generic=117)
 
 #  unsigned int alarm(unsigned int seconds)
 #
@@ -252,13 +253,13 @@ access = EmulatedSyscall(x86=33, x64=21)
 
 nice = UnsupportedSyscall(x86=34)
 ftime = InvalidSyscall(x86=35)
-sync = IrregularEmulatedSyscall(x86=36, x64=162)
+sync = IrregularEmulatedSyscall(x86=36, x64=162, generic=81)
 
 #  int kill(pid_t pid, int sig)
 #
 # The kill() system call can be used to send any signal to any
 # process group or process.
-kill = EmulatedSyscall(x86=37, x64=62)
+kill = EmulatedSyscall(x86=37, x64=62, generic=129)
 
 #  int rename(const char *oldpath, const char *newpath)
 #
@@ -279,7 +280,7 @@ rmdir = EmulatedSyscall(x86=40, x64=84)
 #
 # dup() uses the lowest-numbered unused descriptor for the new
 # descriptor.
-dup = EmulatedSyscall(x86=41, x64=32)
+dup = EmulatedSyscall(x86=41, x64=32, generic=23)
 
 #  int pipe(int pipefd[2]);
 #
@@ -296,7 +297,7 @@ pipe = EmulatedSyscall(x86=42, x64=22, arg1="int[2]")
 #
 # times() stores the current process times in the struct tms that buf
 #  points to.  The struct tms is as defined in <sys/times.h>:
-times = EmulatedSyscall(x86=43, x64=100, arg1="typename Arch::tms")
+times = EmulatedSyscall(x86=43, x64=100, generic=153, arg1="typename Arch::tms")
 
 prof = InvalidSyscall(x86=44)
 
@@ -313,7 +314,7 @@ prof = InvalidSyscall(x86=44)
 # addr, when that value is reasonable, the system has enough memory,
 # and the process does not exceed its maximum data size (see
 # setrlimit(2)).
-brk = IrregularEmulatedSyscall(x86=45, x64=12)
+brk = IrregularEmulatedSyscall(x86=45, x64=12, generic=214)
 
 #  int setgid(gid_t gid)
 #
@@ -329,14 +330,14 @@ brk = IrregularEmulatedSyscall(x86=45, x64=12)
 #
 # setgid will return 0 on success, or if the process already runs
 # under the given gid.
-setgid = EmulatedSyscall(x86=46, x64=106)
+setgid = EmulatedSyscall(x86=46, x64=106, generic=144)
 
-getgid = EmulatedSyscall(x86=47, x64=104)
+getgid = EmulatedSyscall(x86=47, x64=104, generic=176)
 signal = UnsupportedSyscall(x86=48)
-geteuid = EmulatedSyscall(x86=49, x64=107)
-getegid = EmulatedSyscall(x86=50, x64=108)
-acct = EmulatedSyscall(x86=51, x64=163)
-umount2 = EmulatedSyscall(x86=52, x64=166)
+geteuid = EmulatedSyscall(x86=49, x64=107, generic=175)
+getegid = EmulatedSyscall(x86=50, x64=108, generic=177)
+acct = EmulatedSyscall(x86=51, x64=163, generic=89)
+umount2 = EmulatedSyscall(x86=52, x64=166, generic=39)
 lock = InvalidSyscall(x86=53)
 
 #  int ioctl(int d, int request, ...)
@@ -346,9 +347,9 @@ lock = InvalidSyscall(x86=53)
 # character special files (e.g., terminals) may be controlled with
 # ioctl() requests.  The argument d must be an open file descriptor.
 #
-ioctl = IrregularEmulatedSyscall(x86=54, x64=16)
+ioctl = IrregularEmulatedSyscall(x86=54, x64=16, generic=29)
 
-fcntl = IrregularEmulatedSyscall(x86=55, x64=72)
+fcntl = IrregularEmulatedSyscall(x86=55, x64=72, generic=25)
 mpx = InvalidSyscall(x86=56)
 
 #  int setpgid(pid_t pid, pid_t pgid);
@@ -363,7 +364,7 @@ mpx = InvalidSyscall(x86=56)
 # case, the pgid specifies an existing process group to be joined and
 # the session ID of that group must match the session ID of the
 # joining process.
-setpgid = EmulatedSyscall(x86=57, x64=109)
+setpgid = EmulatedSyscall(x86=57, x64=109, generic=154)
 
 ulimit = InvalidSyscall(x86=58)
 oldolduname = UnsupportedSyscall(x86=59)
@@ -373,9 +374,9 @@ oldolduname = UnsupportedSyscall(x86=59)
 # umask() sets the calling process's file mode creation mask (umask)
 # to mask & 0777 (i.e., only the file permission bits of mask are
 # used), and returns the previous value of the mask.
-umask = EmulatedSyscall(x86=60, x64=95)
+umask = EmulatedSyscall(x86=60, x64=95, generic=166)
 
-chroot = EmulatedSyscall(x86=61, x64=161)
+chroot = EmulatedSyscall(x86=61, x64=161, generic=51)
 ustat = UnsupportedSyscall(x86=62, x64=136)
 
 #  int dup2(int oldfd, int newfd)
@@ -388,7 +389,7 @@ dup2 = IrregularEmulatedSyscall(x86=63, x64=33)
 #
 # getppid() returns the process ID of the parent of the calling
 # process.
-getppid = EmulatedSyscall(x86=64, x64=110)
+getppid = EmulatedSyscall(x86=64, x64=110, generic=173)
 
 #  pid_t getpgrp(void)
 #
@@ -399,7 +400,7 @@ getpgrp = EmulatedSyscall(x86=65, x64=111)
 #
 # setsid() is used to start a new session and set the new process
 # group ID.
-setsid = EmulatedSyscall(x86=66, x64=112)
+setsid = EmulatedSyscall(x86=66, x64=112, generic=157)
 
 #  int sigaction(int signum, const struct sigaction *act, struct sigaction
 #*oldact);
@@ -418,11 +419,11 @@ sigaction = IrregularEmulatedSyscall(x86=67)
 
 sgetmask = UnsupportedSyscall(x86=68)
 ssetmask = UnsupportedSyscall(x86=69)
-setreuid = EmulatedSyscall(x86=70, x64=113)
-setregid = EmulatedSyscall(x86=71, x64=114)
+setreuid = EmulatedSyscall(x86=70, x64=113, generic=145)
+setregid = EmulatedSyscall(x86=71, x64=114, generic=143)
 sigsuspend = IrregularEmulatedSyscall(x86=72)
 sigpending = UnsupportedSyscall(x86=73)
-sethostname = EmulatedSyscall(x86=74, x64=170)
+sethostname = EmulatedSyscall(x86=74, x64=170, generic=161)
 
 #  int setrlimit(int resource, const struct rlimit *rlim)
 #
@@ -434,26 +435,26 @@ sethostname = EmulatedSyscall(x86=74, x64=170)
 # NOTE: This syscall is emulated so the limit does not apply during
 # replay. Any signals triggered due to exceeded limits are emulated
 # by other means.
-setrlimit = EmulatedSyscall(x86=75, x64=160)
+setrlimit = EmulatedSyscall(x86=75, x64=160, generic=164)
 
-getrlimit = EmulatedSyscall(x86=76, x64=97, arg2="typename Arch::rlimit")
+getrlimit = EmulatedSyscall(x86=76, x64=97, generic=163, arg2="typename Arch::rlimit")
 
 #  int getrusage(int who, struct rusage *usage)
 #
 # getrusage() returns resource usage measures for who, which can be
 # one of the following..
-getrusage = EmulatedSyscall(x86=77, x64=98, arg2="typename Arch::rusage")
+getrusage = EmulatedSyscall(x86=77, x64=98, generic=165, arg2="typename Arch::rusage")
 
 #  int gettimeofday(struct timeval *tv, struct timezone *tz);
 #
 # The functions gettimeofday() and settimeofday() can get and set the
 # time as well as a timezone.  The tv argument is a struct timeval
 # (as specified in <sys/time.h>):
-gettimeofday = EmulatedSyscall(x86=78, x64=96, arg1="typename Arch::timeval", arg2="typename Arch::timezone")
+gettimeofday = EmulatedSyscall(x86=78, x64=96, generic=169, arg1="typename Arch::timeval", arg2="typename Arch::timezone")
 
-settimeofday = UnsupportedSyscall(x86=79, x64=164)
-getgroups = IrregularEmulatedSyscall(x86=80, x64=115)
-setgroups = EmulatedSyscall(x86=81, x64=116)
+settimeofday = UnsupportedSyscall(x86=79, x64=164, generic=170)
+getgroups = IrregularEmulatedSyscall(x86=80, x64=115, generic=158)
+setgroups = EmulatedSyscall(x86=81, x64=116, generic=159)
 select = IrregularEmulatedSyscall(x86=82, x64=23)
 
 #  int symlink(const char *oldpath, const char *newpath)
@@ -474,8 +475,8 @@ oldlstat = UnsupportedSyscall(x86=84)
 readlink = IrregularEmulatedSyscall(x86=85, x64=89)
 
 uselib = UnsupportedSyscall(x86=86, x64=134)
-swapon = UnsupportedSyscall(x86=87, x64=167)
-reboot = UnsupportedSyscall(x86=88, x64=169)
+swapon = UnsupportedSyscall(x86=87, x64=167, generic=224)
+reboot = UnsupportedSyscall(x86=88, x64=169, generic=142)
 readdir = UnsupportedSyscall(x86=89)
 
 #  void *mmap2(void *addr, size_t length, int prot,int flags, int fd, off_t
@@ -486,7 +487,7 @@ readdir = UnsupportedSyscall(x86=89)
 # the file in 4096-byte units (instead of bytes, as is done by
 # mmap(2)).  This enables applications that use a 32-bit off_t to map
 # large files (up to 2^44 bytes).
-mmap = IrregularEmulatedSyscall(x86=90, x64=9)
+mmap = IrregularEmulatedSyscall(x86=90, x64=9, generic=222)
 
 #  int munmap(void *addr, size_t length)
 #
@@ -495,7 +496,7 @@ mmap = IrregularEmulatedSyscall(x86=90, x64=9)
 # the range to generate invalid memory references.  The region is
 # also automatically unmapped when the process is terminated.  On the
 # other hand, closing the file descriptor does not unmap the region.
-munmap = IrregularEmulatedSyscall(x86=91, x64=11)
+munmap = IrregularEmulatedSyscall(x86=91, x64=11, generic=215)
 
 #  int truncate(const char *path, off_t length);
 #  int ftruncate(int fd, off_t length)
@@ -503,29 +504,29 @@ munmap = IrregularEmulatedSyscall(x86=91, x64=11)
 # The truncate() and ftruncate() functions cause the regular file
 # named by path or referenced by fd to be truncated to a size of
 # precisely length bytes.
-truncate = EmulatedSyscall(x86=92, x64=76)
-ftruncate = EmulatedSyscall(x86=93, x64=77)
+truncate = EmulatedSyscall(x86=92, x64=76, generic=45)
+ftruncate = EmulatedSyscall(x86=93, x64=77, generic=46)
 
 #  int fchmod(int fd, mode_t mode);
 #
 # fchmod() changes the permissions of the file referred to by the
 # open file descriptor fd
-fchmod = EmulatedSyscall(x86=94, x64=91)
+fchmod = EmulatedSyscall(x86=94, x64=91, generic=52)
 
-fchown = EmulatedSyscall(x86=95, x64=93)
+fchown = EmulatedSyscall(x86=95, x64=93, generic=55)
 
 #  int getpriority(int which, int who);
 #
 # The scheduling priority of the process, process group, or user, as
 # indicated by which and who is obtained with the getpriority() call.
-getpriority = EmulatedSyscall(x86=96, x64=140)
+getpriority = EmulatedSyscall(x86=96, x64=140, generic=141)
 
 #  int setpriority(int which, int who, int prio);
 #
 # The scheduling priority of the process, process group, or user, as
 # indicated by which and who is obtained with the getpriority() call
 # and set with the setpriority() call.
-setpriority = IrregularEmulatedSyscall(x86=97, x64=141)
+setpriority = IrregularEmulatedSyscall(x86=97, x64=141, generic=140)
 
 profil = InvalidSyscall(x86=98)
 
@@ -535,7 +536,7 @@ profil = InvalidSyscall(x86=98)
 # system.  path is the pathname of any file within the mounted file
 # system.  buf is a pointer to a statfs structure defined
 # approximately as follows:
-statfs = EmulatedSyscall(x86=99, x64=137, arg2="struct Arch::statfs")
+statfs = EmulatedSyscall(x86=99, x64=137, generic=43, arg2="struct Arch::statfs")
 
 #  int fstatfs(int fd, struct statfs *buf)
 #
@@ -543,7 +544,7 @@ statfs = EmulatedSyscall(x86=99, x64=137, arg2="struct Arch::statfs")
 # system.  path is the pathname of any file within the
 # get_time(GET_TID(thread_id));mounted file system.  buf is a pointer
 # to a statfs structure defined approximately as follows:
-fstatfs = EmulatedSyscall(x86=100, x64=138, arg2="struct Arch::statfs")
+fstatfs = EmulatedSyscall(x86=100, x64=138, generic=44, arg2="struct Arch::statfs")
 
 ioperm = UnsupportedSyscall(x86=101, x64=173)
 
@@ -555,7 +556,7 @@ ioperm = UnsupportedSyscall(x86=101, x64=173)
 # through to the appropriate call.
 socketcall = IrregularEmulatedSyscall(x86=102)
 
-syslog = UnsupportedSyscall(x86=103, x64=103)
+syslog = UnsupportedSyscall(x86=103, x64=103, generic=116)
 
 #  int setitimer(int which, const struct itimerval *new_value, struct itimerval
 #*old_value);
@@ -563,14 +564,14 @@ syslog = UnsupportedSyscall(x86=103, x64=103)
 # The function setitimer() sets the specified timer to the value in
 # new_value.  If old_value is non-NULL, the old value of the timer is
 # stored there.
-setitimer = EmulatedSyscall(x86=104, x64=38, arg3="typename Arch::itimerval")
-getitimer = EmulatedSyscall(x86=105, x64=36, arg2="typename Arch::itimerval")
+setitimer = EmulatedSyscall(x86=104, x64=38, generic=103, arg3="typename Arch::itimerval")
+getitimer = EmulatedSyscall(x86=105, x64=36, generic=102, arg2="typename Arch::itimerval")
 stat = EmulatedSyscall(x86=106, x64=4, arg2="struct Arch::stat")
 lstat = EmulatedSyscall(x86=107, x64=6, arg2="struct Arch::stat")
-fstat = EmulatedSyscall(x86=108, x64=5, arg2="struct Arch::stat")
+fstat = EmulatedSyscall(x86=108, x64=5, generic=80, arg2="struct Arch::stat")
 olduname = UnsupportedSyscall(x86=109)
 iopl = UnsupportedSyscall(x86=110, x64=172)
-vhangup = UnsupportedSyscall(x86=111, x64=153)
+vhangup = UnsupportedSyscall(x86=111, x64=153, generic=58)
 idle = UnsupportedSyscall(x86=112)
 vm86old = UnsupportedSyscall(x86=113)
 
@@ -579,15 +580,15 @@ vm86old = UnsupportedSyscall(x86=113)
 # The wait3() and wait4() system calls are similar to waitpid(2), but
 # additionally return resource usage information about the child in
 # the structure pointed to by rusage.
-wait4 = IrregularEmulatedSyscall(x86=114, x64=61)
+wait4 = IrregularEmulatedSyscall(x86=114, x64=61, generic=260)
 
-swapoff = UnsupportedSyscall(x86=115, x64=168)
+swapoff = UnsupportedSyscall(x86=115, x64=168, generic=225)
 
 #  int sysinfo(struct sysinfo *info)
 #
 # sysinfo() provides a simple way of getting overall system
 # statistics.
-sysinfo = EmulatedSyscall(x86=116, x64=99, arg1="struct Arch::sysinfo")
+sysinfo = EmulatedSyscall(x86=116, x64=99, generic=179, arg1="struct Arch::sysinfo")
 #  int ipc(unsigned int call, int first, int second, int third, void *ptr, long
 #fifth);
 #
@@ -605,7 +606,7 @@ ipc = IrregularEmulatedSyscall(x86=117)
 # device) where that file resides.  The call blocks until the device
 # reports that the transfer has completed.  It also flushes metadata
 # information associated with the file (see stat(2))
-fsync = IrregularEmulatedSyscall(x86=118, x64=74)
+fsync = IrregularEmulatedSyscall(x86=118, x64=74, generic=82)
 
 #  int sigreturn(unsigned long __unused)
 #
@@ -628,15 +629,15 @@ sigreturn = IrregularEmulatedSyscall(x86=119)
 #
 #  long sys_clone(unsigned long clone_flags, unsigned long newsp, void __user
 #*parent_tid, void __user *child_tid, struct pt_regs *regs)
-clone = IrregularEmulatedSyscall(x86=120, x64=56)
+clone = IrregularEmulatedSyscall(x86=120, x64=56, generic=220)
 
-setdomainname = EmulatedSyscall(x86=121, x64=171)
+setdomainname = EmulatedSyscall(x86=121, x64=171, generic=162)
 
 #  int uname(struct utsname *buf)
 #
 # uname() returns system information in the structure pointed to by
 # buf. The utsname struct is defined in <sys/utsname.h>:
-uname = EmulatedSyscall(x86=122, x64=63, arg1="typename Arch::utsname")
+uname = EmulatedSyscall(x86=122, x64=63, generic=160, arg1="typename Arch::utsname")
 
 modify_ldt = IrregularEmulatedSyscall(x86=123, x64=154)
 
@@ -644,7 +645,7 @@ modify_ldt = IrregularEmulatedSyscall(x86=123, x64=154)
 #
 # adjtimex() takes a pointer to a timex structure, reads it, and returns
 # the same structure updated with the current kernel values.
-adjtimex = EmulatedSyscall(x86=124, x64=159, arg1="typename Arch::timex")
+adjtimex = EmulatedSyscall(x86=124, x64=159, generic=171, arg1="typename Arch::timex")
 
 #  int mprotect(const void *addr, size_t len, int prot)
 #
@@ -655,7 +656,7 @@ adjtimex = EmulatedSyscall(x86=124, x64=159, arg1="typename Arch::timex")
 # If the calling process tries to access memory in a manner that
 # violates the protection, then the kernel generates a SIGSEGV signal
 # for the process.
-mprotect = IrregularEmulatedSyscall(x86=125, x64=10)
+mprotect = IrregularEmulatedSyscall(x86=125, x64=10, generic=226)
 
 #  int sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
 #
@@ -666,8 +667,8 @@ mprotect = IrregularEmulatedSyscall(x86=125, x64=10)
 sigprocmask = IrregularEmulatedSyscall(x86=126)
 
 create_module = UnsupportedSyscall(x86=127, x64=174)
-init_module = UnsupportedSyscall(x86=128, x64=175)
-delete_module = UnsupportedSyscall(x86=129, x64=176)
+init_module = UnsupportedSyscall(x86=128, x64=175, generic=105)
+delete_module = UnsupportedSyscall(x86=129, x64=176, generic=106)
 get_kernel_syms = InvalidSyscall(x86=130, x64=177)
 
 #  int quotactl(int cmd, const char *special, int id, caddr_t addr);
@@ -678,27 +679,27 @@ get_kernel_syms = InvalidSyscall(x86=130, x64=177)
 # QCMD(subcmd, type) macro.  The type value is either USRQUOTA, for
 # user quotas, or GRPQUOTA, for group quotas.  The subcmd value is
 # described below.
-quotactl = IrregularEmulatedSyscall(x86=131, x64=179)
+quotactl = IrregularEmulatedSyscall(x86=131, x64=179, generic=60)
 
 #  pid_t getpgid(pid_t pid);
 #
 # getpgid() returns the PGID of the process specified by pid.  If pid
 # is zero, getpgid() the process ID of the calling process is
 # used.int getrusage(int who, struct rusage *usage);
-getpgid = EmulatedSyscall(x86=132, x64=121)
+getpgid = EmulatedSyscall(x86=132, x64=121, generic=155)
 
 #  int fchdir(int fd);
 #
 # fchdir() is identical to chdir(); the only difference is that the
 # directory is given as an open file descriptor.
-fchdir = EmulatedSyscall(x86=133, x64=81)
+fchdir = EmulatedSyscall(x86=133, x64=81, generic=50)
 
 bdflush = UnsupportedSyscall(x86=134)
 sysfs = IrregularEmulatedSyscall(x86=135, x64=139)
-personality = IrregularEmulatedSyscall(x86=136, x64=135)
+personality = IrregularEmulatedSyscall(x86=136, x64=135, generic=92)
 afs_syscall = InvalidSyscall(x86=137, x64=183)
-setfsuid = EmulatedSyscall(x86=138, x64=122)
-setfsgid = EmulatedSyscall(x86=139, x64=123)
+setfsuid = EmulatedSyscall(x86=138, x64=122, generic=151)
+setfsgid = EmulatedSyscall(x86=139, x64=123, generic=152)
 
 #  int _llseek(unsigned int fd, unsigned long offset_high, unsigned long
 #offset_low, loff_t *result, unsigned int whence);
@@ -731,7 +732,7 @@ getdents = IrregularEmulatedSyscall(x86=141, x64=78)
 # blocking.
 _newselect = IrregularEmulatedSyscall(x86=142)
 
-flock = EmulatedSyscall(x86=143, x64=73)
+flock = EmulatedSyscall(x86=143, x64=73, generic=32)
 
 #  int msync(void *addr, size_t length, int flags);
 #
@@ -741,28 +742,28 @@ flock = EmulatedSyscall(x86=143, x64=73)
 # munmap(2) is called.  To be more precise, the part of the file that
 # corresponds to the memory area starting at addr and having length
 # length is updated.
-msync = IrregularEmulatedSyscall(x86=144, x64=26)
+msync = IrregularEmulatedSyscall(x86=144, x64=26, generic=227)
 
 #  ssize_t readv(int fd, const struct iovec *iov, int iovcnt);
 #
 # The readv() system call reads iovcnt buffers from the file associated
 # with the file descriptor fd into the buffers described by iov ("scatter
 # input").
-readv = IrregularEmulatedSyscall(x86=145, x64=19)
+readv = IrregularEmulatedSyscall(x86=145, x64=19, generic=65)
 
 #  ssize_t writev(int fd, const struct iovec *iov, int iovcnt)
 #
 # The writev() function writes iovcnt buffers of data described by
 # iov to the file associated with the file descriptor fd ("gather
 # output").
-writev = IrregularEmulatedSyscall(x86=146, x64=20)
+writev = IrregularEmulatedSyscall(x86=146, x64=20, generic=66)
 
 # pid_t getsid(pid_t pid);
 #
 # getsid(0) returns the session ID of the calling process.  getsid(p)
 # returns the session ID of the process with process ID p.  (The session
 # ID of a process is the process group ID of the session leader.)
-getsid = EmulatedSyscall(x86=147, x64=124)
+getsid = EmulatedSyscall(x86=147, x64=124, generic=156)
 
 #  int fdatasync(int fd)
 #
@@ -775,7 +776,7 @@ getsid = EmulatedSyscall(x86=147, x64=124)
 # handled correctly.  On the other hand, a change to the file size
 # (st_size, as made by say ftruncate(2)), would require a metadata
 # flush
-fdatasync = IrregularEmulatedSyscall(x86=148, x64=75)
+fdatasync = IrregularEmulatedSyscall(x86=148, x64=75, generic=83)
 
 #  int _sysctl(struct __syscall_args* args);
 #
@@ -785,18 +786,18 @@ fdatasync = IrregularEmulatedSyscall(x86=148, x64=75)
 # Often not supported in modern kernels, so can return ENOSYS.
 _sysctl = IrregularEmulatedSyscall(x86=149, x64=156)
 
-mlock = EmulatedSyscall(x86=150, x64=149)
-munlock = EmulatedSyscall(x86=151, x64=150)
-mlockall = EmulatedSyscall(x86=152, x64=151)
-munlockall = EmulatedSyscall(x86=153, x64=152)
-sched_setparam = EmulatedSyscall(x86=154, x64=142)
+mlock = EmulatedSyscall(x86=150, x64=149, generic=228)
+munlock = EmulatedSyscall(x86=151, x64=150, generic=229)
+mlockall = EmulatedSyscall(x86=152, x64=151, generic=230)
+munlockall = EmulatedSyscall(x86=153, x64=152, generic=231)
+sched_setparam = EmulatedSyscall(x86=154, x64=142, generic=118)
 
 #  int sched_getparam(pid_t pid, struct sched_param *param)
 #
 # sched_getparam() retrieves the scheduling parameters for the
 # process i dentified by pid.  If pid is zero, then the parameters of
 # the calling process are retrieved.
-sched_getparam = EmulatedSyscall(x86=155, x64=143, arg2="typename Arch::sched_param")
+sched_getparam = EmulatedSyscall(x86=155, x64=143, generic=121, arg2="typename Arch::sched_param")
 
 #  int sched_setscheduler(pid_t pid, int policy, const struct sched_param
 #*param);
@@ -806,35 +807,35 @@ sched_getparam = EmulatedSyscall(x86=155, x64=143, arg2="typename Arch::sched_pa
 # If pid equals zero, the scheduling policy and parameters of the
 # calling process will be set.  The interpretation of the argument
 # param depends on the selected policy.
-sched_setscheduler = EmulatedSyscall(x86=156, x64=144)
+sched_setscheduler = EmulatedSyscall(x86=156, x64=144, generic=119)
 
 #  int sched_getscheduler(pid_t pid);
 #
 # sched_getscheduler() queries the scheduling policy currently
 # applied to the process identified by pid.  If pid equals zero, the
 # policy of the calling process will be retrieved.
-sched_getscheduler = EmulatedSyscall(x86=157, x64=145)
+sched_getscheduler = EmulatedSyscall(x86=157, x64=145, generic=120)
 
 #  int sched_yield(void)
 #
 # sched_yield() causes the calling thread to relinquish the CPU.  The
 # thread is moved to the end of the queue for its static priority and
 # a new thread gets to run.
-sched_yield = IrregularEmulatedSyscall(x86=158, x64=24)
+sched_yield = IrregularEmulatedSyscall(x86=158, x64=24, generic=124)
 
 #  int sched_get_priority_max(int policy)
 #
 # sched_get_priority_max() returns the maximum priority value that
 # can be used with the scheduling algorithm identified by policy.
-sched_get_priority_max = EmulatedSyscall(x86=159, x64=146)
+sched_get_priority_max = EmulatedSyscall(x86=159, x64=146, generic=125)
 
 #  int sched_get_priority_min(int policy)
 #
 # sched_get_priority_min() returns the minimum priority value that
 # can be used with the scheduling algorithm identified by policy.
-sched_get_priority_min = EmulatedSyscall(x86=160, x64=147)
+sched_get_priority_min = EmulatedSyscall(x86=160, x64=147, generic=126)
 
-sched_rr_get_interval = UnsupportedSyscall(x86=161, x64=148)
+sched_rr_get_interval = UnsupportedSyscall(x86=161, x64=148, generic=127)
 
 #  int nanosleep(const struct timespec *req, struct timespec *rem)
 #
@@ -844,7 +845,7 @@ sched_rr_get_interval = UnsupportedSyscall(x86=161, x64=148)
 # the calling thread or that ter- minates the process.
 #
 # CHECKED: trace->recorded_regs.ecx != NULL
-nanosleep = IrregularEmulatedSyscall(x86=162, x64=35)
+nanosleep = IrregularEmulatedSyscall(x86=162, x64=35, generic=101)
 
 #  void *mremap(void *old_address, size_t old_size, size_t new_size, int flags,
 #... ( void *new_address ));
@@ -852,15 +853,15 @@ nanosleep = IrregularEmulatedSyscall(x86=162, x64=35)
 # mremap() expands (or shrinks) an existing memory mapping,
 # potentially moving it at the same time (controlled by the flags
 # argument and the available virtual address space).
-mremap = IrregularEmulatedSyscall(x86=163, x64=25)
+mremap = IrregularEmulatedSyscall(x86=163, x64=25, generic=216)
 
 #  int setresuid(uid_t ruid, uid_t euid, uid_t suid);
 #
 # setresuid() sets the real user ID, the effective user ID, and the
 # saved set-user-ID of the calling process.
-setresuid = EmulatedSyscall(x86=164, x64=117)
+setresuid = EmulatedSyscall(x86=164, x64=117, generic=147)
 
-getresuid = EmulatedSyscall(x86=165, x64=118, arg1="typename Arch::legacy_uid_t", arg2="typename Arch::legacy_uid_t", arg3="typename Arch::legacy_uid_t")
+getresuid = EmulatedSyscall(x86=165, x64=118, generic=148, arg1="typename Arch::legacy_uid_t", arg2="typename Arch::legacy_uid_t", arg3="typename Arch::legacy_uid_t")
 vm86 = UnsupportedSyscall(x86=166)
 query_module = UnsupportedSyscall(x86=167, x64=178)
 
@@ -880,15 +881,15 @@ query_module = UnsupportedSyscall(x86=167, x64=178)
 # XXX is this irregular?  CHECKED: (trace->recorded_regs.eax > 0)
 poll = IrregularEmulatedSyscall(x86=168, x64=7)
 
-nfsservctl = UnsupportedSyscall(x86=169, x64=180)
+nfsservctl = UnsupportedSyscall(x86=169, x64=180, generic=42)
 
 #  int setresgid(gid_t rgid, gid_t egid, gid_t sgid);
 #
 # setresgid() sets the real GID, effective GID, and saved
 # set-group-ID of the calling process.
-setresgid = EmulatedSyscall(x86=170, x64=119)
+setresgid = EmulatedSyscall(x86=170, x64=119, generic=149)
 
-getresgid = EmulatedSyscall(x86=171, x64=120, arg1="typename Arch::legacy_gid_t", arg2="typename Arch::legacy_gid_t", arg3="typename Arch::legacy_gid_t")
+getresgid = EmulatedSyscall(x86=171, x64=120, generic=150, arg1="typename Arch::legacy_gid_t", arg2="typename Arch::legacy_gid_t", arg3="typename Arch::legacy_gid_t")
 
 #  int prctl(int option, unsigned long arg2, unsigned long arg3, unsigned long
 #arg4, unsigned long arg5);
@@ -897,11 +898,11 @@ getresgid = EmulatedSyscall(x86=171, x64=120, arg1="typename Arch::legacy_gid_t"
 # values defined in <linux/prctl.h>), and further arguments with a
 # significance depending on the first one.
 #
-prctl = IrregularEmulatedSyscall(x86=172, x64=157)
+prctl = IrregularEmulatedSyscall(x86=172, x64=157, generic=167)
 
-rt_sigreturn = IrregularEmulatedSyscall(x86=173, x64=15)
-rt_sigaction = IrregularEmulatedSyscall(x86=174, x64=13)
-rt_sigprocmask = IrregularEmulatedSyscall(x86=175, x64=14)
+rt_sigreturn = IrregularEmulatedSyscall(x86=173, x64=15, generic=139)
+rt_sigaction = IrregularEmulatedSyscall(x86=174, x64=13, generic=134)
+rt_sigprocmask = IrregularEmulatedSyscall(x86=175, x64=14, generic=135)
 
 #  int sigpending(sigset_t *set);
 #
@@ -909,7 +910,7 @@ rt_sigprocmask = IrregularEmulatedSyscall(x86=175, x64=14)
 # delivery to the calling thread (i.e., the signals which have been
 # raised while blocked).  The mask of pending signals is returned in
 # set.
-rt_sigpending = IrregularEmulatedSyscall(x86=176, x64=127)
+rt_sigpending = IrregularEmulatedSyscall(x86=176, x64=127, generic=136)
 
 #  int sigtimedwait(const sigset_t *set, siginfo_t *info,
 #                   const struct timespec *timeout);
@@ -923,7 +924,7 @@ rt_sigpending = IrregularEmulatedSyscall(x86=176, x64=127)
 # except that it has an additional argument, timeout, which specifies
 # a minimum interval for which the thread is suspended waiting for a
 # signal.
-rt_sigtimedwait = IrregularEmulatedSyscall(x86=177, x64=128)
+rt_sigtimedwait = IrregularEmulatedSyscall(x86=177, x64=128, generic=137)
 
 #  int sigsuspend(const sigset_t *mask);
 #
@@ -931,14 +932,14 @@ rt_sigtimedwait = IrregularEmulatedSyscall(x86=177, x64=128)
 # process with the mask given by mask and then suspends the process
 # until delivery of a signal whose action is to invoke a signal
 # handler or to terminate a process.
-rt_sigsuspend = IrregularEmulatedSyscall(x86=179, x64=130)
+rt_sigsuspend = IrregularEmulatedSyscall(x86=179, x64=130, generic=133)
 
 #  ssize_t pread(int fd, void *buf, size_t count, off_t offset);
 #
 # pread, pwrite - read from or write to a file descriptor at a given
 # offset
-pread64 = IrregularEmulatedSyscall(x86=180, x64=17)
-pwrite64 = EmulatedSyscall(x86=181, x64=18)
+pread64 = IrregularEmulatedSyscall(x86=180, x64=17, generic=67)
+pwrite64 = EmulatedSyscall(x86=181, x64=18, generic=68)
 
 chown = EmulatedSyscall(x86=182, x64=92)
 
@@ -948,10 +949,10 @@ chown = EmulatedSyscall(x86=182, x64=92)
 # absolute pathname that is the current working directory of the
 # calling process.  The pathname is returned as the function result
 # and via the argument buf, if present.
-getcwd = IrregularEmulatedSyscall(x86=183, x64=79)
+getcwd = IrregularEmulatedSyscall(x86=183, x64=79, generic=17)
 
-capget = IrregularEmulatedSyscall(x86=184, x64=125)
-capset = EmulatedSyscall(x86=185, x64=126)
+capget = IrregularEmulatedSyscall(x86=184, x64=125, generic=90)
+capset = EmulatedSyscall(x86=185, x64=126, generic=91)
 
 #  int sigaltstack(const stack_t *ss, stack_t *oss)
 #
@@ -960,9 +961,9 @@ capset = EmulatedSyscall(x86=185, x64=126)
 # stack.  An alternate signal stack is used during the execution of a
 # signal handler if the establishment of that handler (see
 # sigaction(2)) requested it.
-sigaltstack = EmulatedSyscall(x86=186, x64=131, arg2="typename Arch::stack_t")
+sigaltstack = EmulatedSyscall(x86=186, x64=131, generic=132, arg2="typename Arch::stack_t")
 
-sendfile = IrregularEmulatedSyscall(x86=187, x64=40)
+sendfile = IrregularEmulatedSyscall(x86=187, x64=40, generic=71)
 getpmsg = InvalidSyscall(x86=188, x64=181)
 putpmsg = InvalidSyscall(x86=189, x64=182)
 vfork = IrregularEmulatedSyscall(x86=190, x64=58)
@@ -1082,8 +1083,8 @@ setuid32 = EmulatedSyscall(x86=213)
 setgid32 = EmulatedSyscall(x86=214)
 setfsuid32 = EmulatedSyscall(x86=215)
 setfsgid32 = EmulatedSyscall(x86=216)
-pivot_root = EmulatedSyscall(x86=217, x64=155)
-mincore = IrregularEmulatedSyscall(x86=218, x64=27)
+pivot_root = EmulatedSyscall(x86=217, x64=155, generic=41)
+mincore = IrregularEmulatedSyscall(x86=218, x64=27, generic=232)
 
 #  int madvise(void *addr, size_t length, int advice);
 #
@@ -1095,9 +1096,9 @@ mincore = IrregularEmulatedSyscall(x86=218, x64=27)
 # techniques.
 # The man page says "This call does not influence the semantics of the
 # application (except in the case of MADV_DONTNEED)", but that is a lie.
-madvise = IrregularEmulatedSyscall(x86=219, x64=28)
+madvise = IrregularEmulatedSyscall(x86=219, x64=28, generic=233)
 
-getdents64 = IrregularEmulatedSyscall(x86=220, x64=217)
+getdents64 = IrregularEmulatedSyscall(x86=220, x64=217, generic=61)
 
 #  int fcntl(int fd, int cmd, ... ( arg ));
 #
@@ -1113,7 +1114,7 @@ fcntl64 = IrregularEmulatedSyscall(x86=221)
 #  pid_t gettid(void);
 #
 # gettid() returns the caller's thread ID (TID).
-gettid = EmulatedSyscall(x86=224, x64=186)
+gettid = EmulatedSyscall(x86=224, x64=186, generic=178)
 
 #  ssize_t readahead(int fd, off64_t offset, size_t count);
 #
@@ -1128,11 +1129,11 @@ gettid = EmulatedSyscall(x86=224, x64=186)
 # readahead() does not read beyond the end of the file.  readahead()
 # blocks until the specified data has been read.  The current file
 # offset of the open file referred to by fd is left unchanged.
-readahead = EmulatedSyscall(x86=225, x64=187)
+readahead = EmulatedSyscall(x86=225, x64=187, generic=213)
 
-setxattr = EmulatedSyscall(x86=226, x64=188)
-lsetxattr = EmulatedSyscall(x86=227, x64=189)
-fsetxattr = EmulatedSyscall(x86=228, x64=190)
+setxattr = EmulatedSyscall(x86=226, x64=188, generic=5)
+lsetxattr = EmulatedSyscall(x86=227, x64=189, generic=6)
+fsetxattr = EmulatedSyscall(x86=228, x64=190, generic=7)
 
 #  ssize_t getxattr(const char *path, const char *name,
 #                   void *value, size_t size);
@@ -1144,17 +1145,17 @@ fsetxattr = EmulatedSyscall(x86=228, x64=190)
 # getxattr() retrieves the value of the extended attribute identified
 # by name and associated with the given path in the file system. The
 # length of the attribute value is returned.
-getxattr = IrregularEmulatedSyscall(x86=229, x64=191)
-lgetxattr = IrregularEmulatedSyscall(x86=230, x64=192)
-fgetxattr = IrregularEmulatedSyscall(x86=231, x64=193)
+getxattr = IrregularEmulatedSyscall(x86=229, x64=191, generic=8)
+lgetxattr = IrregularEmulatedSyscall(x86=230, x64=192, generic=9)
+fgetxattr = IrregularEmulatedSyscall(x86=231, x64=193, generic=10)
 
-listxattr = IrregularEmulatedSyscall(x86=232, x64=194)
-llistxattr = IrregularEmulatedSyscall(x86=233, x64=195)
-flistxattr = IrregularEmulatedSyscall(x86=234, x64=196)
-removexattr = EmulatedSyscall(x86=235, x64=197)
-lremovexattr = EmulatedSyscall(x86=236, x64=198)
-fremovexattr = EmulatedSyscall(x86=237, x64=199)
-tkill = EmulatedSyscall(x86=238, x64=200)
+listxattr = IrregularEmulatedSyscall(x86=232, x64=194, generic=11)
+llistxattr = IrregularEmulatedSyscall(x86=233, x64=195, generic=12)
+flistxattr = IrregularEmulatedSyscall(x86=234, x64=196, generic=13)
+removexattr = EmulatedSyscall(x86=235, x64=197, generic=14)
+lremovexattr = EmulatedSyscall(x86=236, x64=198, generic=15)
+fremovexattr = EmulatedSyscall(x86=237, x64=199, generic=16)
+tkill = EmulatedSyscall(x86=238, x64=200, generic=130)
 
 # ssize_t sendfile64 (int __out_fd, int __in_fd, __off64_t *__offset, size_t
 #__count);
@@ -1177,7 +1178,7 @@ sendfile64 = IrregularEmulatedSyscall(x86=239)
 # locations will correspond for futex() calls).  This system call is
 # typically used to implement the contended case of a lock in shared
 # memory, as described in futex(7).
-futex = IrregularEmulatedSyscall(x86=240, x64=202)
+futex = IrregularEmulatedSyscall(x86=240, x64=202, generic=98)
 
 #  int sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask);
 #
@@ -1186,7 +1187,7 @@ futex = IrregularEmulatedSyscall(x86=240, x64=202)
 # calling process is used.  The argument cpusetsize is the length
 # (in bytes) of the data pointed to by mask.  Normally this argument
 # would be specified as sizeof(cpu_set_t).
-sched_setaffinity = IrregularEmulatedSyscall(x86=241, x64=203)
+sched_setaffinity = IrregularEmulatedSyscall(x86=241, x64=203, generic=122)
 
 #  int sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask);
 #
@@ -1194,7 +1195,7 @@ sched_setaffinity = IrregularEmulatedSyscall(x86=241, x64=203)
 # ID is pid into the cpu_set_t structure pointed to by mask.  The
 # cpusetsize argument specifies the size (in bytes) of mask.  If pid
 # is zero, then the mask of the calling process is returned.
-sched_getaffinity = IrregularEmulatedSyscall(x86=242, x64=204)
+sched_getaffinity = IrregularEmulatedSyscall(x86=242, x64=204, generic=123)
 
 # int sched_setattr(pid_t pid, struct sched_attr *attr,
 #                   unsigned int flags);
@@ -1206,7 +1207,7 @@ sched_getaffinity = IrregularEmulatedSyscall(x86=242, x64=204)
 #
 # XXX Do we want to restrict somehow how this plays with rr's
 # scheduling?
-sched_setattr = EmulatedSyscall(x86=351, x64=314)
+sched_setattr = EmulatedSyscall(x86=351, x64=314, generic=274)
 
 # int sched_getattr(pid_t pid, struct sched_attr *attr,
 #                   unsigned int size, unsigned int flags);
@@ -1215,7 +1216,7 @@ sched_setattr = EmulatedSyscall(x86=351, x64=314)
 # associated attributes for the thread whose ID is specified in pid.
 # If pid equals zero, the scheduling policy and attributes of the call‐
 # ing thread will be retrieved.
-sched_getattr = IrregularEmulatedSyscall(x86=352, x64=315)
+sched_getattr = IrregularEmulatedSyscall(x86=352, x64=315, generic=275)
 
 #  int set_thread_area(struct user_desc *u_info)
 #
@@ -1232,25 +1233,25 @@ sched_getattr = IrregularEmulatedSyscall(x86=352, x64=315)
 set_thread_area = IrregularEmulatedSyscall(x86=243, x64=205)
 
 get_thread_area = IrregularEmulatedSyscall(x86=244, x64=211)
-io_setup = IrregularEmulatedSyscall(x86=245, x64=206)
-io_destroy = UnsupportedSyscall(x86=246, x64=207)
-io_getevents = UnsupportedSyscall(x86=247, x64=208)
-io_submit = UnsupportedSyscall(x86=248, x64=209)
-io_cancel = UnsupportedSyscall(x86=249, x64=210)
+io_setup = IrregularEmulatedSyscall(x86=245, x64=206, generic=0)
+io_destroy = UnsupportedSyscall(x86=246, x64=207, generic=1)
+io_getevents = UnsupportedSyscall(x86=247, x64=208, generic=4)
+io_submit = UnsupportedSyscall(x86=248, x64=209, generic=2)
+io_cancel = UnsupportedSyscall(x86=249, x64=210, generic=3)
 
 #  int posix_fadvise(int fd, off_t offset, off_t len, int advice);
 #
 # Programs can use posix_fadvise() to announce an intention to access
 # file data in a specific pattern in the future, thus allowing the
 # kernel to perform appropriate optimizations.
-fadvise64 = EmulatedSyscall(x86=250, x64=221)
+fadvise64 = EmulatedSyscall(x86=250, x64=221, generic=223)
 
 #  void exit_group(int status)
 #
 # This system call is equivalent to exit(2) except that it terminates
 # not only the calling thread, but all threads in the calling
 # process's thread group.
-exit_group = IrregularEmulatedSyscall(x86=252, x64=231)
+exit_group = IrregularEmulatedSyscall(x86=252, x64=231, generic=94)
 
 lookup_dcookie = UnsupportedSyscall(x86=253, x64=212)
 
@@ -1269,7 +1270,7 @@ epoll_create = EmulatedSyscall(x86=254, x64=213)
 # This system call performs control operations on the epoll instance
 # referred to by the file descriptor epfd.  It requests that the
 # operation op be performed for the target file descriptor, fd.
-epoll_ctl = EmulatedSyscall(x86=255, x64=233)
+epoll_ctl = EmulatedSyscall(x86=255, x64=233, generic=21)
 
 #  int epoll_wait(int epfd, struct epoll_event *events, int maxevents, int
 #timeout);
@@ -1283,7 +1284,7 @@ epoll_ctl = EmulatedSyscall(x86=255, x64=233)
 # XXX is this irregular?  CHECKED: (trace->recorded_regs.eax >= 0)
 epoll_wait = IrregularEmulatedSyscall(x86=256, x64=232)
 
-remap_file_pages = UnsupportedSyscall(x86=257, x64=216)
+remap_file_pages = UnsupportedSyscall(x86=257, x64=216, generic=234)
 
 #  long set_tid_address(int *tidptr);
 #
@@ -1296,20 +1297,20 @@ remap_file_pages = UnsupportedSyscall(x86=257, x64=216)
 #
 # When set_child_tid is set, the very first thing the new process
 # does is writing its PID at this address.
-set_tid_address = EmulatedSyscall(x86=258, x64=218)
+set_tid_address = EmulatedSyscall(x86=258, x64=218, generic=96)
 
-timer_create = EmulatedSyscall(x86=259, x64=222, arg3="typename Arch::__kernel_timer_t")
-timer_settime = EmulatedSyscall(x86=260, x64=223, arg4="typename Arch::itimerspec")
-timer_gettime = EmulatedSyscall(x86=261, x64=224, arg2="typename Arch::itimerspec")
-timer_getoverrun = EmulatedSyscall(x86=262, x64=225)
-timer_delete = EmulatedSyscall(x86=263, x64=226)
-clock_settime = UnsupportedSyscall(x86=264, x64=227)
+timer_create = EmulatedSyscall(x86=259, x64=222, generic=107, arg3="typename Arch::__kernel_timer_t")
+timer_settime = EmulatedSyscall(x86=260, x64=223, generic=110, arg4="typename Arch::itimerspec")
+timer_gettime = EmulatedSyscall(x86=261, x64=224, generic=108, arg2="typename Arch::itimerspec")
+timer_getoverrun = EmulatedSyscall(x86=262, x64=225, generic=109)
+timer_delete = EmulatedSyscall(x86=263, x64=226, generic=111)
+clock_settime = UnsupportedSyscall(x86=264, x64=227, generic=112)
 
 #  int clock_gettime(clockid_t clk_id, struct timespec *tp);
 #
 # The functions clock_gettime() and clock_settime() retrieve and set
 # the time of the specified clock clk_id.
-clock_gettime = EmulatedSyscall(x86=265, x64=228, arg2="typename Arch::timespec")
+clock_gettime = EmulatedSyscall(x86=265, x64=228, generic=113, arg2="typename Arch::timespec")
 
 #  int clock_getres(clockid_t clk_id, struct timespec *res)
 #
@@ -1320,9 +1321,9 @@ clock_gettime = EmulatedSyscall(x86=265, x64=228, arg2="typename Arch::timespec"
 # particular process.  If the time value pointed to by the argument
 # tp of clock_settime() is not a multiple of res, then it is
 # truncated to a multiple of res.
-clock_getres = EmulatedSyscall(x86=266, x64=229, arg2="typename Arch::timespec")
+clock_getres = EmulatedSyscall(x86=266, x64=229, generic=114, arg2="typename Arch::timespec")
 
-clock_nanosleep = IrregularEmulatedSyscall(x86=267, x64=230)
+clock_nanosleep = IrregularEmulatedSyscall(x86=267, x64=230, generic=115)
 
 #  int statfs(const char *path, struct statfs *buf)
 #
@@ -1343,7 +1344,7 @@ fstatfs64 = EmulatedSyscall(x86=269, arg3="struct Arch::statfs64")
 # to send a signal to a process (i.e., thread group) as a whole, and
 # the signal will be delivered to an arbitrary thread within that
 # process.)
-tgkill = EmulatedSyscall(x86=270, x64=234)
+tgkill = EmulatedSyscall(x86=270, x64=234, generic=131)
 
 #  int utimes(const char *filename, const struct timeval times[2])
 #
@@ -1356,18 +1357,18 @@ utimes = EmulatedSyscall(x86=271, x64=235)
 fadvise64_64 = EmulatedSyscall(x86=272)
 
 vserver = InvalidSyscall(x86=273, x64=236)
-mbind = EmulatedSyscall(x86=274, x64=237)
-get_mempolicy = IrregularEmulatedSyscall(x86=275, x64=239)
-set_mempolicy = EmulatedSyscall(x86=276, x64=238)
+mbind = EmulatedSyscall(x86=274, x64=237, generic=235)
+get_mempolicy = IrregularEmulatedSyscall(x86=275, x64=239, generic=236)
+set_mempolicy = EmulatedSyscall(x86=276, x64=238, generic=237)
 
-mq_open = EmulatedSyscall(x86=277, x64=240)
-mq_unlink = EmulatedSyscall(x86=278, x64=241)
-mq_timedsend = EmulatedSyscall(x86=279, x64=242)
-mq_timedreceive = IrregularEmulatedSyscall(x86=280, x64=243)
-mq_notify = EmulatedSyscall(x86=281, x64=244)
-mq_getsetattr = EmulatedSyscall(x86=282, x64=245, arg3="struct Arch::mq_attr")
+mq_open = EmulatedSyscall(x86=277, x64=240, generic=180)
+mq_unlink = EmulatedSyscall(x86=278, x64=241, generic=181)
+mq_timedsend = EmulatedSyscall(x86=279, x64=242, generic=182)
+mq_timedreceive = IrregularEmulatedSyscall(x86=280, x64=243, generic=183)
+mq_notify = EmulatedSyscall(x86=281, x64=244, generic=184)
+mq_getsetattr = EmulatedSyscall(x86=282, x64=245, generic=185, arg3="struct Arch::mq_attr")
 
-kexec_load = UnsupportedSyscall(x86=283, x64=246)
+kexec_load = UnsupportedSyscall(x86=283, x64=246, generic=104)
 
 #  int waitid(idtype_t idtype, id_t id, siginfo_t *infop, int options);
 #
@@ -1377,13 +1378,13 @@ kexec_load = UnsupportedSyscall(x86=283, x64=246)
 # distinguish this case from that where a child was in a waitable
 # state, zero out the si_pid field before the call and check for a
 # nonzero value in this field after the call returns.
-waitid = IrregularEmulatedSyscall(x86=284, x64=247)
+waitid = IrregularEmulatedSyscall(x86=284, x64=247, generic=95)
 
-add_key = EmulatedSyscall(x86=286, x64=248)
-request_key = UnsupportedSyscall(x86=287, x64=249)
-keyctl = IrregularEmulatedSyscall(x86=288, x64=250)
-ioprio_set = UnsupportedSyscall(x86=289, x64=251)
-ioprio_get = UnsupportedSyscall(x86=290, x64=252)
+add_key = EmulatedSyscall(x86=286, x64=248, generic=217)
+request_key = UnsupportedSyscall(x86=287, x64=249, generic=218)
+keyctl = IrregularEmulatedSyscall(x86=288, x64=250, generic=219)
+ioprio_set = UnsupportedSyscall(x86=289, x64=251, generic=30)
+ioprio_get = UnsupportedSyscall(x86=290, x64=252, generic=31)
 
 #  int inotify_init(void)
 #
@@ -1400,33 +1401,33 @@ inotify_init = EmulatedSyscall(x86=291, x64=253)
 # list is to be modified.  The events to be monitored for pathname
 # are specified in the mask bit-mask argument.  See inotify(7) for a
 # description of the bits that can be set in mask.
-inotify_add_watch = EmulatedSyscall(x86=292, x64=254)
+inotify_add_watch = EmulatedSyscall(x86=292, x64=254, generic=27)
 
 #  int inotify_rm_watch(int fd, uint32_t wd)
 #
 # inotify_rm_watch() removes the watch associated with the watch
 # descriptor wd from the inotify instance associated with the file
 # descriptor fd.
-inotify_rm_watch = EmulatedSyscall(x86=293, x64=255)
+inotify_rm_watch = EmulatedSyscall(x86=293, x64=255, generic=28)
 
-migrate_pages = UnsupportedSyscall(x86=294, x64=256)
+migrate_pages = UnsupportedSyscall(x86=294, x64=256, generic=238)
 
 #  int openat(int dirfd, const char *pathname, int flags);
 #  int openat(int dirfd, const char *pathname, int flags, mode_t mode);
 #
 # The openat() system call operates in exactly the same way as
 # open(2), except for the differences described in this manual page.
-openat = IrregularEmulatedSyscall(x86=295, x64=257)
+openat = IrregularEmulatedSyscall(x86=295, x64=257, generic=56)
 
 #  int mkdirat(int dirfd, const char *pathname, mode_t mode);
 #
 # The mkdirat() system call operates in exactly the same way as
 # mkdir(2), except for the differences described in this manual
 # page....
-mkdirat = EmulatedSyscall(x86=296, x64=258)
+mkdirat = EmulatedSyscall(x86=296, x64=258, generic=34)
 
-mknodat = EmulatedSyscall(x86=297, x64=259)
-fchownat = EmulatedSyscall(x86=298, x64=260)
+mknodat = EmulatedSyscall(x86=297, x64=259, generic=33)
+fchownat = EmulatedSyscall(x86=298, x64=260, generic=54)
 futimesat = UnsupportedSyscall(x86=299, x64=261)
 
 #  int fstatat(int dirfd, const char *pathname, struct stat *buf, int flags);
@@ -1434,7 +1435,7 @@ futimesat = UnsupportedSyscall(x86=299, x64=261)
 # The fstatat() system call operates in exactly the same way as
 # stat(2), except for the differences described in this manual
 # page....
-fstatat64 = EmulatedSyscall(x86=300, x64=262, arg3="struct Arch::stat64")
+fstatat64 = EmulatedSyscall(x86=300, x64=262, generic=79, arg3="struct Arch::stat64")
 
 #  int unlinkat(int dirfd, const char *pathname, int flags)
 #
@@ -1442,26 +1443,26 @@ fstatat64 = EmulatedSyscall(x86=300, x64=262, arg3="struct Arch::stat64")
 # either unlink(2) or rmdir(2) (depending on whether or not flags
 # includes the AT_REMOVEDIR flag) except for the differences
 # described in this manual page.
-unlinkat = EmulatedSyscall(x86=301, x64=263)
+unlinkat = EmulatedSyscall(x86=301, x64=263, generic=35)
 
-renameat = EmulatedSyscall(x86=302, x64=264)
-linkat = EmulatedSyscall(x86=303, x64=265)
-symlinkat = EmulatedSyscall(x86=304, x64=266)
-readlinkat = IrregularEmulatedSyscall(x86=305, x64=267)
-fchmodat = EmulatedSyscall(x86=306, x64=268)
+renameat = EmulatedSyscall(x86=302, x64=264, generic=38)
+linkat = EmulatedSyscall(x86=303, x64=265, generic=37)
+symlinkat = EmulatedSyscall(x86=304, x64=266, generic=36)
+readlinkat = IrregularEmulatedSyscall(x86=305, x64=267, generic=78)
+fchmodat = EmulatedSyscall(x86=306, x64=268, generic=53)
 
 #  int faccessat(int dirfd, const char *pathname, int mode, int flags)
 #
 # The faccessat() system call operates in exactly the same way as
 # access(2), except for the differences described in this manual
 # page....
-faccessat = EmulatedSyscall(x86=307, x64=269)
+faccessat = EmulatedSyscall(x86=307, x64=269, generic=48)
 
-pselect6 = IrregularEmulatedSyscall(x86=308, x64=270)
+pselect6 = IrregularEmulatedSyscall(x86=308, x64=270, generic=72)
 
-ppoll = IrregularEmulatedSyscall(x86=309, x64=271)
+ppoll = IrregularEmulatedSyscall(x86=309, x64=271, generic=73)
 
-unshare = EmulatedSyscall(x86=310, x64=272)
+unshare = EmulatedSyscall(x86=310, x64=272, generic=97)
 
 #  long set_robust_list(struct robust_list_head *head, size_t len)
 #
@@ -1472,9 +1473,9 @@ unshare = EmulatedSyscall(x86=310, x64=272)
 #
 # set_robust_list sets the head of the list of robust futexes owned
 # by the current thread to head.  len is the size of *head.
-set_robust_list = EmulatedSyscall(x86=311, x64=273)
+set_robust_list = EmulatedSyscall(x86=311, x64=273, generic=99)
 
-get_robust_list = EmulatedSyscall(x86=312, x64=274, arg2="typename Arch::unsigned_word", arg3="typename Arch::size_t")
+get_robust_list = EmulatedSyscall(x86=312, x64=274, generic=100, arg2="typename Arch::unsigned_word", arg3="typename Arch::size_t")
 
 #  ssize_t splice(int fd_in, loff_t *off_in, int fd_out, loff_t *off_out,
 #size_t len, unsigned int flags);
@@ -1492,14 +1493,14 @@ get_robust_list = EmulatedSyscall(x86=312, x64=274, arg2="typename Arch::unsigne
 # NOTE: Technically, the following implementation is unsound for
 # programs that splice with stdin/stdout/stderr and have output
 # redirected during replay.  But, *crickets*.
-splice = IrregularEmulatedSyscall(x86=313, x64=275)
+splice = IrregularEmulatedSyscall(x86=313, x64=275, generic=76)
 
-sync_file_range = IrregularEmulatedSyscall(x86=314, x64=277)
-tee = UnsupportedSyscall(x86=315, x64=276)
-vmsplice = UnsupportedSyscall(x86=316, x64=278)
-move_pages = UnsupportedSyscall(x86=317, x64=279)
-getcpu = EmulatedSyscall(x86=318, x64=309, arg1="unsigned int", arg2="unsigned int")
-epoll_pwait = IrregularEmulatedSyscall(x86=319, x64=281)
+sync_file_range = IrregularEmulatedSyscall(x86=314, x64=277, generic=84)
+tee = UnsupportedSyscall(x86=315, x64=276, generic=77)
+vmsplice = UnsupportedSyscall(x86=316, x64=278, generic=75)
+move_pages = UnsupportedSyscall(x86=317, x64=279, generic=239)
+getcpu = EmulatedSyscall(x86=318, x64=309, generic=168, arg1="unsigned int", arg2="unsigned int")
+epoll_pwait = IrregularEmulatedSyscall(x86=319, x64=281, generic=22)
 
 #  int utimensat(int dirfd, const char *pathname, const struct timespec
 #times[2], int flags);
@@ -1508,7 +1509,7 @@ epoll_pwait = IrregularEmulatedSyscall(x86=319, x64=281)
 # nanosecond precision.  This contrasts with the historical utime(2)
 # and utimes(2), which permit only second and microsecond precision,
 # respectively, when setting file timestamps.
-utimensat = EmulatedSyscall(x86=320, x64=280)
+utimensat = EmulatedSyscall(x86=320, x64=280, generic=88)
 
 #  int signalfd(int fd, const sigset_t *mask, int flags);
 # There are two underlying Linux system calls: signalfd() and the more
@@ -1522,7 +1523,7 @@ signalfd = EmulatedSyscall(x86=321, x64=282)
 #
 # timerfd_create() creates a new timer object, and returns a file
 # descriptor that refers to that timer.
-timerfd_create = EmulatedSyscall(x86=322, x64=283)
+timerfd_create = EmulatedSyscall(x86=322, x64=283, generic=85)
 
 eventfd = EmulatedSyscall(x86=323, x64=284)
 
@@ -1531,7 +1532,7 @@ eventfd = EmulatedSyscall(x86=323, x64=284)
 # fallocate() allows the caller to directly manipulate the allocated
 # disk space for the file referred to by fd for the byte range
 # starting at offset and continuing for len bytes
-fallocate = EmulatedSyscall(x86=324, x64=285)
+fallocate = EmulatedSyscall(x86=324, x64=285, generic=47)
 
 #  int timerfd_settime(int fd, int flags,
 #                      const struct itimerspec *new_value,
@@ -1539,14 +1540,14 @@ fallocate = EmulatedSyscall(x86=324, x64=285)
 #
 # timerfd_settime() arms (starts) or disarms (stops) the timer
 # referred to by the file descriptor fd.
-timerfd_settime = EmulatedSyscall(x86=325, x64=286, arg4="typename Arch::itimerspec")
+timerfd_settime = EmulatedSyscall(x86=325, x64=286, generic=86, arg4="typename Arch::itimerspec")
 
 #  int timerfd_gettime(int fd, struct itimerspec *curr_value);
 #
 # timerfd_gettime() returns, in curr_value, an itimerspec structure
 # that contains the current setting of the timer referred to by the
 # file descriptor fd.
-timerfd_gettime = EmulatedSyscall(x86=326, x64=287, arg2="typename Arch::itimerspec")
+timerfd_gettime = EmulatedSyscall(x86=326, x64=287, generic=87, arg2="typename Arch::itimerspec")
 
 #  int signalfd(int fd, const sigset_t *mask, int flags);
 # There are two underlying Linux system calls: signalfd() and the more
@@ -1554,7 +1555,7 @@ timerfd_gettime = EmulatedSyscall(x86=326, x64=287, arg2="typename Arch::itimers
 # argument. The latter system call implements the flags values described
 # above. Starting with glibc 2.9, the signalfd() wrapper function will
 # use signalfd4() where it is available.
-signalfd4 = EmulatedSyscall(x86=327, x64=289)
+signalfd4 = EmulatedSyscall(x86=327, x64=289, generic=74)
 
 #  int eventfd(unsigned int initval, int flags);
 #
@@ -1564,7 +1565,7 @@ signalfd4 = EmulatedSyscall(x86=327, x64=289)
 # unsigned 64-bit integer (uint64_t) counter that is maintained by
 # the kernel.  This counter is initialized with the value specified
 # in the argument initval.
-eventfd2 = EmulatedSyscall(x86=328, x64=290)
+eventfd2 = EmulatedSyscall(x86=328, x64=290, generic=19)
 
 #  int epoll_create1(int flags);
 #
@@ -1572,20 +1573,20 @@ eventfd2 = EmulatedSyscall(x86=328, x64=290)
 # if the passed flag value is 0, they are completely identical.  The
 # flag argument can be used to set the close-on-exec flag on the new
 # file descriptor.
-epoll_create1 = EmulatedSyscall(x86=329, x64=291)
+epoll_create1 = EmulatedSyscall(x86=329, x64=291, generic=20)
 
-dup3 = IrregularEmulatedSyscall(x86=330, x64=292)
+dup3 = IrregularEmulatedSyscall(x86=330, x64=292, generic=24)
 
 #  int pipe2(int pipefd[2], int flags)
 #
 # If flags is 0, then pipe2() is the same as pipe().  The following
 # values can be bitwise ORed in flags to obtain different behavior...
-pipe2 = EmulatedSyscall(x86=331, x64=293, arg1="int[2]")
+pipe2 = EmulatedSyscall(x86=331, x64=293, generic=59, arg1="int[2]")
 
-inotify_init1 = EmulatedSyscall(x86=332, x64=294)
+inotify_init1 = EmulatedSyscall(x86=332, x64=294, generic=26)
 
-preadv = IrregularEmulatedSyscall(x86=333, x64=295)
-pwritev = EmulatedSyscall(x86=334, x64=296)
+preadv = IrregularEmulatedSyscall(x86=333, x64=295, generic=69)
+pwritev = EmulatedSyscall(x86=334, x64=296, generic=70)
 
 #  int rt_sigqueueinfo(pid_t tgid, int sig, siginfo_t *uinfo);
 #  int rt_tgsigqueueinfo(pid_t tgid, pid_t tid, int sig,
@@ -1596,8 +1597,8 @@ pwritev = EmulatedSyscall(x86=334, x64=296)
 # or thread.  The receiver of the signal can obtain the accompanying
 # data by establishing a signal handler with the sigaction(2)
 # SA_SIGINFO flag.
-rt_sigqueueinfo = EmulatedSyscall(x86=178, x64=129)
-rt_tgsigqueueinfo = EmulatedSyscall(x86=335, x64=297)
+rt_sigqueueinfo = EmulatedSyscall(x86=178, x64=129, generic=138)
+rt_tgsigqueueinfo = EmulatedSyscall(x86=335, x64=297, generic=240)
 
 #  int perf_event_open(struct perf_event_attr *attr,
 #                      pid_t pid, int cpu, int group_fd,
@@ -1606,7 +1607,7 @@ rt_tgsigqueueinfo = EmulatedSyscall(x86=335, x64=297)
 # Given a list of parameters, perf_event_open() returns a file
 # descriptor, for use in subsequent system calls (read(2), mmap(2),
 # prctl(2), fcntl(2), etc.).
-perf_event_open = IrregularEmulatedSyscall(x86=336, x64=298)
+perf_event_open = IrregularEmulatedSyscall(x86=336, x64=298, generic=241)
 
 #  int recvmmsg(int sockfd, struct mmsghdr *msgvec,
 #               unsigned int vlen, unsigned int flags,
@@ -1617,10 +1618,10 @@ perf_event_open = IrregularEmulatedSyscall(x86=336, x64=298)
 # a single system call.  (This has performance benefits for some
 # applications.)  A further extension over recvmsg(2) is support for
 # a timeout on the receive operation.
-recvmmsg = IrregularEmulatedSyscall(x86=337, x64=299)
+recvmmsg = IrregularEmulatedSyscall(x86=337, x64=299, generic=243)
 
-fanotify_init = EmulatedSyscall(x86=338, x64=300)
-fanotify_mark = EmulatedSyscall(x86=339, x64=301)
+fanotify_init = EmulatedSyscall(x86=338, x64=300, generic=262)
+fanotify_mark = EmulatedSyscall(x86=339, x64=301, generic=263)
 
 #  int prlimit(pid_t pid, int resource, const struct rlimit *new_limit, struct
 #rlimit *old_limit);
@@ -1633,12 +1634,12 @@ fanotify_mark = EmulatedSyscall(x86=339, x64=301)
 # can set a limit on the stack size that will trigger a synchronous SIGSEGV,
 # and we expect synchronous SIGSEGVs to be triggered by the kernel
 # during replay.
-prlimit64 = EmulatedSyscall(x86=340, x64=302, arg4="typename Arch::rlimit64")
+prlimit64 = EmulatedSyscall(x86=340, x64=302, generic=261, arg4="typename Arch::rlimit64")
 
-name_to_handle_at = IrregularEmulatedSyscall(x86=341, x64=303)
-open_by_handle_at = EmulatedSyscall(x86=342, x64=304)
-clock_adjtime = EmulatedSyscall(x86=343, x64=305, arg2="typename Arch::timex")
-syncfs = IrregularEmulatedSyscall(x86=344, x64=306)
+name_to_handle_at = IrregularEmulatedSyscall(x86=341, x64=303, generic=264)
+open_by_handle_at = EmulatedSyscall(x86=342, x64=304, generic=265)
+clock_adjtime = EmulatedSyscall(x86=343, x64=305, generic=266, arg2="typename Arch::timex")
+syncfs = IrregularEmulatedSyscall(x86=344, x64=306, generic=267)
 
 #  int sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
 #               unsigned int flags);
@@ -1647,33 +1648,33 @@ syncfs = IrregularEmulatedSyscall(x86=344, x64=306)
 # allows the caller to transmit multiple messages on a socket using a
 # single system call.  (This has performance benefits for some
 # applications.)
-sendmmsg = IrregularEmulatedSyscall(x86=345, x64=307)
+sendmmsg = IrregularEmulatedSyscall(x86=345, x64=307, generic=269)
 
-setns = EmulatedSyscall(x86=346, x64=308)
-process_vm_readv = IrregularEmulatedSyscall(x86=347, x64=310)
-process_vm_writev = IrregularEmulatedSyscall(x86=348, x64=311)
-kcmp = EmulatedSyscall(x86=349, x64=312)
-finit_module = UnsupportedSyscall(x86=350, x64=313)
-renameat2 = EmulatedSyscall(x86=353, x64=316)
-seccomp = IrregularEmulatedSyscall(x86=354, x64=317)
-getrandom = IrregularEmulatedSyscall(x86=355, x64=318)
-memfd_create = IrregularEmulatedSyscall(x86=356, x64=319)
+setns = EmulatedSyscall(x86=346, x64=308, generic=268)
+process_vm_readv = IrregularEmulatedSyscall(x86=347, x64=310, generic=270)
+process_vm_writev = IrregularEmulatedSyscall(x86=348, x64=311, generic=271)
+kcmp = EmulatedSyscall(x86=349, x64=312, generic=272)
+finit_module = UnsupportedSyscall(x86=350, x64=313, generic=273)
+renameat2 = EmulatedSyscall(x86=353, x64=316, generic=276)
+seccomp = IrregularEmulatedSyscall(x86=354, x64=317, generic=277)
+getrandom = IrregularEmulatedSyscall(x86=355, x64=318, generic=278)
+memfd_create = IrregularEmulatedSyscall(x86=356, x64=319, generic=279)
 arch_prctl = IrregularEmulatedSyscall(x86=384, x64=158)
 
-bpf = IrregularEmulatedSyscall(x86=357, x64=321)
-execveat = UnsupportedSyscall(x86=358, x64=322)
-userfaultfd = UnsupportedSyscall(x86=374, x64=323)
-membarrier = EmulatedSyscall(x86=375, x64=324)
-mlock2 = UnsupportedSyscall(x86=376, x64=325)
-copy_file_range = IrregularEmulatedSyscall(x86=377, x64=326)
-preadv2 = UnsupportedSyscall(x86=378, x64=327)
-pwritev2 = UnsupportedSyscall(x86=379, x64=328)
-pkey_mprotect = UnsupportedSyscall(x86=380, x64=329)
-pkey_alloc = UnsupportedSyscall(x86=381, x64=330)
-pkey_free = UnsupportedSyscall(x86=382, x64=331)
-statx = EmulatedSyscall(x86=383, x64=332, arg5="typename Arch::statx_struct")
-io_pgetevents = UnsupportedSyscall(x86=385, x64=333)
-rseq = UnsupportedSyscall(x86=386, x64=334)
+bpf = IrregularEmulatedSyscall(x86=357, x64=321, generic=280)
+execveat = UnsupportedSyscall(x86=358, x64=322, generic=281)
+userfaultfd = UnsupportedSyscall(x86=374, x64=323, generic=282)
+membarrier = EmulatedSyscall(x86=375, x64=324, generic=283)
+mlock2 = UnsupportedSyscall(x86=376, x64=325, generic=284)
+copy_file_range = IrregularEmulatedSyscall(x86=377, x64=326, generic=285)
+preadv2 = UnsupportedSyscall(x86=378, x64=327, generic=286)
+pwritev2 = UnsupportedSyscall(x86=379, x64=328, generic=287)
+pkey_mprotect = UnsupportedSyscall(x86=380, x64=329, generic=288)
+pkey_alloc = UnsupportedSyscall(x86=381, x64=330, generic=289)
+pkey_free = UnsupportedSyscall(x86=382, x64=331, generic=290)
+statx = EmulatedSyscall(x86=383, x64=332, generic=291, arg5="typename Arch::statx_struct")
+io_pgetevents = UnsupportedSyscall(x86=385, x64=333, generic=292)
+rseq = UnsupportedSyscall(x86=386, x64=334, generic=293)
 
 clock_gettime64 = EmulatedSyscall(x86=403, arg2="typename Arch::Arch64::timespec")
 clock_settime64 = UnsupportedSyscall(x86=404)
@@ -1697,62 +1698,62 @@ futex_time64 = IrregularEmulatedSyscall(x86=422)
 sched_rr_get_interval_time64 = UnsupportedSyscall(x86=423)
 
 # x86-64 decided to skip ahead here to catchup
-pidfd_send_signal = UnsupportedSyscall(x86=424, x64=424)
-io_uring_setup = UnsupportedSyscall(x86=425, x64=425)
-io_uring_enter = UnsupportedSyscall(x86=426, x64=426)
-io_uring_register = UnsupportedSyscall(x86=427, x64=427)
-open_tree = UnsupportedSyscall(x86=428, x64=428)
-move_mount = UnsupportedSyscall(x86=429, x64=429)
-fsopen = UnsupportedSyscall(x86=430, x64=430)
-fsconfig = UnsupportedSyscall(x86=431, x64=431)
-fsmount = UnsupportedSyscall(x86=432, x64=432)
-fspick = UnsupportedSyscall(x86=433, x64=433)
+pidfd_send_signal = UnsupportedSyscall(x86=424, x64=424, generic=424)
+io_uring_setup = UnsupportedSyscall(x86=425, x64=425, generic=425)
+io_uring_enter = UnsupportedSyscall(x86=426, x64=426, generic=426)
+io_uring_register = UnsupportedSyscall(x86=427, x64=427, generic=427)
+open_tree = UnsupportedSyscall(x86=428, x64=428, generic=428)
+move_mount = UnsupportedSyscall(x86=429, x64=429, generic=429)
+fsopen = UnsupportedSyscall(x86=430, x64=430, generic=430)
+fsconfig = UnsupportedSyscall(x86=431, x64=431, generic=431)
+fsmount = UnsupportedSyscall(x86=432, x64=432, generic=432)
+fspick = UnsupportedSyscall(x86=433, x64=433, generic=433)
 
 # restart_syscall is a little special.
-restart_syscall = RestartSyscall(x86=0, x64=219)
+restart_syscall = RestartSyscall(x86=0, x64=219, generic=128)
 
 # Internal rr syscall numbers.
 # These syscall numbers must be the same across all architectures.
-rrcall_init_preload = IrregularEmulatedSyscall(x86=1000, x64=1000)
-rrcall_init_buffers = IrregularEmulatedSyscall(x86=1001, x64=1001)
-rrcall_notify_syscall_hook_exit = IrregularEmulatedSyscall(x86=1002, x64=1002)
-rrcall_notify_control_msg = IrregularEmulatedSyscall(x86=1003, x64=1003)
-rrcall_reload_auxv = IrregularEmulatedSyscall(x86=1004, x64=1004)
-rrcall_mprotect_record = IrregularEmulatedSyscall(x86=1005, x64=1005)
-rrcall_notify_stap_semaphore_added = IrregularEmulatedSyscall(x86=1006, x64=1006)
-rrcall_notify_stap_semaphore_removed = IrregularEmulatedSyscall(x86=1007, x64=1007)
+rrcall_init_preload = IrregularEmulatedSyscall(x86=1000, x64=1000, generic=1000)
+rrcall_init_buffers = IrregularEmulatedSyscall(x86=1001, x64=1001, generic=1001)
+rrcall_notify_syscall_hook_exit = IrregularEmulatedSyscall(x86=1002, x64=1002, generic=1002)
+rrcall_notify_control_msg = IrregularEmulatedSyscall(x86=1003, x64=1003, generic=1003)
+rrcall_reload_auxv = IrregularEmulatedSyscall(x86=1004, x64=1004, generic=1004)
+rrcall_mprotect_record = IrregularEmulatedSyscall(x86=1005, x64=1005, generic=1005)
+rrcall_notify_stap_semaphore_added = IrregularEmulatedSyscall(x86=1006, x64=1006, generic=1006)
+rrcall_notify_stap_semaphore_removed = IrregularEmulatedSyscall(x86=1007, x64=1007, generic=1007)
 
 # These syscalls are also subsumed under socketcall on x86.
-socket = EmulatedSyscall(x86=359, x64=41)
-connect = IrregularEmulatedSyscall(x86=362, x64=42)
-accept = IrregularEmulatedSyscall(x64=43)
-sendto = IrregularEmulatedSyscall(x86=369, x64=44)
-recvfrom = IrregularEmulatedSyscall(x86=371, x64=45)
-sendmsg = IrregularEmulatedSyscall(x86=370, x64=46)
-recvmsg = IrregularEmulatedSyscall(x86=372, x64=47)
-shutdown = EmulatedSyscall(x86=373, x64=48)
-bind = EmulatedSyscall(x86=361, x64=49)
-listen = EmulatedSyscall(x86=363, x64=50)
-getsockname = IrregularEmulatedSyscall(x86=367, x64=51)
-getpeername = IrregularEmulatedSyscall(x86=368, x64=52)
-socketpair = EmulatedSyscall(x86=360, x64=53, arg4="int[2]")
-setsockopt = IrregularEmulatedSyscall(x86=366, x64=54)
-getsockopt = IrregularEmulatedSyscall(x86=365, x64=55)
-accept4 = IrregularEmulatedSyscall(x86=364, x64=288)
+socket = EmulatedSyscall(x86=359, x64=41, generic=198)
+connect = IrregularEmulatedSyscall(x86=362, x64=42, generic=203)
+accept = IrregularEmulatedSyscall(x64=43, generic=202)
+sendto = IrregularEmulatedSyscall(x86=369, x64=44, generic=206)
+recvfrom = IrregularEmulatedSyscall(x86=371, x64=45, generic=207)
+sendmsg = IrregularEmulatedSyscall(x86=370, x64=46, generic=211)
+recvmsg = IrregularEmulatedSyscall(x86=372, x64=47, generic=212)
+shutdown = EmulatedSyscall(x86=373, x64=48, generic=210)
+bind = EmulatedSyscall(x86=361, x64=49, generic=200)
+listen = EmulatedSyscall(x86=363, x64=50, generic=201)
+getsockname = IrregularEmulatedSyscall(x86=367, x64=51, generic=204)
+getpeername = IrregularEmulatedSyscall(x86=368, x64=52, generic=205)
+socketpair = EmulatedSyscall(x86=360, x64=53, generic=199, arg4="int[2]")
+setsockopt = IrregularEmulatedSyscall(x86=366, x64=54, generic=208)
+getsockopt = IrregularEmulatedSyscall(x86=365, x64=55, generic=209)
+accept4 = IrregularEmulatedSyscall(x86=364, x64=288, generic=242)
 
 # These syscalls are subsumed under ipc on x86.
-shmget = EmulatedSyscall(x64=29)
-shmat = IrregularEmulatedSyscall(x64=30)
-shmctl = IrregularEmulatedSyscall(x64=31)
-semget = EmulatedSyscall(x64=64)
-semop = IrregularEmulatedSyscall(x64=65)
-semctl = IrregularEmulatedSyscall(x64=66)
-shmdt = IrregularEmulatedSyscall(x64=67)
-msgget = EmulatedSyscall(x64=68)
-msgsnd = IrregularEmulatedSyscall(x64=69)
-msgrcv = IrregularEmulatedSyscall(x64=70)
-msgctl = IrregularEmulatedSyscall(x64=71)
-semtimedop = IrregularEmulatedSyscall(x64=220)
+shmget = EmulatedSyscall(x64=29, generic=194)
+shmat = IrregularEmulatedSyscall(x64=30, generic=196)
+shmctl = IrregularEmulatedSyscall(x64=31, generic=195)
+semget = EmulatedSyscall(x64=64, generic=190)
+semop = IrregularEmulatedSyscall(x64=65, generic=193)
+semctl = IrregularEmulatedSyscall(x64=66, generic=191)
+shmdt = IrregularEmulatedSyscall(x64=67, generic=197)
+msgget = EmulatedSyscall(x64=68, generic=186)
+msgsnd = IrregularEmulatedSyscall(x64=69, generic=189)
+msgrcv = IrregularEmulatedSyscall(x64=70, generic=188)
+msgctl = IrregularEmulatedSyscall(x64=71, generic=187)
+semtimedop = IrregularEmulatedSyscall(x64=220, generic=192)
 
 # These syscalls simply don't exist on x86.
 tuxcall = InvalidSyscall(x64=184)


### PR DESCRIPTION
These "generic" syscall numbers are in use by newer architectures
such as aarch64 (ref #1373). They are defined in the following file
in the linux kernel:
https://github.com/torvalds/linux/blob/master/include/uapi/asm-generic/unistd.h