### PR TITLE
Add rr_page definitions for aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,10 @@ add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_32"
                    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/src/generate_rr_page.py"
                    "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_32"
                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/generate_rr_page.py")
+add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_arm64"
+                   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/src/generate_rr_page.py"
+                   "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_arm64"
+                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/generate_rr_page.py")
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_64_replay"
                    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/src/generate_rr_page.py"
                    "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_64_replay"
@@ -396,12 +400,18 @@ add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_32_repla
                    COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/src/generate_rr_page.py"
                    "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_32_replay"
                    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/generate_rr_page.py")
+add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_arm64_replay"
+                   COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/src/generate_rr_page.py"
+                   "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_arm64_replay"
+                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/generate_rr_page.py")
 
 add_custom_target(Pages DEPENDS
                   "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_32"
                   "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_64"
+                  "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_arm64"
                   "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_32_replay"
-                  "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_64_replay")
+                  "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_64_replay"
+                  "${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_arm64_replay")
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/rr_trace.capnp.c++"
                           "${CMAKE_CURRENT_BINARY_DIR}/rr_trace.capnp.h"
@@ -617,6 +627,8 @@ install(PROGRAMS scripts/signal-rr-recording.sh
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_64
               ${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_64_replay
+              ${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_arm64
+              ${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_arm64_replay
               ${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_32
               ${CMAKE_CURRENT_BINARY_DIR}/share/rr/rr_page_32_replay
   DESTINATION ${CMAKE_INSTALL_DATADIR}/rr)

--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -679,7 +679,8 @@ public:
   enum Enabled { RECORDING_ONLY, REPLAY_ONLY, RECORDING_AND_REPLAY };
   static remote_code_ptr rr_page_syscall_exit_point(Traced traced,
                                                     Privileged privileged,
-                                                    Enabled enabled);
+                                                    Enabled enabled,
+                                                    SupportedArch arch);
   static remote_code_ptr rr_page_syscall_entry_point(Traced traced,
                                                      Privileged privileged,
                                                      Enabled enabled,
@@ -691,9 +692,10 @@ public:
     Enabled enabled;
   };
   static std::vector<SyscallType> rr_page_syscalls();
-  static const SyscallType* rr_page_syscall_from_exit_point(remote_code_ptr ip);
+  static const SyscallType* rr_page_syscall_from_exit_point(
+    SupportedArch arch, remote_code_ptr ip);
   static const SyscallType* rr_page_syscall_from_entry_point(
-      remote_code_ptr ip);
+    SupportedArch arch, remote_code_ptr ip);
 
   /**
    * Return a pointer to 8 bytes of 0xFF

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -935,7 +935,7 @@ static void save_interrupted_syscall_ret_in_syscallbuf(RecordTask* t,
 }
 
 static bool is_in_privileged_syscall(RecordTask* t) {
-  auto type = AddressSpace::rr_page_syscall_from_exit_point(t->ip());
+  auto type = AddressSpace::rr_page_syscall_from_exit_point(t->arch(), t->ip());
   return type && type->privileged == AddressSpace::PRIVILEGED;
 }
 

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -494,7 +494,7 @@ Completion ReplaySession::cont_syscall_boundary(
     t->resume_execution(RESUME_SYSEMU, RESUME_WAIT, ticks_request);
   }
 
-  auto type = AddressSpace::rr_page_syscall_from_exit_point(t->ip());
+  auto type = AddressSpace::rr_page_syscall_from_exit_point(t->arch(), t->ip());
   if (type && type->traced == AddressSpace::UNTRACED &&
       type->enabled == AddressSpace::REPLAY_ONLY) {
     // Actually perform it. We can hit these when replaying through syscallbuf
@@ -650,7 +650,7 @@ Completion ReplaySession::continue_or_step(ReplayTask* t,
   } else {
     t->resume_execution(resume_how, RESUME_WAIT, tick_request);
     if (t->stop_sig() == 0) {
-      auto type = AddressSpace::rr_page_syscall_from_exit_point(t->ip());
+      auto type = AddressSpace::rr_page_syscall_from_exit_point(t->arch(), t->ip());
       if (type && type->traced == AddressSpace::UNTRACED) {
         // If we recorded an rr replay of an application doing a
         // syscall-buffered 'mprotect', the replay's `flush_syscallbuf`

--- a/src/SeccompFilterRewriter.cc
+++ b/src/SeccompFilterRewriter.cc
@@ -85,7 +85,8 @@ static void install_patched_seccomp_filter_arch(
   for (auto& e : AddressSpace::rr_page_syscalls()) {
     if (e.privileged == AddressSpace::PRIVILEGED) {
       auto ip = AddressSpace::rr_page_syscall_exit_point(e.traced, e.privileged,
-                                                         e.enabled);
+                                                         e.enabled,
+                                                         Arch::arch());
       f.allow_syscalls_from_callsite(ip);
     }
   }

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -2829,7 +2829,8 @@ static SeccompFilter<struct sock_filter> create_seccomp_filter() {
   for (auto& e : AddressSpace::rr_page_syscalls()) {
     if (e.traced == AddressSpace::UNTRACED) {
       auto ip = AddressSpace::rr_page_syscall_exit_point(e.traced, e.privileged,
-                                                         e.enabled);
+                                                         e.enabled,
+                                                         NativeArch::arch());
       f.allow_syscalls_from_callsite(ip);
     }
   }

--- a/src/Task.h
+++ b/src/Task.h
@@ -3,8 +3,6 @@
 #ifndef RR_TASK_H_
 #define RR_TASK_H_
 
-#include <asm/ldt.h>
-
 #include <memory>
 #include <vector>
 
@@ -29,7 +27,6 @@
 
 struct syscallbuf_hdr;
 struct syscallbuf_record;
-struct user_desc;
 
 namespace rr {
 
@@ -543,19 +540,20 @@ public:
   bool set_debug_reg(size_t regno, uintptr_t value);
 
   /** Update the thread area to |addr|. */
-  void set_thread_area(remote_ptr<struct ::user_desc> tls);
+  void set_thread_area(remote_ptr<X86Arch::user_desc> tls);
 
   /** Set the thread area at index `idx` to desc and reflect this
     * into the OS task. Returns 0 on success, errno otherwise.
     */
-  int emulate_set_thread_area(int idx, struct ::user_desc desc);
+  int emulate_set_thread_area(int idx, X86Arch::user_desc desc);
 
   /** Get the thread area from the remote process.
     * Returns 0 on success, errno otherwise.
     */
-  int emulate_get_thread_area(int idx, struct ::user_desc& desc);
+  int emulate_get_thread_area(int idx, X86Arch::user_desc& desc);
 
-  const std::vector<struct ::user_desc>& thread_areas() {
+  const std::vector<X86Arch::user_desc>& thread_areas() {
+    DEBUG_ASSERT(arch() == x86 || arch() == x86_64);
     return thread_areas_;
   }
 
@@ -832,7 +830,7 @@ public:
     Registers regs;
     ExtraRegisters extra_regs;
     std::string prname;
-    std::vector<struct user_desc> thread_areas;
+    std::vector<X86Arch::user_desc> thread_areas;
     remote_ptr<struct syscallbuf_hdr> syscallbuf_child;
     size_t syscallbuf_size;
     size_t num_syscallbuf_bytes;
@@ -1113,7 +1111,8 @@ protected:
   // Entries set by |set_thread_area()| or the |tls| argument to |clone()|
   // (when that's a user_desc). May be more than one due to different
   // entry_numbers.
-  std::vector<struct user_desc> thread_areas_;
+  // x86(_64) only.
+  std::vector<X86Arch::user_desc> thread_areas_;
   // The |stack| argument passed to |clone()|, which for
   // "threads" is the top of the user-allocated stack.
   remote_ptr<void> top_of_stack;

--- a/src/Task.h
+++ b/src/Task.h
@@ -327,7 +327,7 @@ public:
    * instruction.
    */
   bool is_in_untraced_syscall() {
-    auto t = AddressSpace::rr_page_syscall_from_exit_point(ip());
+    auto t = AddressSpace::rr_page_syscall_from_exit_point(arch(), ip());
     return t && t->traced == AddressSpace::UNTRACED;
   }
 

--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -95,13 +95,18 @@ static const uint8_t syscall_insn[] = { 0x0f, 0x05 };
 
 bool get_syscall_instruction_arch(Task* t, remote_code_ptr ptr,
                                   SupportedArch* arch) {
+  if (t->arch() == aarch64) {
+    *arch = aarch64;
+    return true;
+  }
+
   // Lots of syscalls occur in the rr page and we know what it contains without
   // looking at it.
   // (Without this optimization we spend a few % of all CPU time in this
   // function in a syscall-dominated trace.)
   if (t->vm()->has_rr_page()) {
     const AddressSpace::SyscallType* type =
-        AddressSpace::rr_page_syscall_from_entry_point(ptr);
+        AddressSpace::rr_page_syscall_from_entry_point(t->arch(), ptr);
     if (type && (type->enabled == AddressSpace::RECORDING_AND_REPLAY ||
                  type->enabled == (t->session().is_recording()
                                        ? AddressSpace::RECORDING_ONLY

--- a/src/preload/preload_interface.h
+++ b/src/preload/preload_interface.h
@@ -107,11 +107,19 @@ static inline const char* extract_file_name(const char* s) {
 
 #define MPROTECT_RECORD_COUNT 1000
 
+#if defined(__x86_64__) || defined(__i386__)
+#define RR_PAGE_SYSCALL_STUB_SIZE 3
+#define RR_PAGE_SYSCALL_INSTRUCTION_END 2
+#elif defined(__aarch64__)
+#define RR_PAGE_SYSCALL_STUB_SIZE 8
+#define RR_PAGE_SYSCALL_INSTRUCTION_END 4
+#else
+#error "Must be defined for this architecture"
+#endif
+
 /* Must match generate_rr_page.py */
 #define RR_PAGE_ADDR 0x70000000
 #define RR_PAGE_SIZE 4096
-#define RR_PAGE_SYSCALL_STUB_SIZE 3
-#define RR_PAGE_SYSCALL_INSTRUCTION_END 2
 #define RR_PAGE_SYSCALL_ADDR(index)                                            \
   ((void*)(RR_PAGE_ADDR + RR_PAGE_SYSCALL_STUB_SIZE * (index)))
 #define RR_PAGE_SYSCALL_TRACED RR_PAGE_SYSCALL_ADDR(0)

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -3,7 +3,6 @@
 #include "record_syscall.h"
 
 #include <arpa/inet.h>
-#include <asm/ldt.h>
 #include <asm/prctl.h>
 #include <dirent.h>
 #include <elf.h>
@@ -2511,10 +2510,10 @@ static Switchable prepare_ptrace(RecordTask* t,
           emulate = false;
           break;
         }
-        remote_ptr<struct ::user_desc> remote_addr(t->regs().arg4());
+        remote_ptr<X86Arch::user_desc> remote_addr(t->regs().arg4());
         bool ok = true;
-        struct ::user_desc desc;
-        memset(&desc, 0, sizeof(struct ::user_desc));
+        struct X86Arch::user_desc desc;
+        memset(&desc, 0, sizeof(struct X86Arch::user_desc));
         // Do the ptrace request ourselves
         if (command == PTRACE_GET_THREAD_AREA) {
           int ret = -tracee->emulate_get_thread_area(t->regs().arg3(), desc);

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -931,8 +931,8 @@ static void rep_after_enter_syscall_arch(ReplayTask* t) {
         }
         case PTRACE_SET_THREAD_AREA: {
           bool ok = true;
-          struct ::user_desc desc = t->read_mem(
-              remote_ptr<struct ::user_desc>(t->regs().arg4()), &ok);
+          X86Arch::user_desc desc = t->read_mem(
+              remote_ptr<X86Arch::user_desc>(t->regs().arg4()), &ok);
           if (ok) {
             target->emulate_set_thread_area((int)t->regs().arg3(), desc);
           }


### PR DESCRIPTION
Also use `X86Arch::user_desc` throughout rather than relying on it being defined by system headers. This is the type of the thread area, which isn't used on aarch64. That said, there is little harm to still having the field in Task, we just need to make sure it compiles.