### PR TITLE
Bump timeout in thread_open_race

### DIFF
--- a/src/test/thread_open_race.run
+++ b/src/test/thread_open_race.run
@@ -2,5 +2,7 @@ source `dirname $0`/util.sh
 
 # This test requires syscallbuf syscall patching
 skip_if_no_syscall_buf
+
+TIMEOUT=300
 compare_test EXIT-SUCCESS
 


### PR DESCRIPTION
I'm seeing this intermittently fail (on x86). Looking at the trace, it made it through 832 iterations in the loop and I see good progress in the log, so I don't think it's stuck, rather I think it might just actually be taking a long time depending on how the scheduling works out and how busy the machine is. Let's see if bumping the timeout helps.
Example record.err from a failing test: https://gist.github.com/Keno/b09a63666efffeb82e8aaa01b1abcdcd