### PR TITLE
Work around aarch64 x7 woes

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -1882,11 +1882,6 @@ void RecordTask::update_own_namespace_tid() {
   }
 }
 
-void RecordTask::tgkill(int sig) {
-  LOG(debug) << "Sending " << sig << " to tid " << tid;
-  ASSERT(this, 0 == syscall(SYS_tgkill, real_tgid(), tid, sig));
-}
-
 void RecordTask::kill_if_alive() {
   if (!is_dying()) {
     tgkill(SIGKILL);

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -483,11 +483,6 @@ public:
   pid_t find_newborn_process(pid_t child_parent);
 
   /**
-   * Do a tgkill to send a specific signal to this task.
-   */
-  void tgkill(int sig);
-
-  /**
    * If the process looks alive, kill it. It is recommended to call try_wait(),
    * on this task before, to make sure liveness is correctly reflected when
    * making this decision

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -400,6 +400,11 @@ public:
     DEBUG_ASSERT(arch() == aarch64);
     return u.arm64regs.x[1];
   }
+
+  uintptr_t x7() const {
+    DEBUG_ASSERT(arch() == aarch64);
+    return u.arm64regs.x[7];
+  }
   // End of aarch64 specific accessors
 
   /**

--- a/src/Task.h
+++ b/src/Task.h
@@ -918,6 +918,17 @@ public:
                      const std::vector<std::string>& argv,
                      const std::vector<std::string>& envp, pid_t rec_tid = -1);
 
+  /**
+   * Do a tgkill to send a specific signal to this task.
+   */
+  void tgkill(int sig);
+
+  /**
+   * Try to move this task to a signal stop by signaling it with the
+   * syscallbuf desched signal (which is guaranteed not to be blocked).
+   */
+  void move_to_signal_stop();
+
 protected:
   Task(Session& session, pid_t tid, pid_t rec_tid, uint32_t serial,
        SupportedArch a);

--- a/src/record_syscall.h
+++ b/src/record_syscall.h
@@ -33,6 +33,11 @@ void rec_prepare_restart_syscall(RecordTask* t);
  */
 void rec_process_syscall(RecordTask* t);
 
+/**
+ * Apply any necessary processing for an executed sigreturn.
+ */
+void rec_did_sigreturn(RecordTask* t);
+
 } // namespace rr
 
 #endif /* RR_PROCESS_SYSCALL_H_ */

--- a/src/replay_syscall.cc
+++ b/src/replay_syscall.cc
@@ -1183,6 +1183,12 @@ static void rep_process_syscall_arch(ReplayTask* t, ReplayTraceStep* step,
 
     case Arch::sigreturn:
     case Arch::rt_sigreturn:
+      if (Arch::arch() == aarch64) {
+        // The aarch64 kernel has a bug where it refuses to apply updates
+        // to x7 during any syscall stops. Make sure to move to a signal
+        // stop if we reached here using sysemu.
+        t->move_to_signal_stop();
+      }
       t->set_regs(trace_regs);
       t->set_extra_regs(trace_frame.extra_regs());
       step->action = TSTEP_RETIRE;


### PR DESCRIPTION
During a syscall stop, the kernel lies about x7 and ignores writes to
it. That's usually not a problem as long as we don't look at it. However,
it becomes a problem if we do any AutoRemoteSyscall'ing during the exit
processing. AutoRemoteSyscalls might leave us in either a singlestep
or a syscall exit trap. If the former, then trying to re-apply the
registers that it thought the task had before the AutoRemoteSyscall
will actually end up modifying the real x7 register (because we're
no longer in a syscall stop where the kernel would ignore such a
write).

There's also a few other corner cases (e.g. during restart where
similar tricks need to apply).

In general, we rely on x7 being accurate during syscall entry
(since we expect to enter using a seccomp trap), and then
just copy it to the output event.

This is all a huge mess and I have an ongoing thread with
the kernel maintainers pleading for an option to give some sanity
here. That said, this seems to work in the meantime.