### PR TITLE
Apply syscall restart register modifications during replay

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -905,7 +905,10 @@ static void maybe_discard_syscall_interruption(RecordTask* t, intptr_t ret) {
   syscallno = t->ev().Syscall().number;
   if (0 > ret) {
     syscall_not_restarted(t);
-  } else {
+  } else if (t->arch() == x86 || t->arch() == x86_64) {
+    // On x86, we would have expected this to get restored to the syscallno.
+    // Since the syscallno is in a different register on other platforms, this
+    // assert does not apply.
     ASSERT(t, syscallno == ret)
         << "Interrupted call was " << t->ev().Syscall().syscall_name()
         << " and sigreturn claims to be restarting "
@@ -918,7 +921,7 @@ static void maybe_discard_syscall_interruption(RecordTask* t, intptr_t ret) {
  * syscall number) from |from| to |to|.
  */
 static void copy_syscall_arg_regs(Registers* to, const Registers& from) {
-  to->set_arg1(from.arg1());
+  to->set_orig_arg1(from.arg1());
   to->set_arg2(from.arg2());
   to->set_arg3(from.arg3());
   to->set_arg4(from.arg4());

--- a/src/ReplaySession.cc
+++ b/src/ReplaySession.cc
@@ -1601,6 +1601,27 @@ ReplayTask* ReplaySession::setup_replay_one_trace_frame(ReplayTask* t) {
         if (current_step.action == TSTEP_RETIRE) {
           t->on_syscall_exit(current_step.syscall.number,
                              current_step.syscall.arch, trace_frame.regs());
+          if (t->arch() == aarch64 && t->regs().syscall_may_restart()) {
+            // If we're restarting a system call, we may have to apply register
+            // modifications to match what the kernel does. Whether or not we need
+            // to do this depends on the ordering of the kernel's register
+            // modification and the signal stop that interrupted the system
+            // call. On x86, the ptrace stop happens first, and then all
+            // register modifications happen. On aarch64, some register
+            // modifications happen [1], then the ptrace stop and then
+            // potentially more register modifications. Any register
+            // modifications that happen after the ptrace signal stop will
+            // get recorded in the signal frame and thus don't need any
+            // special handling. However, for register modifications that
+            // happen before the signal stop, we need to apply them here.
+            // On x86, there are none, but on aarch64, we need to restore arg1
+            // and pc.
+            // [1] https://github.com/torvalds/linux/blob/caffb99b6929f41a69edbb5aef3a359bf45f3315/arch/arm64/kernel/signal.c#L855-L862
+            Registers r = t->regs();
+            r.set_arg1(r.orig_arg1());
+            r.set_ip(r.ip().decrement_by_syscall_insn_length(t->arch()));
+            t->set_regs(r);
+          }
         }
       }
       break;


### PR DESCRIPTION
So this one I'm a little unsure about. @rocallahan I think your insight is required. The question here is when to apply the kernel's register modifications for a system call restart before signal delivery. I would have expected us to already need to do this for x86, but I didn't see the code for it. There's something here: https://github.com/mozilla/rr/blob/master/src/RecordSession.cc#L1523-L1534, but that's on the replay side and also only if there isn't a signal handler installed. What I'm doing in this PR seems to work, but I'm not sure it's the correct place to make this register modification.