### PR TITLE
Miscellaneous aarch64 build fixes

### DIFF
--- a/src/Registers.cc
+++ b/src/Registers.cc
@@ -544,7 +544,8 @@ void Registers::set_from_ptrace(const NativeArch::user_regs_struct& ptrace_regs)
   DEBUG_ASSERT(arch() == x86 && NativeArch::arch() == x86_64);
   convert_x86<to_x86_narrow, to_x86_narrow>(
       u.x86regs,
-      *const_cast<struct X64Arch::user_regs_struct*>(&ptrace_regs));
+      *const_cast<X64Arch::user_regs_struct*>(
+        reinterpret_cast<const X64Arch::user_regs_struct*>(&ptrace_regs)));
 }
 
 /**
@@ -555,7 +556,7 @@ void Registers::set_from_ptrace(const NativeArch::user_regs_struct& ptrace_regs)
  */
 NativeArch::user_regs_struct Registers::get_ptrace() const {
   union {
-    struct NativeArch::user_regs_struct linux_api;
+    NativeArch::user_regs_struct linux_api;
     struct X64Arch::user_regs_struct x64arch_api;
   } result;
   if (arch() == NativeArch::arch()) {

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -72,7 +72,7 @@ public:
    * rr build is 32-bit, or when the Registers' arch is completely different
    * to the rr build (e.g. ARM vs x86).
    */
-  void set_from_ptrace(const struct NativeArch::user_regs_struct& ptrace_regs);
+  void set_from_ptrace(const NativeArch::user_regs_struct& ptrace_regs);
 
   /**
    * Get a user_regs_struct from these Registers. If the tracee architecture
@@ -83,7 +83,7 @@ public:
    * rr build is 32-bit, or when the Registers' arch is completely different
    * to the rr build (e.g. ARM vs x86).
    */
-  struct NativeArch::user_regs_struct get_ptrace() const;
+  NativeArch::user_regs_struct get_ptrace() const;
 
   /**
    * Get a user_regs_struct for a particular Arch from these Registers.

--- a/src/RerunCommand.cc
+++ b/src/RerunCommand.cc
@@ -112,6 +112,30 @@ static uint8_t user_regs_fields[16] = {
   offsetof(user_regs_struct, esp), offsetof(user_regs_struct, ebp),
   offsetof(user_regs_struct, esi), offsetof(user_regs_struct, edi),
 };
+#elif defined(__aarch64__)
+#define user_regs_struct NativeArch::user_regs_struct
+static uint16_t user_regs_fields[34] = {
+  offsetof(user_regs_struct, x[0]), offsetof(user_regs_struct, x[1]),
+  offsetof(user_regs_struct, x[2]), offsetof(user_regs_struct, x[3]),
+  offsetof(user_regs_struct, x[4]), offsetof(user_regs_struct, x[5]),
+  offsetof(user_regs_struct, x[6]), offsetof(user_regs_struct, x[7]),
+  offsetof(user_regs_struct, x[8]), offsetof(user_regs_struct, x[9]),
+  offsetof(user_regs_struct, x[10]), offsetof(user_regs_struct, x[11]),
+  offsetof(user_regs_struct, x[12]), offsetof(user_regs_struct, x[13]),
+  offsetof(user_regs_struct, x[14]), offsetof(user_regs_struct, x[15]),
+  offsetof(user_regs_struct, x[16]), offsetof(user_regs_struct, x[17]),
+  offsetof(user_regs_struct, x[18]), offsetof(user_regs_struct, x[19]),
+  offsetof(user_regs_struct, x[20]), offsetof(user_regs_struct, x[21]),
+  offsetof(user_regs_struct, x[22]), offsetof(user_regs_struct, x[23]),
+  offsetof(user_regs_struct, x[24]), offsetof(user_regs_struct, x[25]),
+  offsetof(user_regs_struct, x[26]), offsetof(user_regs_struct, x[27]),
+  offsetof(user_regs_struct, x[28]), offsetof(user_regs_struct, x[29]),
+  offsetof(user_regs_struct, x[30]),
+  offsetof(user_regs_struct, sp),
+  offsetof(user_regs_struct, pc),
+  offsetof(user_regs_struct, pstate)
+};
+#undef user_regs_struct
 #else
 #error Unsupported architecture
 #endif

--- a/src/ThreadDb.cc
+++ b/src/ThreadDb.cc
@@ -16,10 +16,8 @@ extern "C" {
 #include "proc_service.h"
 }
 
-#include <asm/prctl.h>
 #include <dlfcn.h>
 #include <linux/elf.h>
-#include <sys/reg.h>
 
 #define LIBRARY_NAME "libthread_db.so.1"
 
@@ -67,7 +65,7 @@ ps_err_e ps_lgetregs(struct ps_prochandle* h, lwpid_t rec_tid,
   rr::Task* task = h->thread_group->session()->find_task(rec_tid);
   DEBUG_ASSERT(task != nullptr);
 
-  struct NativeArch::user_regs_struct regs = task->regs().get_ptrace();
+  NativeArch::user_regs_struct regs = task->regs().get_ptrace();
   memcpy(result, static_cast<void*>(&regs), sizeof(regs));
   LOG(debug) << "ps_lgetregs OK";
   return PS_OK;
@@ -93,6 +91,9 @@ pid_t ps_getpid(struct ps_prochandle* h) {
   return h->tgid;
 }
 
+static const int REG_FS = 25;
+static const int REG_GS = 26;
+
 ps_err_e ps_get_thread_area(const struct ps_prochandle* h, lwpid_t rec_tid,
                             int val, psaddr_t* base) {
   if (!h->thread_group) {
@@ -113,23 +114,26 @@ ps_err_e ps_get_thread_area(const struct ps_prochandle* h, lwpid_t rec_tid,
     }
     LOG(debug) << "ps_get_thread_area 32 failed";
     return PS_ERR;
-  }
+  } else if (task->arch() == rr::x86_64) {
+    uintptr_t result;
+    switch (val) {
+      case REG_FS:
+        result = task->regs().fs_base();
+        break;
+      case REG_GS:
+        result = task->regs().gs_base();
+        break;
+      default:
+        LOG(debug) << "ps_get_thread_area PS_BADADDR";
+        return PS_BADADDR;
+    }
 
-  uintptr_t result;
-  switch (val) {
-    case FS:
-      result = task->regs().fs_base();
-      break;
-    case GS:
-      result = task->regs().gs_base();
-      break;
-    default:
-      LOG(debug) << "ps_get_thread_area PS_BADADDR";
-      return PS_BADADDR;
+    *base = reinterpret_cast<psaddr_t>(result);
+    return PS_OK;
+  } else {
+    LOG(error) << "Unknown architecture in ThreadDb";
+    return PS_ERR;
   }
-
-  *base = reinterpret_cast<psaddr_t>(result);
-  return PS_OK;
 }
 
 rr::ThreadDb::ThreadDb(pid_t tgid)

--- a/src/generate_syscalls.py
+++ b/src/generate_syscalls.py
@@ -153,7 +153,7 @@ generators_for = {
     'SyscallEnumsGeneric': lambda f: write_syscall_enum(f, 'generic'),
     'SyscallEnumsForTestsX86': lambda f: write_syscall_enum_for_tests(f, 'x86'),
     'SyscallEnumsForTestsX64': lambda f: write_syscall_enum_for_tests(f, 'x64'),
-    'SyscallEnumsForTestsGeneric': lambda f: write_syscall_enum(f, 'generic'),
+    'SyscallEnumsForTestsGeneric': lambda f: write_syscall_enum_for_tests(f, 'generic'),
     'SyscallnameArch': write_syscallname_arch,
     'SyscallRecordCase': write_syscall_record_cases,
     'SyscallHelperFunctions': write_syscall_helper_functions,

--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -6,7 +6,6 @@
 
 // Get all the kernel definitions so we can verify our alternative versions.
 #include <arpa/inet.h>
-#include <asm/ldt.h>
 #include <dirent.h>
 #include <elf.h>
 #include <fcntl.h>
@@ -48,6 +47,12 @@
 #include <sys/utsname.h>
 #include <sys/vfs.h>
 #include <termios.h>
+
+// x86_only
+#if defined(__i386__) || defined(__x86_64__)
+#include <asm/prctl.h>
+#include <asm/ldt.h>
+#endif
 
 // Used to verify definitions in kernel_abi.h
 namespace rr {

--- a/src/kernel_abi.cc
+++ b/src/kernel_abi.cc
@@ -66,6 +66,11 @@ namespace rr {
 
 // For instances where the system type and the rr type are named identically.
 #define RR_VERIFY_TYPE(type_) RR_VERIFY_TYPE_EXPLICIT(::type_, type_)
+
+#if defined(__i386__) || defined(__x86_64__)
+#define RR_VERIFY_TYPE_X86(type_) RR_VERIFY_TYPE(type_)
+#define RR_VERIFY_TYPE_X86_ARCH(arch_, system_type_, rr_type_) RR_VERIFY_TYPE_ARCH(arch_, system_type_, rr_type_)
+#endif
 }
 
 #include "kernel_abi.h"

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -53,6 +53,12 @@ template <typename T> struct Verifier<RR_NATIVE_ARCH, T, T> {
 #define RR_VERIFY_TYPE(x)                                  // no-op
 #endif
 
+// For structs whose native definitions only exist on x86
+#ifndef RR_VERIFY_TYPE_X86
+#define RR_VERIFY_TYPE_X86_ARCH(arch_, system_type_, rr_type_) // no-op
+#define RR_VERIFY_TYPE_X86(x)                                  // no-op
+#endif
+
 struct KernelConstants {
   static const ::size_t SIGINFO_MAX_SIZE = 128;
 
@@ -762,7 +768,7 @@ struct BaseArch : public wordsize,
     unsigned_int useable : 1;
     unsigned_int lm : 1;
   };
-  RR_VERIFY_TYPE(user_desc);
+  RR_VERIFY_TYPE_X86(user_desc);
 
   struct __user_cap_header_struct {
     __u32 version;
@@ -1802,8 +1808,8 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
     uint32_t xmm_space[64];
     uint32_t padding[24];
   };
-  RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, ::user_fpregs_struct,
-                      user_fpregs_struct);
+  RR_VERIFY_TYPE_X86_ARCH(SupportedArch::x86_64, ::user_fpregs_struct,
+                          user_fpregs_struct);
 
   struct user {
     struct user_regs_struct regs;
@@ -1828,7 +1834,7 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
     char u_comm[32];
     uint64_t u_debugreg[8];
   };
-  RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, ::user, user);
+  RR_VERIFY_TYPE_X86_ARCH(SupportedArch::x86_64, ::user, user);
 
   struct stat {
     dev_t st_dev;
@@ -1911,7 +1917,7 @@ struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {
     int32_t esp;
     int32_t xss;
   };
-  RR_VERIFY_TYPE_ARCH(SupportedArch::x86, ::user_regs_struct, user_regs_struct);
+  RR_VERIFY_TYPE_X86_ARCH(SupportedArch::x86, ::user_regs_struct, user_regs_struct);
 
   struct user_fpregs_struct {
     int32_t cwd;
@@ -1923,8 +1929,8 @@ struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {
     int32_t fos;
     int32_t st_space[20];
   };
-  RR_VERIFY_TYPE_ARCH(SupportedArch::x86, ::user_fpregs_struct,
-                      user_fpregs_struct);
+  RR_VERIFY_TYPE_X86_ARCH(SupportedArch::x86, ::user_fpregs_struct,
+                          user_fpregs_struct);
 
   struct user_fpxregs_struct {
     uint16_t cwd;
@@ -1989,7 +1995,7 @@ struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {
     char u_comm[32];
     int u_debugreg[8];
   };
-  RR_VERIFY_TYPE_ARCH(SupportedArch::x86, ::user, user);
+  RR_VERIFY_TYPE_X86_ARCH(SupportedArch::x86, ::user, user);
 
   struct stat {
     dev_t st_dev;

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -709,18 +709,6 @@ struct BaseArch : public wordsize,
   };
   RR_VERIFY_TYPE(shm_info);
 
-  struct semid64_ds {
-    ipc64_perm sem_perm;
-    __kernel_time_t sem_otime;
-    __kernel_ulong_t __unused1;
-    __kernel_time_t sem_ctime;
-    __kernel_ulong_t __unused2;
-    __kernel_ulong_t sem_nsems;
-    __kernel_ulong_t __unused3;
-    __kernel_ulong_t __unused4;
-  };
-  RR_VERIFY_TYPE(semid64_ds);
-
   struct seminfo {
     int semmap;
     int semmni;
@@ -1857,6 +1845,18 @@ struct X64Arch : public BaseArch<SupportedArch::x86_64, WordSize64Defs> {
 
   struct stat64 : public stat {};
   RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, struct ::stat64, struct stat64);
+
+  struct semid64_ds {
+    ipc64_perm sem_perm;
+    __kernel_time_t sem_otime;
+    __kernel_ulong_t __unused1;
+    __kernel_time_t sem_ctime;
+    __kernel_ulong_t __unused2;
+    __kernel_ulong_t sem_nsems;
+    __kernel_ulong_t __unused3;
+    __kernel_ulong_t __unused4;
+  };
+  RR_VERIFY_TYPE_ARCH(SupportedArch::x86_64, struct ::semid64_ds, struct semid64_ds);
 };
 
 struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {
@@ -2037,6 +2037,18 @@ struct X86Arch : public BaseArch<SupportedArch::x86, WordSize32Defs> {
     ino64_t st_ino;
   };
   RR_VERIFY_TYPE_ARCH(SupportedArch::x86, struct ::stat64, struct stat64);
+
+  struct semid64_ds {
+    ipc64_perm sem_perm;
+    __kernel_time_t sem_otime;
+    __kernel_ulong_t sem_otime_high;
+    __kernel_time_t sem_ctime;
+    __kernel_ulong_t sem_ctime_high;
+    __kernel_ulong_t sem_nsems;
+    __kernel_ulong_t __unused3;
+    __kernel_ulong_t __unused4;
+  };
+  RR_VERIFY_TYPE_ARCH(SupportedArch::x86, struct ::semid64_ds, struct semid64_ds);
 };
 
 // Archs that inherit Linux's "generic" data structures
@@ -2064,6 +2076,15 @@ struct GenericArch : public BaseArch<arch_, wordsize> {
     struct timespec st_mtim;
     struct timespec st_ctim;
     int __rr_unused[2];
+  };
+
+  struct semid64_ds {
+    typename BaseArch<arch_, wordsize>::ipc64_perm sem_perm;
+    uint64_t sem_otime;
+    uint64_t sem_ctime;
+    typename BaseArch<arch_, wordsize>::unsigned_long sem_nsems;
+    typename BaseArch<arch_, wordsize>::unsigned_long __unused3;
+    typename BaseArch<arch_, wordsize>::unsigned_long __unused4;
   };
 
   struct stat64 : public stat {};
@@ -2103,6 +2124,8 @@ struct ARM64Arch : public GenericArch<SupportedArch::aarch64, WordSize64Defs> {
     uint32_t rr_reserved[2];
   };
   typedef struct user_fpsimd_state user_fpregs_struct;
+
+  RR_VERIFY_TYPE_ARCH(SupportedArch::aarch64, struct ::semid64_ds, struct semid64_ds);
 };
 
 #define RR_ARCH_FUNCTION(f, arch, args...)                                     \

--- a/src/record_signal.cc
+++ b/src/record_signal.cc
@@ -12,7 +12,10 @@
 #include <sys/resource.h>
 #include <sys/user.h>
 #include <syscall.h>
+
+#if defined(__i386__) || defined(__x86_64__)
 #include <x86intrin.h>
+#endif
 
 #include "preload/preload_interface.h"
 
@@ -32,7 +35,14 @@ using namespace std;
 
 namespace rr {
 
-static __inline__ unsigned long long rdtsc(void) { return __rdtsc(); }
+static __inline__ unsigned long long rdtsc(void) {
+#if defined(__i386__) || defined(__x86_64__)
+  return __rdtsc();
+#else
+  FATAL() << "Reached x86-only code path on non-x86 architecture";
+  return 0;
+#endif
+}
 
 static void restore_sighandler_if_not_default(RecordTask* t, int sig) {
   if (t->sig_disposition(sig) != SIGNAL_DEFAULT) {

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2696,8 +2696,12 @@ static void prepare_exit(RecordTask* t) {
 
 static void prepare_mmap_register_params(RecordTask* t) {
   Registers r = t->regs();
+  intptr_t mask_flag = MAP_FIXED;
+#ifdef MAP_32BIT
+  mask_flag |= MAP_32BIT;
+#endif
   if (t->session().enable_chaos() &&
-      !(r.arg4_signed() & (MAP_FIXED | MAP_32BIT)) && r.arg1() == 0) {
+      !(r.arg4_signed() & mask_flag) && r.arg1() == 0) {
     // No address hint was provided. Randomize the allocation address.
     size_t len = r.arg2();
     if (r.arg4_signed() & MAP_GROWSDOWN) {

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -1,6 +1,5 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
 
-#include <asm/prctl.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/futex.h>

--- a/src/test/legacy_ugid.c
+++ b/src/test/legacy_ugid.c
@@ -28,7 +28,7 @@ static void verify_results(size_t n, union legacy_id* ids) {
 #if defined(__i386__)
     // For UID16 syscall-supporting archs, the cookie should be intact.
     test_assert(ids[i].u16[1] == UID_COOKIE);
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
     // For UID32 archs, assume that the user doesn't have a UID with the
     // upper bits equivalent to our cookie.  This is not a great assumption,
     // but we don't really have anything better.

--- a/src/test/util.h
+++ b/src/test/util.h
@@ -17,7 +17,6 @@
 #include <sys/mount.h>
 
 #include <arpa/inet.h>
-#include <asm/prctl.h>
 #include <assert.h>
 #include <ctype.h>
 #include <dirent.h>
@@ -102,12 +101,19 @@
 #include <ucontext.h>
 #include <unistd.h>
 #include <utime.h>
+
+// X86 specific headers
+#if defined(__i386__) || defined(__x86_64__)
+#include <asm/prctl.h>
 #include <x86intrin.h>
+#endif
 
 #if defined(__i386__)
 #include "SyscallEnumsForTestsX86.generated"
 #elif defined(__x86_64__)
 #include "SyscallEnumsForTestsX64.generated"
+#elif defined(__aarch64__)
+#include "SyscallEnumsForTestsGeneric.generated"
 #else
 #error Unknown architecture
 #endif
@@ -188,10 +194,12 @@ inline static void check_data(void* buf, size_t len) {
   }
 }
 
+#if defined(__i386__) || defined(__x86_64)
 /**
  * Return the current value of the time-stamp counter.
  */
 inline static uint64_t rdtsc(void) { return __rdtsc(); }
+#endif
 
 /**
  * Perform some syscall that writes an event, i.e. is not syscall-buffered.


### PR DESCRIPTION
Most not particularly interesting. The one thing I thought was kinda interesting is that of the structs we verify, in kernel_abi.h, there's only one that did not match the layout in BaseArch (semid64_ds), so that's fixed also.