### PR TITLE
Add a record flag to unmap vDSO in new tasks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1334,6 +1334,7 @@ set(TESTS_WITHOUT_PROGRAM
   syscallbuf_timeslice_250
   trace_version
   term_trace_cpu
+  unmap_vdso
   unwind_on_signal
   vfork_exec
   vfork_break_parent

--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -258,6 +258,10 @@ uint32_t AddressSpace::offset_to_syscall_in_vdso[SupportedArch_MAX + 1];
 
 remote_code_ptr AddressSpace::find_syscall_instruction(Task* t) {
   SupportedArch arch = t->arch();
+  // This assert passes even if --unmap-vdso is passed because this only ever
+  // gets called at the start of process_execve before we unmap the vdso. After
+  // the rr page is mapped in, we use the syscall instructions contained therein
+  ASSERT(t, has_vdso()) << "Kernel with vDSO disabled?";
   if (!offset_to_syscall_in_vdso[arch]) {
     auto vdso_data = t->read_mem(vdso().start().cast<uint8_t>(), vdso().size());
     offset_to_syscall_in_vdso[arch] = find_offset_of_syscall_instruction_in(

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -621,6 +621,7 @@ public:
 
   /** Return the vdso mapping of this. */
   KernelMapping vdso() const;
+  bool has_vdso() const { return has_mapping(vdso_start_addr); }
 
   /**
    * Verify that this cached address space matches what the

--- a/src/Monkeypatcher.cc
+++ b/src/Monkeypatcher.cc
@@ -723,6 +723,11 @@ void patch_after_exec_arch<X86Arch>(RecordTask* t, Monkeypatcher& patcher) {
   setup_preload_library_path<X86Arch>(t);
   setup_audit_library_path<X86Arch>(t);
 
+  if (!t->vm()->has_vdso()) {
+    patch_auxv_vdso(t);
+    return;
+  }
+
   VdsoReader reader(t);
   auto syms = reader.read_symbols(".dynsym", ".dynstr");
   patcher.x86_vsyscall = locate_and_verify_kernel_vsyscall(t, reader, syms);
@@ -845,6 +850,18 @@ void patch_after_exec_arch<X64Arch>(RecordTask* t, Monkeypatcher& patcher) {
   setup_preload_library_path<X64Arch>(t);
   setup_audit_library_path<X64Arch>(t);
 
+  for (const auto& m : t->vm()->maps()) {
+    auto& km = m.map;
+    patcher.patch_after_mmap(t, km.start(), km.size(),
+                             km.file_offset_bytes()/page_size(), -1,
+                             Monkeypatcher::MMAP_EXEC);
+  }
+
+  if (!t->vm()->has_vdso()) {
+    patch_auxv_vdso(t);
+    return;
+  }
+
   auto vdso_start = t->vm()->vdso().start();
   size_t vdso_size = t->vm()->vdso().size();
 
@@ -908,13 +925,6 @@ void patch_after_exec_arch<X64Arch>(RecordTask* t, Monkeypatcher& patcher) {
   }
 
   obliterate_debug_info(t, reader);
-
-  for (const auto& m : t->vm()->maps()) {
-    auto& km = m.map;
-    patcher.patch_after_mmap(t, km.start(), km.size(),
-                             km.file_offset_bytes()/page_size(), -1,
-                             Monkeypatcher::MMAP_EXEC);
-  }
 }
 
 template <>

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2008,7 +2008,8 @@ static string lookup_by_path(const string& name) {
     BindCPU bind_cpu,
     const string& output_trace_dir,
     const TraceUuid* trace_id,
-    bool use_audit) {
+    bool use_audit,
+    bool unmap_vdso) {
   // The syscallbuf library interposes some critical
   // external symbols like XShmQueryExtension(), so we
   // preload it whether or not syscallbuf is enabled. Indicate here whether
@@ -2105,7 +2106,7 @@ static string lookup_by_path(const string& name) {
   shr_ptr session(
       new RecordSession(full_path, argv, env, disable_cpuid_features,
                         syscallbuf, syscallbuf_desched_sig, bind_cpu,
-                        output_trace_dir, trace_id, use_audit));
+                        output_trace_dir, trace_id, use_audit, unmap_vdso));
   session->set_asan_active(!exe_info.libasan_path.empty() ||
                            exe_info.has_asan_symbols);
   return session;
@@ -2120,7 +2121,8 @@ RecordSession::RecordSession(const std::string& exe_path,
                              BindCPU bind_cpu,
                              const string& output_trace_dir,
                              const TraceUuid* trace_id,
-                             bool use_audit)
+                             bool use_audit,
+                             bool unmap_vdso)
     : trace_out(argv[0], output_trace_dir, ticks_semantics_),
       scheduler_(*this),
       trace_id(trace_id),
@@ -2136,7 +2138,8 @@ RecordSession::RecordSession(const std::string& exe_path,
       enable_chaos_(false),
       asan_active_(false),
       wait_for_all_(false),
-      use_audit_(use_audit) {
+      use_audit_(use_audit),
+      unmap_vdso_(unmap_vdso) {
   if (!has_cpuid_faulting() &&
       disable_cpuid_features.any_features_disabled()) {
     FATAL() << "CPUID faulting required to disable CPUID features";

--- a/src/RecordSession.h
+++ b/src/RecordSession.h
@@ -68,7 +68,8 @@ public:
       BindCPU bind_cpu = BIND_CPU,
       const std::string& output_trace_dir = "",
       const TraceUuid* trace_id = nullptr,
-      bool use_audit = false);
+      bool use_audit = false,
+      bool unmap_vdso = false);
 
   const DisableCPUIDFeatures& disable_cpuid_features() const {
     return disable_cpuid_features_;
@@ -85,6 +86,7 @@ public:
   void set_asan_active(bool active) { asan_active_ = active; }
   bool asan_active() const { return asan_active_; }
   bool use_audit() const { return use_audit_; }
+  bool unmap_vdso() { return unmap_vdso_; }
   uint64_t rr_signal_mask() const;
 
   enum RecordStatus {
@@ -201,7 +203,8 @@ private:
                 BindCPU bind_cpu,
                 const std::string& output_trace_dir,
                 const TraceUuid* trace_id,
-                bool use_audit);
+                bool use_audit,
+                bool unmap_vdso);
 
   virtual void on_create(Task* t) override;
 
@@ -256,6 +259,7 @@ private:
   std::string output_trace_dir;
 
   bool use_audit_;
+  bool unmap_vdso_;
 };
 
 } // namespace rr

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -4671,6 +4671,7 @@ static void process_execve(RecordTask* t, TaskSyscallState& syscall_state) {
   ASSERT(t, mode == TraceWriter::DONT_RECORD_IN_TRACE);
 
   KernelMapping vvar;
+  KernelMapping vdso;
 
   // get the remote executable entry point
   // with the pointer, we find out which mapping is the executable
@@ -4686,6 +4687,8 @@ static void process_execve(RecordTask* t, TaskSyscallState& syscall_state) {
       stacks.push_back(km);
     } else if (km.is_vvar()) {
       vvar = km;
+    } else if (km.is_vdso()) {
+      vdso = km;
     }
 
     // if true, this mapping is our executable
@@ -4711,6 +4714,12 @@ static void process_execve(RecordTask* t, TaskSyscallState& syscall_state) {
       remote.infallible_syscall(syscall_number_for_munmap(remote.arch()),
                                 vvar.start(), vvar.size());
       t->vm()->unmap(t, vvar.start(), vvar.size());
+    }
+
+    if (t->session().unmap_vdso() && vdso.size()) {
+      remote.infallible_syscall(syscall_number_for_munmap(remote.arch()),
+                                vdso.start(), vdso.size());
+      t->vm()->unmap(t, vdso.start(), vdso.size());
     }
 
     for (auto& km : stacks) {

--- a/src/test/unmap_vdso.run
+++ b/src/test/unmap_vdso.run
@@ -1,0 +1,6 @@
+source `dirname $0`/util.sh
+RECORD_ARGS="--unmap-vdso"
+just_record cat /proc/self/maps
+if grep "vdso" record.out; then
+    failed "vdso should have been unmapped"
+fi

--- a/src/util.h
+++ b/src/util.h
@@ -37,6 +37,7 @@ struct Event;
 class KernelMapping;
 class Task;
 class TraceFrame;
+class RecordTask;
 
 enum Completion { COMPLETE, INCOMPLETE };
 
@@ -49,6 +50,8 @@ std::vector<uint8_t> read_auxv(Task* t);
  * Returns a vector containing the environment strings.
  */
 std::vector<std::string> read_env(Task* t);
+
+void patch_auxv_vdso(RecordTask* t);
 
 /**
  * Create a file named |filename| and dump |buf_len| words in |buf| to


### PR DESCRIPTION
This adds `--unmap-vdso` as a record flag, which will unmap
the vDSO from every task's address space after exec and clear
the corresponding entry from the auxv list.
The vDSO patching machinery is a fair bit of complexity. When
porting to new architectures, it can be useful to first try
without it. I suppose it may also be useful if there is ever
a kernel version that has a vDSO entrypoint the Monkeypatcher
doesn't know about.

I'm hoping this will be useful to the next person trying to port to
a new architectures (cc @vchuravy ;) ).