### PR TITLE
Fix breakpoint reached checks

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -267,7 +267,7 @@ void RecordSession::handle_seccomp_traced_syscall(RecordTask* t,
     t->resume_execution(RESUME_SYSCALL, RESUME_WAIT, RESUME_NO_TICKS);
     t->vm()->remove_breakpoint(ret_addr, BKPT_INTERNAL);
 
-    ASSERT(t, t->regs().ip() == ret_addr.increment_by_bkpt_insn_length(t->arch()));
+    ASSERT(t, t->regs().ip().undo_executed_bkpt(t->arch()) == ret_addr);
 
     // Now that we're in a sane state, ask the Moneypatcher to try and patch
     // that.

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -691,7 +691,7 @@ static void guard_overshoot(ReplayTask* t, const Registers& target_regs,
      * have been had it not hit the breakpoint (if it did
      * hit the breakpoint).*/
     t->vm()->remove_breakpoint(target_ip, BKPT_INTERNAL);
-    if (t->regs().ip() == target_ip.increment_by_bkpt_insn_length(t->arch())) {
+    if (t->regs().ip().undo_executed_bkpt(t->arch()) == target_ip) {
       t->move_ip_before_breakpoint();
     }
     if (closest_matching_regs) {
@@ -864,8 +864,7 @@ Completion ReplaySession::emulate_async_signal(
         // deterministic signal instead of an async one.
         // So we must have hit our internal breakpoint.
         ASSERT(t, did_set_internal_breakpoint);
-        ASSERT(t,
-               regs.ip().increment_by_bkpt_insn_length(t->arch()) == t->ip());
+        ASSERT(t, regs.ip() == t->ip().undo_executed_bkpt(t->arch()));
         // We didn't do an internal singlestep, and if we'd done a
         // user-requested singlestep we would have hit the above case.
         ASSERT(t, !trap_reasons.singlestep);

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1908,7 +1908,7 @@ void Task::did_waitpid(WaitStatus status) {
     if (did_set_breakpoint_after_cpuid) {
       remote_code_ptr bkpt_addr =
         address_of_last_execution_resume + trapped_instruction_len(singlestepping_instruction);
-      if (ip() == bkpt_addr.increment_by_bkpt_insn_length(arch())) {
+      if (ip().undo_executed_bkpt(arch()) == bkpt_addr) {
         Registers r = regs();
         r.set_ip(bkpt_addr);
         set_regs(r);
@@ -1937,9 +1937,7 @@ void Task::did_waitpid(WaitStatus status) {
     if (as->get_breakpoint_type_at_addr(address_of_last_execution_resume) !=
             BKPT_NONE &&
         stop_sig() == SIGTRAP && !ptrace_event() &&
-        ip() ==
-            address_of_last_execution_resume.increment_by_bkpt_insn_length(
-                arch())) {
+        ip().undo_executed_bkpt(arch()) == address_of_last_execution_resume) {
       ASSERT(this, more_ticks == 0);
       // When we resume execution and immediately hit a breakpoint, the original
       // syscall number can be reset to -1. Undo that, so that the register


### PR DESCRIPTION
There's legitimate reasons to use the increment_by_bkpt_insn_length
function. However, to check whether a breakpoint was reached, we need
to use the undo_executed_bkpt function instead, since the behavior is
arch specific.