### PR TITLE
Add aarch64 registers definition

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -516,7 +516,7 @@ void RecordTask::on_syscall_exit_arch(int syscallno, const Registers& regs) {
 
   switch (syscallno) {
     case Arch::set_robust_list:
-      set_robust_list(regs.arg1(), (size_t)regs.arg2());
+      set_robust_list(regs.orig_arg1(), (size_t)regs.arg2());
       return;
     case Arch::sigaction:
     case Arch::rt_sigaction:
@@ -524,7 +524,7 @@ void RecordTask::on_syscall_exit_arch(int syscallno, const Registers& regs) {
       update_sigaction(regs);
       return;
     case Arch::set_tid_address:
-      set_tid_addr(regs.arg1());
+      set_tid_addr(regs.orig_arg1());
       return;
     case Arch::sigsuspend:
     case Arch::rt_sigsuspend:
@@ -1172,7 +1172,7 @@ void RecordTask::set_siginfo(const siginfo_t& si) {
 
 template <typename Arch>
 void RecordTask::update_sigaction_arch(const Registers& regs) {
-  int sig = regs.arg1_signed();
+  int sig = regs.orig_arg1_signed();
   remote_ptr<typename Arch::kernel_sigaction> new_sigaction = regs.arg2();
   if (0 == regs.syscall_result() && !new_sigaction.is_null()) {
     // A new sighandler was installed.  Update our

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -198,6 +198,7 @@ public:
   }
 
   SYSCALL_REGISTER(syscall_result, eax, rax, x[0]);
+  SYSCALL_REGISTER(orig_arg1, ebx, rdi, orig_x0)
   SYSCALL_REGISTER(arg1, ebx, rdi, x[0])
   SYSCALL_REGISTER(arg2, ecx, rsi, x[1])
   SYSCALL_REGISTER(arg3, edx, rdx, x[2])

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -565,7 +565,10 @@ Completion ReplaySession::enter_syscall(ReplayTask* t,
         r.set_ip(
             syscall_instruction.increment_by_syscall_insn_length(t->arch()));
         r.set_original_syscallno(r.syscallno());
-        r.set_syscall_result(-ENOSYS);
+        r.set_orig_arg1(r.arg1());
+        if (t->arch() == x86 || t->arch() == x86_64) {
+          r.set_syscall_result(-ENOSYS);
+        }
         t->set_regs(r);
         t->canonicalize_regs(current_trace_frame().event().Syscall().arch());
         t->validate_regs();

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2871,7 +2871,7 @@ static void prepare_clone(RecordTask* t, TaskSyscallState& syscall_state) {
   Registers new_r = new_task->regs();
   new_r.set_original_syscallno(
       syscall_state.syscall_entry_registers.original_syscallno());
-  new_r.set_arg1(syscall_state.syscall_entry_registers.arg1());
+  new_r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
   new_task->set_regs(new_r);
   new_task->canonicalize_regs(new_task->arch());
   new_task->set_termination_signal(termination_signal);
@@ -2913,7 +2913,7 @@ static void prepare_clone(RecordTask* t, TaskSyscallState& syscall_state) {
   // see the original registers without our modifications if it inspects them
   // in the ptrace event.
   r = t->regs();
-  r.set_arg1(syscall_state.syscall_entry_registers.arg1());
+  r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
   r.set_original_syscallno(
       syscall_state.syscall_entry_registers.original_syscallno());
   t->set_regs(r);
@@ -5467,7 +5467,7 @@ static void rec_process_syscall_arch(RecordTask* t,
         }
         case Arch::RegisterArguments: {
           Registers r = t->regs();
-          r.set_arg1(syscall_state.syscall_entry_registers.arg1());
+          r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
           r.set_arg4(syscall_state.syscall_entry_registers.arg4_signed());
           t->set_regs(r);
           process_mmap(t, (size_t)r.arg2(), (int)r.arg3_signed(),
@@ -5480,7 +5480,7 @@ static void rec_process_syscall_arch(RecordTask* t,
 
     case Arch::mmap2: {
       Registers r = t->regs();
-      r.set_arg1(syscall_state.syscall_entry_registers.arg1());
+      r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
       r.set_arg4(syscall_state.syscall_entry_registers.arg4_signed());
       t->set_regs(r);
       process_mmap(t, (size_t)r.arg2(), (int)r.arg3_signed(),
@@ -5530,7 +5530,7 @@ static void rec_process_syscall_arch(RecordTask* t,
         Registers r = t->regs();
         r.set_original_syscallno(
             syscall_state.syscall_entry_registers.original_syscallno());
-        r.set_arg1(syscall_state.syscall_entry_registers.arg1());
+        r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
         t->set_regs(r);
         auto attr =
             t->read_mem(remote_ptr<struct perf_event_attr>(t->regs().arg1()));
@@ -5628,7 +5628,7 @@ static void rec_process_syscall_arch(RecordTask* t,
     case Arch::setsockopt: {
       // restore possibly-modified regs
       Registers r = t->regs();
-      r.set_arg1(syscall_state.syscall_entry_registers.arg1());
+      r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
       t->set_regs(r);
       break;
     }
@@ -5640,7 +5640,7 @@ static void rec_process_syscall_arch(RecordTask* t,
         // `connect` was suppressed
         r.set_syscall_result(-EACCES);
       }
-      r.set_arg1(syscall_state.syscall_entry_registers.arg1());
+      r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
       r.set_original_syscallno(
           syscall_state.syscall_entry_registers.original_syscallno());
       t->set_regs(r);
@@ -5701,7 +5701,7 @@ static void rec_process_syscall_arch(RecordTask* t,
     case Arch::mprotect: {
       // Restore the registers that we may have altered.
       Registers r = t->regs();
-      r.set_arg1(syscall_state.syscall_entry_registers.arg1());
+      r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
       r.set_arg2(syscall_state.syscall_entry_registers.arg2());
       r.set_arg3(syscall_state.syscall_entry_registers.arg3());
       t->set_regs(r);
@@ -5722,7 +5722,7 @@ static void rec_process_syscall_arch(RecordTask* t,
       t->in_wait_type = WAIT_TYPE_NONE;
       // Restore possibly-modified registers
       Registers r = t->regs();
-      r.set_arg1(syscall_state.syscall_entry_registers.arg1());
+      r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
       r.set_arg2(syscall_state.syscall_entry_registers.arg2());
       r.set_arg3(syscall_state.syscall_entry_registers.arg3());
       r.set_arg4(syscall_state.syscall_entry_registers.arg4());
@@ -5777,7 +5777,7 @@ static void rec_process_syscall_arch(RecordTask* t,
     case Arch::prctl: {
       // Restore arg1 in case we modified it to disable the syscall
       Registers r = t->regs();
-      r.set_arg1(syscall_state.syscall_entry_registers.arg1());
+      r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
       t->set_regs(r);
       switch ((int)t->regs().arg1()) {
         case PR_SET_SECCOMP:
@@ -5795,7 +5795,7 @@ static void rec_process_syscall_arch(RecordTask* t,
     case Arch::arch_prctl: {
       // Restore arg1 in case we modified it to disable the syscall
       Registers r = t->regs();
-      r.set_arg1(syscall_state.syscall_entry_registers.arg1());
+      r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
       t->set_regs(r);
       break;
     }
@@ -5826,7 +5826,7 @@ static void rec_process_syscall_arch(RecordTask* t,
     case Arch::seccomp: {
       // Restore arg1 in case we modified it to disable the syscall
       Registers r = t->regs();
-      r.set_arg1(syscall_state.syscall_entry_registers.arg1());
+      r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
       t->set_regs(r);
       if (t->regs().arg1() == SECCOMP_SET_MODE_FILTER) {
         ASSERT(t, t->session().done_initial_exec())


### PR DESCRIPTION
This one's a bit tricky, because the aarch64 syscall ABI differs from x86. Rather than overwriting the syscall number with the return value, instead the kernel overwrites arg1. It does store the value of arg1 at entry internally (for use in restart_syscall), but this is not exposed via ptrace. Also, the currently executing system call is a separate regset, rather than being part of the regular NT_PRSTATUS regset as it is on x86. It's not clear to me whether or not `original_syscall` should be part of `Registers` on aarch64 or not. If it is, `Task` needs to learn how to deal with multiple regsets being potentially independently dirty. The alternative would be to have a `Task::change_syscall` that is eager on aarch64 and modifies the Task's registers on x86. I have a commit that does that also, but thought this might be cleaner. Having implemented it, I'm not sure. Neither feels particularly satisfying.
Similar story with `orig_arg1`. We often need to look at the original arg1 at Task exit both in record and in replay, so we need to store it somewhere, but it's not clear that `Registers` is the right place for it. During record, we generally already do have the original arg1 stored in the syscall state anyway, but we currently don't have a good place to stash it during replay. Anyway, thoughts appreciated.