### PR TITLE
Fix two issues with the ptrace test

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -621,17 +621,17 @@ void Task::on_syscall_exit_arch(int syscallno, const Registers& regs) {
         case PTRACE_SETFPREGS: {
           auto data = read_mem(
               remote_ptr<typename Arch::user_fpregs_struct>(regs.arg4()));
-          auto r = extra_regs();
+          auto r = tracee->extra_regs();
           r.set_user_fpregs_struct(this, Arch::arch(), &data, sizeof(data));
-          set_extra_regs(r);
+          tracee->set_extra_regs(r);
           break;
         }
         case PTRACE_SETFPXREGS: {
           auto data =
               read_mem(remote_ptr<X86Arch::user_fpxregs_struct>(regs.arg4()));
-          auto r = extra_regs();
+          auto r = tracee->extra_regs();
           r.set_user_fpxregs_struct(this, data);
-          set_extra_regs(r);
+          tracee->set_extra_regs(r);
           break;
         }
         case PTRACE_SETREGSET: {

--- a/src/test/ptrace.c
+++ b/src/test/ptrace.c
@@ -116,6 +116,12 @@ int main(void) {
     asm("movdqu %0,%%xmm15" ::"m"(dummy));
 #endif
 
+    // Also initialize at least one ymm register. Otherwise the initial state
+    // optimization might prevent the kernel from writing this state component.
+    if (xsave_size > 576) {
+      asm("vinsertf128 $128,%0,%%ymm2,%%ymm1" ::"m"(dummy));
+    }
+
     kill(getpid(), SIGSTOP);
     test_assert(static_data == NEW_VALUE);
     return 77;

--- a/src/test/ptrace.c
+++ b/src/test/ptrace.c
@@ -174,7 +174,13 @@ int main(void) {
   test_assert(0 == ptrace(PTRACE_GETFPREGS, child, NULL, fpregs));
   test_assert(NULL == memchr(fpregs, 0xBB, sizeof(*fpregs)));
   VERIFY_GUARD(fpregs);
+  fpregs->cwd = 0xFFFF;
   test_assert(0 == ptrace(PTRACE_SETFPREGS, child, NULL, fpregs));
+  {
+    struct user_fpregs_struct fpregs3;
+    test_assert(0 == ptrace(PTRACE_GETFPREGS, child, NULL, &fpregs3));
+    test_assert(0 == memcmp(fpregs, &fpregs3, sizeof(fpregs3)));
+  }
 
 #ifdef __i386__
   ALLOCATE_GUARD(fpxregs, 0xCC);
@@ -182,7 +188,14 @@ int main(void) {
   clear_reserved_area((uint8_t*)fpxregs);
   test_assert(NULL == memchr(fpxregs, 0xCC, sizeof(*fpxregs)));
   VERIFY_GUARD(fpxregs);
+  fpxregs->xmm_space[0] = 0xFFFFF;
   test_assert(0 == ptrace(PTRACE_SETFPXREGS, child, NULL, fpxregs));
+
+  {
+    struct user_fpxregs_struct fpxregs3;
+    test_assert(0 == ptrace(PTRACE_GETFPXREGS, child, NULL, &fpxregs3));
+    test_assert(0 == memcmp(fpxregs, &fpxregs3, sizeof(fpxregs3)));
+  }
 #endif
 
   ALLOCATE_GUARD(regs2, 0xCD);


### PR DESCRIPTION
The second issue found by inspection, the first issue while banging my head against the wall wondering why the test is failing. I've also submitted patches to the ptrace man page as well as the intel architecture manual to correctly describe how the NT_X86_XSTATE actually works,
because it's ... uhm, quite something.