### PR TITLE
Move arch specific ptrace commands into kernel_abi

### DIFF
--- a/src/Registers.h
+++ b/src/Registers.h
@@ -13,7 +13,6 @@
 #include "GdbRegister.h"
 #include "core.h"
 #include "kernel_abi.h"
-#include "kernel_supplement.h"
 #include "remote_code_ptr.h"
 #include "remote_ptr.h"
 

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -334,6 +334,54 @@ struct BaseArch : public wordsize,
   typedef uint64_t __u64;
   typedef __u64 aligned_u64 __attribute((aligned(8)));
 
+  // These are the same across all architectures. The kernel defines them for
+  // all architectures in the uapi headers, but the libc's headers may not.
+  // Further, the libc headers may conflict with the kernel headers, so for
+  // simplicitly, we just define everything here:
+  static const int PTRACE_TRACEME = 0;
+  static const int PTRACE_PEEKTEXT = 1;
+  static const int PTRACE_PEEKDATA = 2;
+  static const int PTRACE_PEEKUSR = 3;
+  static const int PTRACE_POKETEXT = 4;
+  static const int PTRACE_POKEDATA = 5;
+  static const int PTRACE_POKEUSR = 6;
+  static const int PTRACE_CONT = 7;
+  static const int PTRACE_KILL = 8;
+  static const int PTRACE_SINGLESTEP = 9;
+
+  // If they are defined in the header, undef them now.
+  // In rr, we always refer to them as these constants.
+#undef PTRACE_GETREGS
+#undef PTRACE_SETREGS
+#undef PTRACE_GETFPREGS
+#undef PTRACE_SETFPREGS
+#undef PTRACE_GETFPXREGS
+#undef PTRACE_SETFPXREGS
+#undef PTRACE_OLDSETOPTIONS
+#undef PTRACE_GET_THREAD_AREA
+#undef PTRACE_SET_THREAD_AREA
+#undef PTRACE_ARCH_PRCTL
+#undef PTRACE_SYSEMU
+#undef PTRACE_SYSEMU_SINGLESTEP
+
+  // These are architecture specific and may not exist on any given
+  // architecture or the number assigned on the architecture may vary.
+  // Here we give each of these a unique negative number that makes writing
+  // architecture generic code easier (the same approach is used for
+  // architecture specific syscalls).
+  static const int PTRACE_GETREGS = -1;
+  static const int PTRACE_SETREGS = -2;
+  static const int PTRACE_GETFPREGS = -3;
+  static const int PTRACE_SETFPREGS = -4;
+  static const int PTRACE_GETFPXREGS = -5;
+  static const int PTRACE_SETFPXREGS = -6;
+  static const int PTRACE_OLDSETOPTIONS = -7;
+  static const int PTRACE_GET_THREAD_AREA = -8;
+  static const int PTRACE_SET_THREAD_AREA = -9;
+  static const int PTRACE_ARCH_PRCTL = -10;
+  static const int PTRACE_SYSEMU = -11;
+  static const int PTRACE_SYSEMU_SINGLESTEP = -12;
+
   template <typename T> struct ptr {
     typedef T Referent;
     unsigned_word val;
@@ -1658,6 +1706,21 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
 
 #include "SyscallEnumsX64.generated"
 
+  // Architecture specific ptrace commands
+
+  static const int PTRACE_GETREGS = 12;
+  static const int PTRACE_SETREGS = 13;
+  static const int PTRACE_GETFPREGS = 14;
+  static const int PTRACE_SETFPREGS = 15;
+  static const int PTRACE_GETFPXREGS = 18;
+  static const int PTRACE_SETFPXREGS = 19;
+  static const int PTRACE_OLDSETOPTIONS = 21;
+  static const int PTRACE_GET_THREAD_AREA = 25;
+  static const int PTRACE_SET_THREAD_AREA = 26;
+  static const int PTRACE_ARCH_PRCTL = 30;
+  static const int PTRACE_SYSEMU = 31;
+  static const int PTRACE_SYSEMU_SINGLESTEP = 32;
+
   struct user_regs_struct {
     uint64_t r15;
     uint64_t r14;
@@ -1814,6 +1877,20 @@ struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {
   typedef uint16_t legacy_gid_t;
 
 #include "SyscallEnumsX86.generated"
+
+  // The same as x86_64
+  static const int PTRACE_GETREGS = Arch64::PTRACE_GETREGS;
+  static const int PTRACE_SETREGS = Arch64::PTRACE_SETREGS;
+  static const int PTRACE_GETFPREGS = Arch64::PTRACE_GETFPREGS;
+  static const int PTRACE_SETFPREGS = Arch64::PTRACE_SETFPREGS;
+  static const int PTRACE_GETFPXREGS = Arch64::PTRACE_GETFPXREGS;
+  static const int PTRACE_SETFPXREGS = Arch64::PTRACE_SETFPXREGS;
+  static const int PTRACE_OLDSETOPTIONS = Arch64::PTRACE_OLDSETOPTIONS;
+  static const int PTRACE_GET_THREAD_AREA = Arch64::PTRACE_GET_THREAD_AREA;
+  static const int PTRACE_SET_THREAD_AREA = Arch64::PTRACE_SET_THREAD_AREA;
+  // PTRACE_ARCH_PRCTL does not exist on x86
+  static const int PTRACE_SYSEMU = Arch64::PTRACE_SYSEMU;
+  static const int PTRACE_SYSEMU_SINGLESTEP = Arch64::PTRACE_SYSEMU_SINGLESTEP;
 
   struct user_regs_struct {
     int32_t ebx;
@@ -2000,6 +2077,10 @@ struct ARM64Arch : public GenericArch<SupportedArch::aarch64, WordSize64Defs> {
       SelectRegisterArguments;
 
 #include "SyscallEnumsGeneric.generated"
+
+  // Architecture specific ptrace commands
+  static const int PTRACE_SYSEMU = 31;
+  static const int PTRACE_SYSEMU_SINGLESTEP = 32;
 
   struct user_pt_regs {
     uint64_t x[31];

--- a/src/kernel_metadata.cc
+++ b/src/kernel_metadata.cc
@@ -66,26 +66,31 @@ string ptrace_event_name(int event) {
   }
 }
 
+#define PTRACE_ARCH_CASE(_id)                                                  \
+  case Arch::_id:                                                              \
+    return #_id;
+
+template <typename Arch>
 string ptrace_req_name(int request) {
-  switch (request) {
-    CASE(PTRACE_TRACEME);
-    CASE(PTRACE_PEEKTEXT);
-    CASE(PTRACE_PEEKDATA);
-    CASE(PTRACE_PEEKUSER);
-    CASE(PTRACE_POKETEXT);
-    CASE(PTRACE_POKEDATA);
-    CASE(PTRACE_POKEUSER);
-    CASE(PTRACE_CONT);
-    CASE(PTRACE_KILL);
-    CASE(PTRACE_SINGLESTEP);
-    CASE(PTRACE_GETREGS);
-    CASE(PTRACE_SETREGS);
-    CASE(PTRACE_GETFPREGS);
-    CASE(PTRACE_SETFPREGS);
+  switch (request >= 0 ? request : INT32_MAX) {
+    PTRACE_ARCH_CASE(PTRACE_TRACEME);
+    PTRACE_ARCH_CASE(PTRACE_PEEKTEXT);
+    PTRACE_ARCH_CASE(PTRACE_PEEKDATA);
+    PTRACE_ARCH_CASE(PTRACE_PEEKUSR);
+    PTRACE_ARCH_CASE(PTRACE_POKETEXT);
+    PTRACE_ARCH_CASE(PTRACE_POKEDATA);
+    PTRACE_ARCH_CASE(PTRACE_POKEUSR);
+    PTRACE_ARCH_CASE(PTRACE_CONT);
+    PTRACE_ARCH_CASE(PTRACE_KILL);
+    PTRACE_ARCH_CASE(PTRACE_SINGLESTEP);
+    PTRACE_ARCH_CASE(PTRACE_GETREGS);
+    PTRACE_ARCH_CASE(PTRACE_SETREGS);
+    PTRACE_ARCH_CASE(PTRACE_GETFPREGS);
+    PTRACE_ARCH_CASE(PTRACE_SETFPREGS);
+    PTRACE_ARCH_CASE(PTRACE_GETFPXREGS);
+    PTRACE_ARCH_CASE(PTRACE_SETFPXREGS);
     CASE(PTRACE_ATTACH);
     CASE(PTRACE_DETACH);
-    CASE(PTRACE_GETFPXREGS);
-    CASE(PTRACE_SETFPXREGS);
     CASE(PTRACE_SYSCALL);
     CASE(PTRACE_SETOPTIONS);
     CASE(PTRACE_GETEVENTMSG);
@@ -97,8 +102,8 @@ string ptrace_req_name(int request) {
     CASE(PTRACE_INTERRUPT);
     CASE(PTRACE_LISTEN);
     // These aren't part of the official ptrace-request enum.
-    CASE(PTRACE_SYSEMU);
-    CASE(PTRACE_SYSEMU_SINGLESTEP);
+    PTRACE_ARCH_CASE(PTRACE_SYSEMU);
+    PTRACE_ARCH_CASE(PTRACE_SYSEMU_SINGLESTEP);
     default: {
       char buf[100];
       snprintf(buf, sizeof(buf), "PTRACE_REQUEST(%d)", request);
@@ -106,6 +111,10 @@ string ptrace_req_name(int request) {
     }
   }
 }
+
+template string ptrace_req_name<X86Arch>(int request);
+template string ptrace_req_name<X64Arch>(int request);
+template string ptrace_req_name<ARM64Arch>(int request);
 
 string signal_name(int sig) {
   /* strsignal() would be nice to use here, but it provides TMI. */

--- a/src/kernel_metadata.h
+++ b/src/kernel_metadata.h
@@ -33,6 +33,7 @@ std::string ptrace_event_name(int event);
  * Return the symbolic name of the PTRACE_ |request|, or "PTRACE_REQUEST(%d)" if
  * unknown.
  */
+template <typename Arch>
 std::string ptrace_req_name(int request);
 
 /**

--- a/src/kernel_supplement.h
+++ b/src/kernel_supplement.h
@@ -27,29 +27,6 @@ namespace rr {
 #define PTRACE_EVENT_STOP 128
 #endif
 
-#ifndef PTRACE_OLDSETOPTIONS
-#define PTRACE_OLDSETOPTIONS 21
-#endif
-
-#ifndef PTRACE_GET_THREAD_AREA
-#define PTRACE_GET_THREAD_AREA 25
-#endif
-
-#ifndef PTRACE_SET_THREAD_AREA
-#define PTRACE_SET_THREAD_AREA 26
-#endif
-
-#ifndef PTRACE_ARCH_PRCTL
-#define PTRACE_ARCH_PRCTL 30
-#endif
-
-#ifndef PTRACE_SYSEMU
-#define PTRACE_SYSEMU 31
-#endif
-#ifndef PTRACE_SYSEMU_SINGLESTEP
-#define PTRACE_SYSEMU_SINGLESTEP 32
-#endif
-
 #ifndef PTRACE_GETREGSET
 #define PTRACE_GETREGSET 0x4204
 #endif
@@ -323,6 +300,22 @@ struct rr_input_mask {
 #ifndef CLONE_NEWCGROUP
 #define CLONE_NEWCGROUP 0x02000000
 #endif
+
+// These are only defined on x86. For simplicity, we defined
+// them here for all architectures.
+#ifndef ARCH_SET_GS
+#define ARCH_SET_GS 0x1001
+#endif
+#ifndef ARCH_SET_FS
+#define ARCH_SET_FS 0x1002
+#endif
+#ifndef ARCH_GET_FS
+#define ARCH_GET_FS 0x1003
+#endif
+#ifndef ARCH_GET_GS
+#define ARCH_GET_GS 0x1004
+#endif
+
 // New in the 4.12 kernel
 #ifndef ARCH_GET_CPUID
 #define ARCH_GET_CPUID 0x1011

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -1,7 +1,5 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
 
-#include "replay_syscall.h"
-
 #include <asm/prctl.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -24,6 +22,8 @@
 #include <memory>
 #include <sstream>
 #include <string>
+
+#include "replay_syscall.h"
 
 #include "preload/preload_interface.h"
 

--- a/src/util.h
+++ b/src/util.h
@@ -16,6 +16,7 @@
 #include "ScopedFd.h"
 #include "TraceFrame.h"
 #include "remote_ptr.h"
+#include "kernel_supplement.h"
 
 /* This is pretty arbitrary. On Linux SIGPWR is sent to PID 1 (init) on
  * power failure, and it's unlikely rr will be recording that.


### PR DESCRIPTION
ptrace is highly architecture specific. Different architectures support
different ptrace commands and even when they support the same ones, the
number assigned to the PTRACE_* constants can vary (at least for the
low-numbered commands, the numbering scheme was unified in newer kernels).
If they all had the same numbers across architectures (just with some
architectures missing), we could just put everything in kernel_supplement,
but since that's not the case, kernel_abi is probably the right place for
it. This requries a bit of re-organization, but is fairly mechanical.

While we're here, also take care of arch_prctl, but here, since this
syscall is x86_64 specific, we only need to make sure all values we
use are present in kernel_supplement.h