### PR TITLE
Refactor bpkt insn logic to handle non-x86 breakpoints

### DIFF
--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -631,9 +631,6 @@ public:
   bool has_breakpoints() { return !breakpoints.empty(); }
   bool has_watchpoints() { return !watchpoints.empty(); }
 
-  // Encoding of the |int $3| instruction.
-  static const uint8_t breakpoint_insn = 0xCC;
-
   ScopedFd& mem_fd() { return child_mem_fd; }
   void set_mem_fd(ScopedFd&& fd) { child_mem_fd = std::move(fd); }
 
@@ -935,18 +932,14 @@ private:
       return user_count > 0 ? BKPT_USER : BKPT_INTERNAL;
     }
 
-    size_t data_length() { return 1; }
-    uint8_t* original_data() { return &overwritten_data; }
+    uint8_t* original_data() { return overwritten_data; }
 
     // "Refcounts" of breakpoints set at |addr|.  The breakpoint
     // object must be unique since we have to save the overwritten
     // data, and we can't enforce the order in which breakpoints
     // are set/removed.
     int internal_count, user_count;
-    uint8_t overwritten_data;
-    static_assert(sizeof(overwritten_data) ==
-                      sizeof(AddressSpace::breakpoint_insn),
-                  "Must have the same size.");
+    uint8_t overwritten_data[MAX_BKPT_INSTRUCTION_LENGTH];
 
     int* counter(BreakpointType which) {
       DEBUG_ASSERT(BKPT_INTERNAL == which || BKPT_USER == which);

--- a/src/GdbServer.cc
+++ b/src/GdbServer.cc
@@ -629,7 +629,7 @@ void GdbServer::dispatch_debugger_request(Session& session,
       return;
     }
     case DREQ_SET_SW_BREAK: {
-      ASSERT(target, req.watch().kind == sizeof(AddressSpace::breakpoint_insn))
+      ASSERT(target, req.watch().kind == bkpt_instruction_length(target->arch()))
           << "Debugger setting bad breakpoint insn";
       // Mirror all breakpoint/watchpoint sets/unsets to the target process
       // if it's not part of the timeline (i.e. it's a diversion).

--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -165,6 +165,20 @@ ssize_t syscall_instruction_length(SupportedArch arch) {
   }
 }
 
+ssize_t bkpt_instruction_length(SupportedArch arch) {
+  ssize_t val = 0;
+  switch (arch) {
+    case x86_64:
+    case x86:
+      val = 1;
+      break;
+    default:
+      DEBUG_ASSERT(0 && "Need to define bkpt instruction length");
+  }
+  DEBUG_ASSERT(val <= MAX_BKPT_INSTRUCTION_LENGTH);
+  return val;
+}
+
 ssize_t movrm_instruction_length(SupportedArch arch) {
   switch (arch) {
     case x86:

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -2007,6 +2007,14 @@ std::vector<uint8_t> syscall_instruction(SupportedArch arch);
 ssize_t syscall_instruction_length(SupportedArch arch);
 
 /**
+ * Return the length of the breakpoint instruction.
+ */
+ssize_t bkpt_instruction_length(SupportedArch arch);
+
+// The maximum breakpoint instruction length for any architecture
+static const int MAX_BKPT_INSTRUCTION_LENGTH = 4;
+
+/**
  * Return the length of the vsyscall invocation pattern. Currently,
  * we only support patterns of the form movq %addr, %rax; callq *%rax.
  */

--- a/src/remote_code_ptr.h
+++ b/src/remote_code_ptr.h
@@ -47,14 +47,14 @@ public:
   remote_code_ptr increment_by_syscall_insn_length(SupportedArch arch) const {
     return remote_code_ptr(ptr + rr::syscall_instruction_length(arch));
   }
-  remote_code_ptr decrement_by_bkpt_insn_length(SupportedArch) const {
-    return remote_code_ptr(ptr - 1);
+  remote_code_ptr decrement_by_bkpt_insn_length(SupportedArch arch) const {
+    return remote_code_ptr(ptr - rr::bkpt_instruction_length(arch));
   }
-  remote_code_ptr increment_by_bkpt_insn_length(SupportedArch) const {
-    return remote_code_ptr(ptr + 1);
+  remote_code_ptr increment_by_bkpt_insn_length(SupportedArch arch) const {
+    return remote_code_ptr(ptr + rr::bkpt_instruction_length(arch));
   }
   remote_code_ptr increment_by_movrm_insn_length(SupportedArch arch) const {
-    return remote_code_ptr(ptr + movrm_instruction_length(arch));
+    return remote_code_ptr(ptr + rr::movrm_instruction_length(arch));
   }
   remote_code_ptr decrement_by_vsyscall_entry_length(SupportedArch arch) const {
     return remote_code_ptr(ptr - rr::vsyscall_entry_length(arch));


### PR DESCRIPTION
Currently everything is assuming that breakpoint instructions have
length one. This is not true on other architectures. Refactor everything
to remove this assumption.