### PR TITLE
Fix race condition in timer test

### DIFF
--- a/src/test/timer.c
+++ b/src/test/timer.c
@@ -77,7 +77,7 @@ int main(void) {
     test_assert(0 == timer_settime(*id, 0, &its3, NULL));
     for (int i = 0; i < 5000 && !caught_limit_sig; ++i) {
       caught_sig = 0;
-      for (counter = 0; counter >= 0 && !caught_sig; counter++) {
+      for (counter = 0; counter >= 0 && !caught_sig && !caught_limit_sig; counter++) {
         (void)sys_gettid();
       }
     }


### PR DESCRIPTION
It's possible for the SIGUSR1 timer and the SIGALRM timer to become pending
at the same time, right after we check  !caught_limit_sig but before we set
`caught_sig = 0;`. In this case the subsequent loop will become essentially infinite,
because the SIGUSR1 sighandler turns off the SIGALRM timer (or rather gives it
a huge period).

Fixes #2555 