### PR TITLE
Aarch64 GDB register mappings and trace format support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -587,6 +587,9 @@ set(RR_GDB_RESOURCES
   amd64-linux.xml
   i386-avx-linux.xml
   i386-linux.xml
+  aarch64-core.xml
+  aarch64-fpu.xml
+  aarch64-pauth.xml
 )
 foreach(file ${RR_GDB_RESOURCES})
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/third-party/gdb/${file}"

--- a/src/GdbConnection.cc
+++ b/src/GdbConnection.cc
@@ -432,6 +432,8 @@ static const char* target_description_name(uint32_t cpu_features) {
       return "i386-avx-linux.xml";
     case GdbConnection::CPU_X86_64 | GdbConnection::CPU_AVX:
       return "amd64-avx-linux.xml";
+    case GdbConnection::CPU_AARCH64:
+      return "aarch64-core.xml";
     default:
       FATAL() << "Unknown features";
       return nullptr;

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2156,8 +2156,11 @@ RecordSession::RecordSession(const std::string& exe_path,
       Task::spawn(*this, error_fd, &tracee_socket_fd(),
                   &tracee_socket_fd_number,
                   exe_path, argv, envp));
-  // CPU affinity has been set.
-  trace_out.setup_cpuid_records(has_cpuid_faulting(), disable_cpuid_features_);
+
+  if (NativeArch::arch() == x86 || NativeArch::arch() == x86_64) {
+    // CPU affinity has been set.
+    trace_out.setup_cpuid_records(has_cpuid_faulting(), disable_cpuid_features_);
+  }
 
   initial_thread_group = t->thread_group();
   on_create(t);

--- a/src/Registers.cc
+++ b/src/Registers.cc
@@ -97,7 +97,6 @@ template <> struct RegisterInfo<rr::X64Arch> {
 
 template <> struct RegisterInfo<rr::ARM64Arch> {
   static bool ignore_undefined_register(GdbRegister) {
-    FATAL() << "Unimplemented";
     return false;
   }
   static const size_t num_registers = DREG_NUM_LINUX_AARCH64;
@@ -119,6 +118,9 @@ template <> struct RegisterInfo<rr::ARM64Arch> {
   RV_ARCH(gdb_suffix, name, rr::X86Arch, COMMA comparison_mask)
 #define RV_X64_WITH_MASK(gdb_suffix, name, comparison_mask, size)              \
   RV_ARCH(gdb_suffix, name, rr::X64Arch, COMMA comparison_mask COMMA size)
+#define RV_AARCH64(gdb_suffix, name) RV_ARCH(gdb_suffix, name, rr::ARM64Arch, /* empty */)
+#define RV_AARCH64_WITH_MASK(gdb_suffix, name, comparison_mask, size)          \
+  RV_ARCH(gdb_suffix, name, rr::ARM64Arch, COMMA comparison_mask COMMA size)
 
 RegisterInfo<rr::X86Arch>::Table RegisterInfo<rr::X86Arch>::registers = {
   RV_X86(EAX, eax), RV_X86(ECX, ecx), RV_X86(EDX, edx), RV_X86(EBX, ebx),
@@ -154,10 +156,28 @@ RegisterInfo<rr::X64Arch>::Table RegisterInfo<rr::X64Arch>::registers = {
 };
 
 RegisterInfo<rr::ARM64Arch>::Table RegisterInfo<rr::ARM64Arch>::registers = {
+  RV_AARCH64(X0, x[0]), RV_AARCH64(X1, x[1]), RV_AARCH64(X2, x[2]),
+  RV_AARCH64(X3, x[3]), RV_AARCH64(X4, x[4]), RV_AARCH64(X5, x[5]),
+  RV_AARCH64(X6, x[6]), RV_AARCH64(X7, x[7]), RV_AARCH64(X8, x[8]),
+  RV_AARCH64(X9, x[9]),
+  RV_AARCH64(X10, x[10]), RV_AARCH64(X11, x[11]), RV_AARCH64(X12, x[12]),
+  RV_AARCH64(X13, x[13]), RV_AARCH64(X14, x[14]), RV_AARCH64(X15, x[15]),
+  RV_AARCH64(X16, x[16]), RV_AARCH64(X17, x[17]), RV_AARCH64(X18, x[18]),
+  RV_AARCH64(X19, x[19]),
+  RV_AARCH64(X20, x[20]), RV_AARCH64(X21, x[21]), RV_AARCH64(X22, x[22]),
+  RV_AARCH64(X23, x[23]), RV_AARCH64(X24, x[24]), RV_AARCH64(X25, x[25]),
+  RV_AARCH64(X26, x[26]), RV_AARCH64(X27, x[27]), RV_AARCH64(X28, x[28]),
+  RV_AARCH64(X29, x[29]), RV_AARCH64(X30, x[30]),
+  RV_AARCH64(SP, sp), RV_AARCH64(PC, pc),
+  RV_AARCH64_WITH_MASK(CPSR, pstate, 0xffffffffLL, 4),
 };
 
 #undef RV_X64
 #undef RV_X86
+#undef RV_AARCH64
+#undef RV_X64_WITH_MASK
+#undef RV_X86_WITH_MASK
+#undef RV_AARCH64_WITH_MASK
 #undef RV_ARCH
 
 // 32-bit format, 64-bit format for all of these.

--- a/src/Registers.cc
+++ b/src/Registers.cc
@@ -515,7 +515,7 @@ void to_x86_narrow(int32_t& r32, uint64_t& r64) { r32 = r64; }
 void from_x86_narrow(int32_t& r32, uint64_t& r64) { r64 = (uint32_t)r32; }
 void from_x86_narrow_signed(int32_t& r32, uint64_t& r64) { r64 = (int64_t)r32; }
 
-void Registers::set_from_ptrace(const struct user_regs_struct& ptrace_regs) {
+void Registers::set_from_ptrace(const NativeArch::user_regs_struct& ptrace_regs) {
   if (arch() == NativeArch::arch()) {
     memcpy(&u, &ptrace_regs, sizeof(ptrace_regs));
     return;
@@ -524,8 +524,7 @@ void Registers::set_from_ptrace(const struct user_regs_struct& ptrace_regs) {
   DEBUG_ASSERT(arch() == x86 && NativeArch::arch() == x86_64);
   convert_x86<to_x86_narrow, to_x86_narrow>(
       u.x86regs,
-      *reinterpret_cast<X64Arch::user_regs_struct*>(
-          const_cast<struct user_regs_struct*>(&ptrace_regs)));
+      *const_cast<struct X64Arch::user_regs_struct*>(&ptrace_regs));
 }
 
 /**
@@ -534,9 +533,9 @@ void Registers::set_from_ptrace(const struct user_regs_struct& ptrace_regs) {
  * 64-bit rr. In that case the user_regs_struct is 64-bit and we copy
  * the 32-bit register values from u.x86regs into it.
  */
-struct user_regs_struct Registers::get_ptrace() const {
+NativeArch::user_regs_struct Registers::get_ptrace() const {
   union {
-    struct user_regs_struct linux_api;
+    struct NativeArch::user_regs_struct linux_api;
     struct X64Arch::user_regs_struct x64arch_api;
   } result;
   if (arch() == NativeArch::arch()) {
@@ -579,8 +578,8 @@ vector<uint8_t> Registers::get_ptrace_for_arch(SupportedArch arch) const {
 void Registers::set_from_ptrace_for_arch(SupportedArch a, const void* data,
                                          size_t size) {
   if (a == NativeArch::arch()) {
-    DEBUG_ASSERT(size == sizeof(struct user_regs_struct));
-    set_from_ptrace(*static_cast<const struct user_regs_struct*>(data));
+    DEBUG_ASSERT(size == sizeof(NativeArch::user_regs_struct));
+    set_from_ptrace(*static_cast<const NativeArch::user_regs_struct*>(data));
     return;
   }
 

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -73,7 +73,7 @@ public:
    * rr build is 32-bit, or when the Registers' arch is completely different
    * to the rr build (e.g. ARM vs x86).
    */
-  void set_from_ptrace(const struct ::user_regs_struct& ptrace_regs);
+  void set_from_ptrace(const struct NativeArch::user_regs_struct& ptrace_regs);
   /**
    * Get a user_regs_struct from these Registers. If the tracee architecture
    * is not rr's native architecture, then it must be a 32-bit tracee with a
@@ -83,7 +83,7 @@ public:
    * rr build is 32-bit, or when the Registers' arch is completely different
    * to the rr build (e.g. ARM vs x86).
    */
-  struct ::user_regs_struct get_ptrace() const;
+  struct NativeArch::user_regs_struct get_ptrace() const;
   /**
    * Get a user_regs_struct for a particular Arch from these Registers.
    * It's invalid to call this when 'arch' is 64-bit and the

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -171,23 +171,26 @@ ReplaySession::ReplaySession(const std::string& dir, const Flags& flags)
 
   trace_start_time = trace_frame.monotonic_time();
 
-  if (trace_in.uses_cpuid_faulting() && !has_cpuid_faulting()) {
-    CLEAN_FATAL()
-        << "Trace was recorded with CPUID faulting enabled, but this\n"
-           "system does not support CPUID faulting.";
-  }
-  if (!has_cpuid_faulting() && !cpuid_compatible(trace_in.cpuid_records())) {
-    CLEAN_FATAL()
-        << "Trace was recorded on a machine with different CPUID values\n"
-           "and CPUID faulting is not enabled; replay will not work.";
-  }
   if (!PerfCounters::supports_ticks_semantics(ticks_semantics_)) {
     CLEAN_FATAL()
         << "Trace was recorded on a machine that defines ticks differently\n"
            "to this machine; replay will not work.";
   }
 
-  check_xsave_compatibility(trace_in);
+  if (trace_in.arch() == x86 || trace_in.arch() == x86_64) {
+    if (trace_in.uses_cpuid_faulting() && !has_cpuid_faulting()) {
+      CLEAN_FATAL()
+          << "Trace was recorded with CPUID faulting enabled, but this\n"
+            "system does not support CPUID faulting.";
+    }
+    if (!has_cpuid_faulting() && !cpuid_compatible(trace_in.cpuid_records())) {
+      CLEAN_FATAL()
+          << "Trace was recorded on a machine with different CPUID values\n"
+            "and CPUID faulting is not enabled; replay will not work.";
+    }
+
+    check_xsave_compatibility(trace_in);
+  }
 }
 
 ReplaySession::ReplaySession(const ReplaySession& other)

--- a/src/RerunCommand.cc
+++ b/src/RerunCommand.cc
@@ -168,7 +168,7 @@ static uint64_t seg_reg(const Registers& regs, uint8_t index) {
 static void print_regs(Task* t, FrameTime event, uint64_t instruction_count,
                        const RerunFlags& flags, FILE* out) {
   union {
-    struct user_regs_struct gp_regs;
+    NativeArch::user_regs_struct gp_regs;
     uintptr_t regs_values[sizeof(struct user_regs_struct) / sizeof(uintptr_t)];
   };
   bool got_gp_regs = false;

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1756,7 +1756,7 @@ void Task::did_waitpid(WaitStatus status) {
     // task's register values are not what they should be.
     if (!is_stopped && !registers_dirty) {
       LOG(debug) << "Requesting registers from tracee " << tid;
-      struct user_regs_struct ptrace_regs;
+      NativeArch::user_regs_struct ptrace_regs;
       if (ptrace_if_alive(PTRACE_GETREGS, nullptr, &ptrace_regs)) {
         registers.set_from_ptrace(ptrace_regs);
   #if defined(__i386__) || defined(__x86_64__)

--- a/src/ThreadDb.cc
+++ b/src/ThreadDb.cc
@@ -67,7 +67,7 @@ ps_err_e ps_lgetregs(struct ps_prochandle* h, lwpid_t rec_tid,
   rr::Task* task = h->thread_group->session()->find_task(rec_tid);
   DEBUG_ASSERT(task != nullptr);
 
-  struct ::user_regs_struct regs = task->regs().get_ptrace();
+  struct NativeArch::user_regs_struct regs = task->regs().get_ptrace();
   memcpy(result, static_cast<void*>(&regs), sizeof(regs));
   LOG(debug) << "ps_lgetregs OK";
   return PS_OK;

--- a/src/TraceStream.h
+++ b/src/TraceStream.h
@@ -418,6 +418,8 @@ public:
   // The base syscall number for rr syscalls in this trace
   int rrcall_base() const { return rrcall_base_; }
 
+  SupportedArch arch() const { return arch_; }
+
 private:
   CompressedReader& reader(Substream s) { return *readers[s]; }
   const CompressedReader& reader(Substream s) const { return *readers[s]; }
@@ -432,6 +434,7 @@ private:
   bool trace_uses_cpuid_faulting;
   bool preload_thread_locals_recorded_;
   int rrcall_base_;
+  SupportedArch arch_;
 };
 
 extern std::string trace_save_dir();

--- a/src/rr_trace.capnp
+++ b/src/rr_trace.capnp
@@ -52,15 +52,6 @@ struct Header {
   # The CPU number the trace was bound to during recording, or -1 if it
   # wasn't bound.
   bindToCpu @1 :Int32;
-  # True if the trace used CPUID faulting during recording (so CPUIDs
-  # were recorded as InstructionTraps).
-  hasCpuidFaulting @2 :Bool;
-  # A list of captured CPUID values.
-  # A series of 24-byte records. See CPUIDRecord in util.h.
-  cpuidRecords @3 :Data;
-  # Captured XCR0 value defining XSAVE features enabled by OS.
-  # 0 means "unknown"; default to everything supported by CPUID EAX=0xd ECX=0
-  xcr0 @5 :UInt64;
   # Semantics of "ticks" in this trace
   ticksSemantics @6 :TicksSemantics;
   # The syscallbuf protocol version. See SYSCALLBUF_PROTOCOL_VERSION.
@@ -72,6 +63,20 @@ struct Header {
   # Base rr syscall number (rrcall_init_preload). Before this was variable,
   # it was 442.
   rrcallBase @9 :Int32 = 442;
+
+  nativeArch @10 :Arch = x8664;
+  # Architecture specific data, determined by nativeArch
+  x86 :group {
+    # True if the trace used CPUID faulting during recording (so CPUIDs
+    # were recorded as InstructionTraps).
+    hasCpuidFaulting @2 :Bool;
+    # A list of captured CPUID values.
+    # A series of 24-byte records. See CPUIDRecord in util.h.
+    cpuidRecords @3 :Data;
+    # Captured XCR0 value defining XSAVE features enabled by OS.
+    # 0 means "unknown"; default to everything supported by CPUID EAX=0xd ECX=0
+    xcr0 @5 :UInt64;
+  }
 }
 
 # A file descriptor belonging to a task
@@ -164,6 +169,7 @@ struct MemWrite {
 enum Arch {
   x86 @0;
   x8664 @1;
+  aarch64 @2;
 }
 
 struct Registers {

--- a/third-party/gdb/aarch64-core.xml
+++ b/third-party/gdb/aarch64-core.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2009-2020 Free Software Foundation, Inc.
+     Contributed by ARM Ltd.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.aarch64.core">
+  <reg name="x0" bitsize="64"/>
+  <reg name="x1" bitsize="64"/>
+  <reg name="x2" bitsize="64"/>
+  <reg name="x3" bitsize="64"/>
+  <reg name="x4" bitsize="64"/>
+  <reg name="x5" bitsize="64"/>
+  <reg name="x6" bitsize="64"/>
+  <reg name="x7" bitsize="64"/>
+  <reg name="x8" bitsize="64"/>
+  <reg name="x9" bitsize="64"/>
+  <reg name="x10" bitsize="64"/>
+  <reg name="x11" bitsize="64"/>
+  <reg name="x12" bitsize="64"/>
+  <reg name="x13" bitsize="64"/>
+  <reg name="x14" bitsize="64"/>
+  <reg name="x15" bitsize="64"/>
+  <reg name="x16" bitsize="64"/>
+  <reg name="x17" bitsize="64"/>
+  <reg name="x18" bitsize="64"/>
+  <reg name="x19" bitsize="64"/>
+  <reg name="x20" bitsize="64"/>
+  <reg name="x21" bitsize="64"/>
+  <reg name="x22" bitsize="64"/>
+  <reg name="x23" bitsize="64"/>
+  <reg name="x24" bitsize="64"/>
+  <reg name="x25" bitsize="64"/>
+  <reg name="x26" bitsize="64"/>
+  <reg name="x27" bitsize="64"/>
+  <reg name="x28" bitsize="64"/>
+  <reg name="x29" bitsize="64"/>
+  <reg name="x30" bitsize="64"/>
+  <reg name="sp" bitsize="64" type="data_ptr"/>
+
+  <reg name="pc" bitsize="64" type="code_ptr"/>
+
+  <flags id="cpsr_flags" size="4">
+    <!-- Stack Pointer.  -->
+    <field name="SP" start="0" end="0"/>
+
+    <!-- Exception Level.  -->
+    <field name="EL" start="2" end="3"/>
+    <!-- Execution state.  -->
+    <field name="nRW" start="4" end="4"/>
+
+    <!-- FIQ interrupt mask.  -->
+    <field name="F" start="6" end="6"/>
+    <!-- IRQ interrupt mask.  -->
+    <field name="I" start="7" end="7"/>
+    <!-- SError interrupt mask.  -->
+    <field name="A" start="8" end="8"/>
+    <!-- Debug exception mask.  -->
+    <field name="D" start="9" end="9"/>
+
+    <!-- ARMv8.0-A: Speculative Store Bypass.  -->
+    <field name="SSBS" start="12" end="12"/>
+
+    <!-- Illegal Execution state.  -->
+    <field name="IL" start="20" end="20"/>
+    <!-- Software Step.  -->
+    <field name="SS" start="21" end="21"/>
+    <!-- ARMv8.1-A: Privileged Access Never.  -->
+    <field name="PAN" start="22" end="22"/>
+    <!-- ARMv8.2-A: User Access Override.  -->
+    <field name="UAO" start="23" end="23"/>
+    <!-- ARMv8.4-A: Data Independent Timing.  -->
+    <field name="DIT" start="24" end="24"/>
+    <!-- ARMv8.5-A: Tag Check Override.  -->
+    <field name="TCO" start="25" end="25"/>
+
+    <!-- Overflow Condition flag.  -->
+    <field name="V" start="28" end="28"/>
+    <!-- Carry Condition flag.  -->
+    <field name="C" start="29" end="29"/>
+    <!-- Zero Condition flag.  -->
+    <field name="Z" start="30" end="30"/>
+    <!-- Negative Condition flag.  -->
+    <field name="N" start="31" end="31"/>
+  </flags>
+  <reg name="cpsr" bitsize="32" type="cpsr_flags"/>
+
+</feature>

--- a/third-party/gdb/aarch64-fpu.xml
+++ b/third-party/gdb/aarch64-fpu.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2009-2020 Free Software Foundation, Inc.
+     Contributed by ARM Ltd.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.aarch64.fpu">
+  <vector id="v2d" type="ieee_double" count="2"/>
+  <vector id="v2u" type="uint64" count="2"/>
+  <vector id="v2i" type="int64" count="2"/>
+  <vector id="v4f" type="ieee_single" count="4"/>
+  <vector id="v4u" type="uint32" count="4"/>
+  <vector id="v4i" type="int32" count="4"/>
+  <vector id="v8f" type="ieee_half" count="8"/>
+  <vector id="v8u" type="uint16" count="8"/>
+  <vector id="v8i" type="int16" count="8"/>
+  <vector id="v16u" type="uint8" count="16"/>
+  <vector id="v16i" type="int8" count="16"/>
+  <vector id="v1u" type="uint128" count="1"/>
+  <vector id="v1i" type="int128" count="1"/>
+  <union id="vnd">
+    <field name="f" type="v2d"/>
+    <field name="u" type="v2u"/>
+    <field name="s" type="v2i"/>
+  </union>
+  <union id="vns">
+    <field name="f" type="v4f"/>
+    <field name="u" type="v4u"/>
+    <field name="s" type="v4i"/>
+  </union>
+  <union id="vnh">
+    <field name="f" type="v8f"/>
+    <field name="u" type="v8u"/>
+    <field name="s" type="v8i"/>
+  </union>
+  <union id="vnb">
+    <field name="u" type="v16u"/>
+    <field name="s" type="v16i"/>
+  </union>
+  <union id="vnq">
+    <field name="u" type="v1u"/>
+    <field name="s" type="v1i"/>
+  </union>
+  <union id="aarch64v">
+    <field name="d" type="vnd"/>
+    <field name="s" type="vns"/>
+    <field name="h" type="vnh"/>
+    <field name="b" type="vnb"/>
+    <field name="q" type="vnq"/>
+  </union>
+  <reg name="v0" bitsize="128" type="aarch64v" regnum="34"/>
+  <reg name="v1" bitsize="128" type="aarch64v" />
+  <reg name="v2" bitsize="128" type="aarch64v" />
+  <reg name="v3" bitsize="128" type="aarch64v" />
+  <reg name="v4" bitsize="128" type="aarch64v" />
+  <reg name="v5" bitsize="128" type="aarch64v" />
+  <reg name="v6" bitsize="128" type="aarch64v" />
+  <reg name="v7" bitsize="128" type="aarch64v" />
+  <reg name="v8" bitsize="128" type="aarch64v" />
+  <reg name="v9" bitsize="128" type="aarch64v" />
+  <reg name="v10" bitsize="128" type="aarch64v"/>
+  <reg name="v11" bitsize="128" type="aarch64v"/>
+  <reg name="v12" bitsize="128" type="aarch64v"/>
+  <reg name="v13" bitsize="128" type="aarch64v"/>
+  <reg name="v14" bitsize="128" type="aarch64v"/>
+  <reg name="v15" bitsize="128" type="aarch64v"/>
+  <reg name="v16" bitsize="128" type="aarch64v"/>
+  <reg name="v17" bitsize="128" type="aarch64v"/>
+  <reg name="v18" bitsize="128" type="aarch64v"/>
+  <reg name="v19" bitsize="128" type="aarch64v"/>
+  <reg name="v20" bitsize="128" type="aarch64v"/>
+  <reg name="v21" bitsize="128" type="aarch64v"/>
+  <reg name="v22" bitsize="128" type="aarch64v"/>
+  <reg name="v23" bitsize="128" type="aarch64v"/>
+  <reg name="v24" bitsize="128" type="aarch64v"/>
+  <reg name="v25" bitsize="128" type="aarch64v"/>
+  <reg name="v26" bitsize="128" type="aarch64v"/>
+  <reg name="v27" bitsize="128" type="aarch64v"/>
+  <reg name="v28" bitsize="128" type="aarch64v"/>
+  <reg name="v29" bitsize="128" type="aarch64v"/>
+  <reg name="v30" bitsize="128" type="aarch64v"/>
+  <reg name="v31" bitsize="128" type="aarch64v"/>
+  <reg name="fpsr" bitsize="32"/>
+  <reg name="fpcr" bitsize="32"/>
+</feature>

--- a/third-party/gdb/aarch64-pauth.xml
+++ b/third-party/gdb/aarch64-pauth.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!-- Copyright (C) 2018-2020 Free Software Foundation, Inc.
+
+     Copying and distribution of this file, with or without modification,
+     are permitted in any medium without royalty provided the copyright
+     notice and this notice are preserved.  -->
+
+<!DOCTYPE feature SYSTEM "gdb-target.dtd">
+<feature name="org.gnu.gdb.aarch64.pauth">
+  <reg name="pauth_dmask" bitsize="64"/>
+  <reg name="pauth_cmask" bitsize="64"/>
+</feature>
+


### PR DESCRIPTION
Add the GDB mappings and import the GDB .xml files so that the GdbServer will work as soon as we hook up register support. Also add a representation of aarch64 in the trace format.