### PR TITLE
More robust exits from coredumping signals

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -195,6 +195,7 @@ RecordTask::RecordTask(RecordSession& session, pid_t _tid, uint32_t serial,
       did_record_robust_futex_changes(false),
       waiting_for_reap(false),
       waiting_for_zombie(false),
+      waiting_for_ptrace_exit(false),
       retry_syscall_patching(false) {
   push_event(Event::sentinel());
   if (session.tasks().empty()) {
@@ -1516,7 +1517,8 @@ bool RecordTask::may_be_blocked() const {
          emulated_stop_type != NOT_STOPPED ||
          (EV_SIGNAL_DELIVERY == ev().type() &&
           DISPOSITION_FATAL == ev().Signal().disposition) ||
-         waiting_for_zombie;
+         waiting_for_zombie ||
+         waiting_for_ptrace_exit;
 }
 
 bool RecordTask::maybe_in_spinlock() {

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -735,6 +735,10 @@ public:
   // This task is waiting to reach zombie state
   bool waiting_for_zombie;
 
+  // This task is waiting for a ptrace exit event. It should not
+  // be manuall run.
+  bool waiting_for_ptrace_exit;
+
   // When exiting a syscall, we should call MonkeyPatcher::try_patch_syscall again.
   bool retry_syscall_patching;
 };


### PR DESCRIPTION
Coredumping signals are extremely annoying. Every task in the
same address space, save for the one doing the coredumping
needs to reach its exit event before that task can proceed.
However, we must make sure not to accidentally continue a
task past its exit state, because otherwise it too will hang
until all other tasks have continued. Unfortunately, we don't
have a "ptrace-continue-unless-in-exit-state" command, so we
try to waitpid beforehand to make sure we're not in this
situation. That seems to work reasonably well on x86, but
for some reason not on aarch64, where I'm routinely observing
the waitpid not reporting hat the task has stopped, but
the subsequent ptrace continue, moving it right past the stop.
This change tries to make that race detection slightly less
necessary by not provoking it during coredumping signals
that we inject. Instead, we mark that we're expecting a
ptrace exit event for every task that's about to die and
then refuse to schedule these tasks even if they otherwise
look runnable. This may feel like the return of unstable_exit,
but note that once the exit event arrives, we still process
the exits in an orderly manner, recording each tasks robust
futex changes etc. in order, so we don't lose any of the
advantages that removing unstable exit gave us. Instead,
we're simply avoiding the above described race, and relying
on the existing logic to handle everything properly.