### PR TITLE
Add basic ExtraRegisters support for aarch64

### DIFF
--- a/src/ExtraRegisters.h
+++ b/src/ExtraRegisters.h
@@ -29,8 +29,9 @@ public:
   // Create empty (uninitialized/unknown registers) value
   ExtraRegisters(SupportedArch arch = SupportedArch(-1))
       : format_(NONE), arch_(arch) {}
-
+  enum Format { NONE,
   /**
+   * The XSAVE format is x86(_64) only.
    * On a x86 64-bit kernel, these structures are initialized by an XSAVE64 or
    * FXSAVE64.
    * On a x86 32-bit kernel, they are initialized by an XSAVE or FXSAVE.
@@ -53,7 +54,13 @@ public:
    * The data always uses our CPU's native XSAVE layout. When reading a trace,
    * we need to convert from the trace's CPU's XSAVE layout to our layout.
    */
-  enum Format { NONE, XSAVE };
+  XSAVE,
+  /**
+   * Stores the content of the NT_FPREGS regset. The format depends on the
+   * architecture. It is given by Arch::user_fpregs_struct for the appropriate
+   * architecture.
+   */
+  NT_FPR };
 
   // Set values from raw data, with the given XSAVE layout. Returns false
   // if this could not be done.

--- a/src/GdbRegister.h
+++ b/src/GdbRegister.h
@@ -156,6 +156,7 @@ enum GdbRegister {
   // Last register we can find in user_regs_struct (except for orig_rax).
   DREG_64_NUM_USER_REGS = DREG_64_GS + 1,
 
+  // aarch64-core.xml
   DREG_X0 = 0,
   DREG_X1,
   DREG_X2,
@@ -190,7 +191,44 @@ enum GdbRegister {
   DREG_SP,
   DREG_PC,
   DREG_CPSR,
-  DREG_NUM_LINUX_AARCH64 = DREG_CPSR + 1,
+
+  // aarch64-fpu.xml
+  DREG_V0 = 34,
+  DREG_V1,
+  DREG_V2,
+  DREG_V3,
+  DREG_V4,
+  DREG_V5,
+  DREG_V6,
+  DREG_V7,
+  DREG_V8,
+  DREG_V9,
+  DREG_V10,
+  DREG_V11,
+  DREG_V12,
+  DREG_V13,
+  DREG_V14,
+  DREG_V15,
+  DREG_V16,
+  DREG_V17,
+  DREG_V18,
+  DREG_V19,
+  DREG_V20,
+  DREG_V21,
+  DREG_V22,
+  DREG_V23,
+  DREG_V24,
+  DREG_V25,
+  DREG_V26,
+  DREG_V27,
+  DREG_V28,
+  DREG_V29,
+  DREG_V30,
+  DREG_V31,
+  DREG_FPSR,
+  DREG_FPCR,
+
+  DREG_NUM_LINUX_AARCH64 = DREG_FPCR + 1,
 };
 
 } // namespace rr

--- a/src/TraceStream.cc
+++ b/src/TraceStream.cc
@@ -550,11 +550,23 @@ TraceFrame TraceReader::read_frame() {
   }
   auto extra_reg_data = frame.getExtraRegisters().getRaw();
   if (extra_reg_data.size()) {
+    ExtraRegisters::Format fmt;
+    switch (arch) {
+      case x86:
+      case x86_64:
+        fmt = ExtraRegisters::XSAVE;
+        break;
+      case aarch64:
+        fmt = ExtraRegisters::NT_FPR;
+        break;
+      default:
+        FATAL() << "Unknown architecture";
+    }
     bool ok = ret.recorded_extra_regs.set_to_raw_data(
-        arch, ExtraRegisters::XSAVE, extra_reg_data.begin(),
+        arch, fmt, extra_reg_data.begin(),
         extra_reg_data.size(), xsave_layout_from_trace(cpuid_records()));
     if (!ok) {
-      FATAL() << "Invalid XSAVE data in trace";
+      FATAL() << "Invalid extended register data in trace";
     }
   } else {
     ret.recorded_extra_regs = ExtraRegisters(arch);

--- a/src/kernel_metadata.cc
+++ b/src/kernel_metadata.cc
@@ -26,6 +26,18 @@ string syscall_name(int syscall, SupportedArch arch) {
   case _id:                                                                    \
     return #_id;
 
+string arch_name(SupportedArch arch) {
+  switch (arch) {
+    CASE(x86_64);
+    CASE(x86);
+    CASE(aarch64);
+  default:
+    char buf[100];
+    snprintf(buf, sizeof(buf), "Unknown architecture %d", arch);
+    return string(buf);
+  }
+}
+
 string ptrace_event_name(int event) {
   switch (event) {
     CASE(PTRACE_EVENT_FORK);
@@ -48,7 +60,7 @@ string ptrace_event_name(int event) {
       return "PTRACE_EVENT(0)";
     default: {
       char buf[100];
-      sprintf(buf, "PTRACE_EVENT(%d)", event);
+      snprintf(buf, sizeof(buf), "PTRACE_EVENT(%d)", event);
       return string(buf);
     }
   }
@@ -89,7 +101,7 @@ string ptrace_req_name(int request) {
     CASE(PTRACE_SYSEMU_SINGLESTEP);
     default: {
       char buf[100];
-      sprintf(buf, "PTRACE_REQUEST(%d)", request);
+      snprintf(buf, sizeof(buf), "PTRACE_REQUEST(%d)", request);
       return string(buf);
     }
   }
@@ -143,7 +155,7 @@ string signal_name(int sig) {
       return "signal(0)";
     default: {
       char buf[100];
-      sprintf(buf, "signal(%d)", sig);
+      snprintf(buf, sizeof(buf), "signal(%d)", sig);
       return string(buf);
     }
   }
@@ -291,7 +303,7 @@ string errno_name(int err) {
       CASE(EHWPOISON);
     default: {
       char buf[100];
-      sprintf(buf, "errno(%d)", err);
+      snprintf(buf, sizeof(buf), "errno(%d)", err);
       return string(buf);
     }
   }
@@ -379,7 +391,7 @@ string sicode_name(int code, int sig) {
   }
 
   char buf[100];
-  sprintf(buf, "sicode(%d)", code);
+  snprintf(buf, sizeof(buf), "sicode(%d)", code);
   return string(buf);
 }
 

--- a/src/kernel_metadata.h
+++ b/src/kernel_metadata.h
@@ -13,6 +13,11 @@
 namespace rr {
 
 /**
+ * Return the symbolic name of the architecture `arch`.
+ */
+std::string arch_name(SupportedArch arch);
+
+/**
  * Return the symbolic name of |syscall|, f.e. "read", or "syscall(%d)"
  * if unknown.
  */


### PR DESCRIPTION
For the moment, we use the NT_PRFPREG regset. Modern arm chips
have a few additional registers that are not part of this regset
(most notably pointer auth registers). Applications making use of
those features likely won't work here. That said, let's cross that
bridge when we get there. Having the fp/simd registers should get
us far enough for the moment.