### PR TITLE
Look at the correct arg1 in a few more places

### DIFF
--- a/src/FileMonitor.cc
+++ b/src/FileMonitor.cc
@@ -51,7 +51,7 @@ static int64_t retrieve_offset_arch(Task* t, int syscallno,
     case Arch::write: {
       ASSERT(t, t->session().is_recording())
           << "Can only read a file descriptor's offset while recording";
-      int fd = regs.arg1_signed();
+      int fd = regs.orig_arg1_signed();
       // Get the offset from /proc/*/fdinfo/*
       char fdinfo_path[PATH_MAX];
       sprintf(fdinfo_path, "/proc/%d/fdinfo/%d", t->tid, fd);

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -271,6 +271,25 @@ public:
     }
   }
 
+  void set_orig_arg(int index, uintptr_t value) {
+    switch (index) {
+      case 1:
+        return set_orig_arg1(value);
+      case 2:
+        return set_arg2(value);
+      case 3:
+        return set_arg3(value);
+      case 4:
+        return set_arg4(value);
+      case 5:
+        return set_arg5(value);
+      case 6:
+        return set_arg6(value);
+      default:
+        DEBUG_ASSERT(0 && "Argument index out of range");
+    }
+  }
+
   /**
    * Returns true if syscall_result() indicates failure.
    */

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -755,7 +755,7 @@ void TaskSyscallState::process_syscall_results() {
     for (size_t i = 0; i < param_list.size(); ++i) {
       auto& param = param_list[i];
       if (param.ptr_in_reg) {
-        r.set_arg(param.ptr_in_reg, param.dest.as_int());
+        r.set_orig_arg(param.ptr_in_reg, param.dest.as_int());
       }
       if (!param.ptr_in_memory.is_null()) {
         memory_cleaned_up = true;

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2850,6 +2850,7 @@ static void prepare_clone(RecordTask* t, TaskSyscallState& syscall_state) {
       t->set_regs(r);
       t->enter_syscall();
       r.set_ip(t->regs().ip());
+      r.set_syscallno(original_syscall);
       r.set_original_syscallno(original_syscall);
       t->set_regs(r);
       t->canonicalize_regs(t->arch());

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -5485,7 +5485,7 @@ static void rec_process_syscall_arch(RecordTask* t,
       switch (Arch::mmap_semantics) {
         case Arch::StructArguments: {
           auto args = t->read_mem(
-              remote_ptr<typename Arch::mmap_args>(t->regs().arg1()));
+              remote_ptr<typename Arch::mmap_args>(t->regs().orig_arg1()));
           process_mmap(t, args.len, args.prot, args.flags, args.fd,
                        args.offset / 4096);
           break;
@@ -5515,16 +5515,16 @@ static void rec_process_syscall_arch(RecordTask* t,
     }
 
     case Arch::mremap:
-      process_mremap(t, t->regs().arg1(), t->regs().arg2(), t->regs().arg3());
+      process_mremap(t, t->regs().orig_arg1(), t->regs().arg2(), t->regs().arg3());
       break;
 
     case Arch::shmat:
-      process_shmat(t, (int)t->regs().arg1_signed(),
+      process_shmat(t, (int)t->regs().orig_arg1_signed(),
                     (int)t->regs().arg3_signed(), t->regs().syscall_result());
       break;
 
     case Arch::ipc:
-      switch ((int)t->regs().arg1_signed()) {
+      switch ((int)t->regs().orig_arg1_signed()) {
         case SHMAT: {
           auto out_ptr = t->read_mem(
               remote_ptr<typename Arch::unsigned_long>(t->regs().arg4()));
@@ -5558,7 +5558,7 @@ static void rec_process_syscall_arch(RecordTask* t,
         r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
         t->set_regs(r);
         auto attr =
-            t->read_mem(remote_ptr<struct perf_event_attr>(t->regs().arg1()));
+            t->read_mem(remote_ptr<struct perf_event_attr>(t->regs().orig_arg1()));
         t->fd_table()->add_monitor(t,
             fd, new VirtualPerfCounterMonitor(
                     t, t->session().find_task((pid_t)t->regs().arg2_signed()),
@@ -5582,7 +5582,7 @@ static void rec_process_syscall_arch(RecordTask* t,
     case Arch::openat: {
       Registers r = t->regs();
       if (r.syscall_failed()) {
-        uintptr_t path = syscallno == Arch::openat ? r.arg2() : r.arg1();
+        uintptr_t path = syscallno == Arch::openat ? r.arg2() : r.orig_arg1();
         string pathname = t->read_c_str(remote_ptr<char>(path));
         if (is_gcrypt_deny_file(pathname.c_str())) {
           fake_gcrypt_file(t, &r);
@@ -5612,7 +5612,7 @@ static void rec_process_syscall_arch(RecordTask* t,
 
     case SYS_rrcall_notify_control_msg: {
       auto msg =
-          t->read_mem(remote_ptr<typename Arch::msghdr>(t->regs().arg1()));
+          t->read_mem(remote_ptr<typename Arch::msghdr>(t->regs().orig_arg1()));
       check_scm_rights_fd<Arch>(t, msg);
       break;
     }
@@ -5638,7 +5638,7 @@ static void rec_process_syscall_arch(RecordTask* t,
       break;
 
     case Arch::sched_getaffinity: {
-      pid_t pid = (pid_t)t->regs().arg1();
+      pid_t pid = (pid_t)t->regs().orig_arg1();
       if (!t->regs().syscall_failed() && (pid == 0 || pid == t->rec_tid)) {
         if (t->regs().syscall_result() > sizeof(cpu_set_t)) {
           LOG(warn) << "Don't understand kernel's sched_getaffinity result";
@@ -5671,7 +5671,7 @@ static void rec_process_syscall_arch(RecordTask* t,
       t->set_regs(r);
 
       if (!t->regs().syscall_failed()) {
-        switch ((int)t->regs().arg1_signed()) {
+        switch ((int)t->regs().orig_arg1_signed()) {
           case SYS_RECVMSG: {
             auto args = t->read_mem(
                 remote_ptr<typename Arch::recvmsg_args>(t->regs().arg2()));
@@ -5699,7 +5699,7 @@ static void rec_process_syscall_arch(RecordTask* t,
       break;
 
     case Arch::process_vm_writev: {
-      RecordTask* dest = t->session().find_task(t->regs().arg1());
+      RecordTask* dest = t->session().find_task(t->regs().orig_arg1());
       if (dest) {
         record_iovec_output<Arch>(t, dest, t->regs().arg4(), t->regs().arg5());
       }
@@ -5736,7 +5736,7 @@ static void rec_process_syscall_arch(RecordTask* t,
     case Arch::getdents:
     case Arch::getdents64: {
       Registers r = t->regs();
-      int fd = r.arg1();
+      int fd = r.orig_arg1();
       t->fd_table()->filter_getdents(fd, t);
       break;
     }
@@ -5826,7 +5826,7 @@ static void rec_process_syscall_arch(RecordTask* t,
     }
 
     case Arch::quotactl:
-      switch (t->regs().arg1() >> SUBCMDSHIFT) {
+      switch (t->regs().orig_arg1() >> SUBCMDSHIFT) {
         case Q_GETQUOTA:
         case Q_GETINFO:
         case Q_GETFMT:
@@ -5853,7 +5853,7 @@ static void rec_process_syscall_arch(RecordTask* t,
       Registers r = t->regs();
       r.set_orig_arg1(syscall_state.syscall_entry_registers.arg1());
       t->set_regs(r);
-      if (t->regs().arg1() == SECCOMP_SET_MODE_FILTER) {
+      if (t->regs().orig_arg1() == SECCOMP_SET_MODE_FILTER) {
         ASSERT(t, t->session().done_initial_exec())
             << "no seccomp calls during spawn";
         t->session()


### PR DESCRIPTION
On x86, there is no difference between arg1 and orig_arg1, but on aarch64, the former gets overwritten by the syscall result, so we need to look at the orig_arg1 value we save. I had fixed a bunch of these when I introduced Register support, but missed a few. This accumulates all the ones I found during any of the basic tests (and in the vicinity by inspection).