### PR TITLE
Move fxregs to correct test category

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -803,7 +803,6 @@ set(BASIC_TESTS
   futex_exit_race_sigsegv
   futex_pi
   futex_priorities
-  fxregs
   gdb_bogus_breakpoint
   gcrypt_rdrand
   getcpu
@@ -1159,6 +1158,7 @@ set(TESTS_WITH_PROGRAM
   fork_stress
   fork_syscalls
   function_calls
+  fxregs
   getcwd
   goto_event
   hello


### PR DESCRIPTION
This test has a .py/.run, but was in the BASIC_TESTS list,
so those were ignored.