### PR TITLE
Work around kernel quirk for invalid syscalls

### DIFF
--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -293,6 +293,7 @@ struct BaseArch : public wordsize,
                   public FcntlConstants,
                   public KernelConstants {
   static SupportedArch arch() { return arch_; }
+  static bool is_x86ish() { return arch_ == x86 || arch_ == x86_64; }
 
   typedef typename wordsize::syscall_slong_t syscall_slong_t;
   typedef typename wordsize::syscall_ulong_t syscall_ulong_t;


### PR DESCRIPTION
On non-x86 systems, it appears the kernel will not set ENOSYS for
syscalls that started out negative, if a seccomp trap is incurred.
I would argue this is a bug since a passive ptracer will affect
program execution, but what can you do.

I've also emailed LKML about it to ask if this is really what was intended here: https://lkml.org/lkml/2020/5/22/1216. 