### PR TITLE
Clean up misc x86 assumptions

### DIFF
--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -670,7 +670,7 @@ public:
   }
 
   static remote_ptr<void> preload_thread_locals_start() {
-    return rr_page_start() + PAGE_SIZE;
+    return rr_page_start() + rr_page_size();
   }
   static uint32_t preload_thread_locals_size() {
     return PRELOAD_THREAD_LOCALS_SIZE;

--- a/src/AutoRemoteSyscalls.cc
+++ b/src/AutoRemoteSyscalls.cc
@@ -588,7 +588,7 @@ void AutoRemoteSyscalls::finish_direct_mmap(
    * recording. */
   {
     AutoRestoreMem child_str(*this, backing_file_name.c_str());
-    fd = infallible_syscall(syscall_number_for_open(arch()),
+    fd = infallible_syscall(syscall_number_for_openat(arch()), -1,
                             child_str.get().as_int(),
                             backing_file_open_flags);
   }

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -68,7 +68,7 @@ ReplaySession::MemoryRanges ReplaySession::always_free_address_space(
   // Assume 64-bit address spaces with the 47-bit user-space limitation,
   // for now.
   remote_ptr<void> addressable_max = uintptr_t(
-      sizeof(void*) == 8 ? uint64_t(1) << 47 : (uint64_t(1) << 32) - PAGE_SIZE);
+      sizeof(void*) == 8 ? uint64_t(1) << 47 : (uint64_t(1) << 32) - page_size());
   result.insert(MemoryRange(addressable_min, addressable_max));
   TraceReader tmp_reader(reader);
   bool found;

--- a/src/ReplayTask.cc
+++ b/src/ReplayTask.cc
@@ -158,7 +158,7 @@ bool ReplayTask::post_vm_clone(CloneReason reason, int flags, Task* origin) {
     TraceReader::MappedData data;
     KernelMapping km = trace_reader().read_mapped_region(&data);
     ASSERT(this, km.start() == AddressSpace::preload_thread_locals_start() &&
-           km.size() == PAGE_SIZE);
+           km.size() == page_size());
     return true;
   }
 

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -109,6 +109,7 @@ static inline const char* extract_file_name(const char* s) {
 
 /* Must match generate_rr_page.py */
 #define RR_PAGE_ADDR 0x70000000
+#define RR_PAGE_SIZE 4096
 #define RR_PAGE_SYSCALL_STUB_SIZE 3
 #define RR_PAGE_SYSCALL_INSTRUCTION_END 2
 #define RR_PAGE_SYSCALL_ADDR(index)                                            \
@@ -126,7 +127,7 @@ static inline const char* extract_file_name(const char* s) {
 
 /* PRELOAD_THREAD_LOCALS_ADDR should not change.
  * Tools depend on this address. */
-#define PRELOAD_THREAD_LOCALS_ADDR (RR_PAGE_ADDR + PAGE_SIZE)
+#define PRELOAD_THREAD_LOCALS_ADDR (RR_PAGE_ADDR + RR_PAGE_SIZE)
 #define PRELOAD_THREAD_LOCALS_SIZE 104
 
 /* "Magic" (rr-implemented) syscalls that we use to initialize the

--- a/src/preload/syscallbuf.c
+++ b/src/preload/syscallbuf.c
@@ -45,7 +45,6 @@
  * wrapper.
  */
 
-#define PAGE_SIZE 4096
 #include <dlfcn.h>
 #include <limits.h>
 #include <asm/errno.h>

--- a/src/test/blacklist.c
+++ b/src/test/blacklist.c
@@ -11,16 +11,18 @@ int main(void) {
 
   open(file_name, O_CREAT | O_WRONLY, 0700);
 
+#ifdef SYS_open
   fd = syscall(SYS_open, file_name, O_RDONLY);
   test_assert(fd < 0);
   test_assert(errno == ENOENT);
+#endif
 
   fd = syscall(SYS_openat, AT_FDCWD, file_name, O_RDONLY);
   test_assert(fd < 0);
   test_assert(errno == ENOENT);
 
   getcwd(buf, PATH_MAX);
-  dirfd = syscall(SYS_open, buf, O_PATH);
+  dirfd = syscall(SYS_openat, -1, buf, O_PATH);
   test_assert(dirfd >= 0);
   fd = syscall(SYS_openat, dirfd, "rr-test-blacklist-file_name", O_RDONLY);
   test_assert(fd < 0);

--- a/src/test/block.c
+++ b/src/test/block.c
@@ -232,8 +232,10 @@ static void* reader_thread(__attribute__((unused)) void* dontcare) {
     arg.except = NULL;
     arg.timeout = &tv;
     ret = syscall(SYS_select, &arg);
-#else
+#elif defined(SYS_select)
     ret = syscall(SYS_select, sock + 1, &fds, NULL, NULL, &tv);
+#else
+    ret = syscall(SYS_pselect6, sock + 1, &fds, NULL, NULL, &tv, NULL);
 #endif
     atomic_printf("r:   ... returned %d; tv { %ld, %ld }\n", ret, tv.tv_sec,
                   tv.tv_usec);

--- a/src/test/eventfd.c
+++ b/src/test/eventfd.c
@@ -13,7 +13,9 @@ static void do_test(int fd) {
 }
 
 int main(void) {
+#ifdef SYS_eventfd
   do_test(syscall(SYS_eventfd, 0));
+#endif
   do_test(eventfd(0, 0));
 
   atomic_puts("EXIT-SUCCESS");

--- a/src/test/mmap_shared_dev_zero.c
+++ b/src/test/mmap_shared_dev_zero.c
@@ -7,14 +7,15 @@
 #include <sys/stat.h>
 
 int main(void) {
+  size_t page_size = sysconf(_SC_PAGE_SIZE);
   int fd = open("/dev/zero", O_RDWR);
-  void* p1 = mmap(0, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  void* p1 = mmap(0, page_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   assert(p1 != MAP_FAILED);
-  void* p2 = mmap(0, PAGE_SIZE, PROT_READ, MAP_SHARED, fd, 0);
+  void* p2 = mmap(0, page_size, PROT_READ, MAP_SHARED, fd, 0);
   assert(p2 != MAP_FAILED);
   assert(p1 != p2);
 
-  memset(p1, 0xdd, PAGE_SIZE);
+  memset(p1, 0xdd, page_size);
   // Verify that these mappings are not connected.
   assert(*(long*)p2 == 0);
   atomic_printf("EXIT-SUCCESS");

--- a/src/test/mmap_shared_multiple.c
+++ b/src/test/mmap_shared_multiple.c
@@ -6,10 +6,11 @@ int main(void) {
   char* p;
   char* q;
 
-  p = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  p = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS,
            -1, 0);
   test_assert(p != MAP_FAILED);
-  q = mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS,
+  q = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS,
            -1, 0);
   test_assert(q != MAP_FAILED);
 

--- a/src/test/proc_fds.c
+++ b/src/test/proc_fds.c
@@ -56,7 +56,7 @@ int main(void) {
   pthread_barrier_wait(&bar);
 
   const char proc_fd_path[] = "/proc/self/fd";
-  int fd = syscall(SYS_open, proc_fd_path, O_DIRECTORY);
+  int fd = syscall(SYS_openat, -1, proc_fd_path, O_DIRECTORY);
   test_assert(fd >= 0);
 
   char buf[128];

--- a/src/test/string_instructions_watch.c
+++ b/src/test/string_instructions_watch.c
@@ -55,7 +55,8 @@ static void string_store(char* dest, uintptr_t a, uintptr_t size, int unit,
 }
 
 int main(void) {
-  buf = (char*)mmap(NULL, PAGE_SIZE, PROT_READ | PROT_WRITE,
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  buf = (char*)mmap(NULL, page_size, PROT_READ | PROT_WRITE,
                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
 
   string_store(buf, to_uintptr("aaaaaaaa"), 16, 1, 1);


### PR DESCRIPTION
This collects all the x86 assumptions I encountered while porting rr to aarch64
that are not part of the core rr logic. That said, I disabled a good number
of tests in my porting effort, so several of them certainly still have x86
assumptions or are x86 specific.