### PR TITLE
Properly track register modifications for restart_syscall

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -228,6 +228,13 @@ static void note_entering_syscall(RecordTask* t) {
      * (if it's not a SYS_restart_syscall restart)
      * will use the original registers. */
     t->ev().Syscall().regs = t->regs();
+  } else {
+    t->ev().Syscall().regs.set_syscallno(t->regs().syscallno());
+    // We may have intentionally stored the syscall result here.
+    // Now that we're safely past the signal delivery, make the
+    // registers look like they did at the original syscall entry
+    // again.
+    t->ev().Syscall().regs.set_arg1(t->ev().Syscall().regs.orig_arg1());
   }
 }
 
@@ -1144,6 +1151,10 @@ void RecordSession::syscall_state_changed(RecordTask* t,
           Registers r = t->regs();
           copy_syscall_arg_regs(&r, t->ev().Syscall().regs);
           t->set_regs(r);
+          // We need to track what the return value was on architectures
+          // where the kernel replaces the return value by the new arg1
+          // on restart.
+          t->ev().Syscall().regs = r;
         }
         t->record_current_event();
 
@@ -1524,21 +1535,20 @@ bool RecordSession::signal_state_changed(RecordTask* t, StepState* step_state) {
       bool has_other_signals = t->has_any_actionable_signal();
       auto r = t->regs();
       if (!is_fatal) {
-        if (can_switch == PREVENT_SWITCH && !has_other_signals &&
-            r.original_syscallno() >= 0 && r.syscall_may_restart()) {
-          switch (r.syscall_result_signed()) {
+        Event *prev_ev = t->prev_ev();
+        if (can_switch == PREVENT_SWITCH && !has_other_signals && prev_ev &&
+            EV_SYSCALL_INTERRUPTION == prev_ev->type()) {
+          switch (prev_ev->Syscall().regs.syscall_result_signed()) {
             case -ERESTARTNOHAND:
             case -ERESTARTSYS:
             case -ERESTARTNOINTR:
               r.set_syscallno(r.original_syscallno());
-              r.set_ip(r.ip().decrement_by_syscall_insn_length(t->arch()));
               break;
             case -ERESTART_RESTARTBLOCK:
               r.set_syscallno(syscall_number_for_restart_syscall(t->arch()));
-              r.set_ip(r.ip().decrement_by_syscall_insn_length(t->arch()));
               break;
           }
-
+          r.set_ip(r.ip().decrement_by_syscall_insn_length(t->arch()));
           // Now that we've mucked with the registers, we can't switch tasks. That
           // could allow more signals to be generated, breaking our assumption
           // that we are the last signal.

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -413,6 +413,14 @@ public:
   const Event& ev() const { return pending_events.back(); }
 
   /**
+   * Obtain the previous event on the stack (if any) or nullptr (if not)
+   */
+  Event *prev_ev() {
+    ssize_t depth = pending_events.size();
+    return depth > 2 ? &pending_events[depth - 2] : nullptr;
+  }
+
+  /**
    * Call this before recording events or data.  Records
    * syscallbuf data and flushes the buffer, if there's buffered
    * data.


### PR DESCRIPTION
On aarch64, the x8 value for restart_syscall leaks into the
tracee, since it doesn't get overwritten by the syscall result.
As a result, we can't just copy the register state from the
original syscall entry. Also, for signal stops, the restart
errno was already overwritten by the original arg1, so we
need to make sure to save what the errno was (in the
EV_SYSCALL_INTERRUPTION event), so we can look at it when
the signal event arrives.