### PR TITLE
Add watchpoint support for aarch64

### DIFF
--- a/src/AddressSpace.h
+++ b/src/AddressSpace.h
@@ -213,6 +213,17 @@ enum WatchType {
   WATCH_READWRITE = 0x03
 };
 
+enum ArmWatchType {
+  ARM_WATCH_EXEC = 0x0,
+  ARM_WATCH_READ = 0x1,
+  ARM_WATCH_WRITE = 0x2,
+  ARM_WATCH_READWRITE = ARM_WATCH_READ | ARM_WATCH_WRITE
+};
+
+enum ArmPrivLevel {
+  ARM_PRIV_EL0 = 0x2
+};
+
 enum DebugStatus {
   DS_WATCHPOINT_ANY = 0xf,
   DS_SINGLESTEP = 1 << 14,
@@ -582,6 +593,7 @@ public:
    * are known to not be set on singlestep).
    */
   bool notify_watchpoint_fired(uintptr_t debug_status,
+      remote_ptr<void> hit_addr,
       remote_code_ptr address_of_singlestep_start);
   /**
    * Return true if any watchpoint has fired. Will keep returning true until

--- a/src/Registers.cc
+++ b/src/Registers.cc
@@ -172,7 +172,10 @@ RegisterInfo<rr::ARM64Arch>::Table RegisterInfo<rr::ARM64Arch>::registers = {
   RV_AARCH64(X26, x[26]), RV_AARCH64(X27, x[27]), RV_AARCH64(X28, x[28]),
   RV_AARCH64(X29, x[29]), RV_AARCH64(X30, x[30]),
   RV_AARCH64(SP, sp), RV_AARCH64(PC, pc),
-  RV_AARCH64_WITH_MASK(CPSR, pstate, 0xffffffffLL, 4),
+  // Mask out the single-step flag from the pstate. During replay, we may
+  // single-step to an execution point, which could set the single-step bit
+  // when it wasn't set during record.
+  RV_AARCH64_WITH_MASK(CPSR, pstate, 0xffffffffLL & ~AARCH64_DBG_SPSR_SS, 4),
 };
 
 #undef RV_X64

--- a/src/Registers.cc
+++ b/src/Registers.cc
@@ -674,28 +674,44 @@ void Registers::set_flags(uintptr_t value) {
   }
 }
 
-bool Registers::singlestep_flag() {
+bool Registers::aarch64_singlestep_flag() {
   switch (arch()) {
-    case x86:
-    case x86_64:
-      return flags() & X86_TF_FLAG;
     case aarch64:
       return pstate() & AARCH64_DBG_SPSR_SS;
     default:
-      DEBUG_ASSERT(0 && "Unknown arch");
+      DEBUG_ASSERT(0 && "X86 only code path");
       return false;
   }
 }
 
-void Registers::clear_singlestep_flag() {
+void Registers::set_aarch64_singlestep_flag() {
+  switch (arch()) {
+    case aarch64:
+      return set_pstate(pstate() & AARCH64_DBG_SPSR_SS);
+    default:
+      DEBUG_ASSERT(0 && "AArch64 only code path");
+      return;
+  }
+}
+
+bool Registers::x86_singlestep_flag() {
+  switch (arch()) {
+    case x86:
+    case x86_64:
+      return flags() & X86_TF_FLAG;
+    default:
+      DEBUG_ASSERT(0 && "X86 only code path");
+      return false;
+  }
+}
+
+void Registers::clear_x86_singlestep_flag() {
   switch (arch()) {
     case x86:
     case x86_64:
       return set_flags(flags() & ~X86_TF_FLAG);
-    case aarch64:
-      return set_pstate(pstate() & ~AARCH64_DBG_SPSR_SS);
     default:
-      DEBUG_ASSERT(0 && "Unknown arch");
+      DEBUG_ASSERT(0 && "X86 only code path");
       break;
   }
 }

--- a/src/Registers.h
+++ b/src/Registers.h
@@ -409,11 +409,27 @@ public:
 
   /**
    * Modify the processor's single step flag. On x86 this is the TF flag in the
-   * eflags register. On aarch64 this is the DBG_SPSR_SS flag in the pstate
-   * register.
+   * eflags register.
    */
-  bool singlestep_flag();
-  void clear_singlestep_flag();
+  bool x86_singlestep_flag();
+  void clear_x86_singlestep_flag();
+
+  /**
+   * Aarch64 has two flags that control single stepping. An EL1 one that
+   * enables singlestep execeptions and an EL0 one in pstate (SPSR_SS). The EL1 bit
+   * is controlled by PTRACE_SINGLESTEP (it gets turned on upon the first
+   * PTRACE_(SYSEMU_)SINGLESTEP and turned off on any other ptrace resume).
+   * The EL0 bit controls whether an exception is taken *before* execution
+   * of the next instruction (an exception is taken when the bit is *clear*).
+   * The hardware clears this bit whenever an instruction completes. Thus, to
+   * ensure that a single step actually happens, regardless of how we got to
+   * this step, we must both using PTRACE_SINGLESTEP and *set* the SPSR_SS bit.
+   * Otherwise, if we got to this stop via single step, the SPSR_SS bit will
+   * likely already be clear, and we'd take a single step exception without
+   * ever having executed any userspace instructions whatsoever.
+   */
+  bool aarch64_singlestep_flag();
+  void set_aarch64_singlestep_flag();
 
   void print_register_file(FILE* f) const;
   void print_register_file_compact(FILE* f) const;

--- a/src/ReplaySession.h
+++ b/src/ReplaySession.h
@@ -286,6 +286,8 @@ public:
 
   virtual ReplaySession* as_replay() override { return this; }
 
+  SupportedArch arch() { return trace_in.arch(); }
+
   /**
    * Return true if |sig| is a signal that may be generated during
    * replay but should be ignored.  For example, SIGCHLD can be

--- a/src/Task.h
+++ b/src/Task.h
@@ -546,8 +546,11 @@ public:
    */
   bool set_debug_regs(const DebugRegs& regs);
 
+  bool set_aarch64_debug_regs(int which, ARM64Arch::user_hwdebug_state *regs, size_t nregs);
+  bool get_aarch64_debug_regs(int which, ARM64Arch::user_hwdebug_state *regs);
+
   uintptr_t get_debug_reg(size_t regno);
-  bool set_debug_reg(size_t regno, uintptr_t value);
+  bool set_x86_debug_reg(size_t regno, uintptr_t value);
 
   /** Update the thread area to |addr|. */
   void set_thread_area(remote_ptr<X86Arch::user_desc> tls);

--- a/src/fast_forward.cc
+++ b/src/fast_forward.cc
@@ -177,8 +177,7 @@ FastForwardStatus fast_forward_through_instruction(Task* t, ResumeRequest how,
     // breakpoint must have fired
     return result;
   }
-  if (t->vm()->notify_watchpoint_fired(t->x86_debug_status(),
-          t->last_execution_resume())) {
+  if (t->compute_trap_reasons().watchpoint) { 
     // watchpoint fired
     return result;
   }

--- a/src/kernel_abi.h
+++ b/src/kernel_abi.h
@@ -2111,6 +2111,27 @@ struct ARM64Arch : public GenericArch<SupportedArch::aarch64, WordSize64Defs> {
   };
   typedef struct user_fpsimd_state user_fpregs_struct;
 
+  struct hw_breakpoint_ctrl {
+    uint32_t enabled:1;
+    uint32_t priv:2;
+    uint32_t type:2;
+    uint32_t length:8;
+    uint32_t _pad:19;
+  };
+  static_assert(sizeof(hw_breakpoint_ctrl) == sizeof(uint32_t), "Size mismatch");
+
+  struct hw_bp {
+    uint64_t addr;
+    hw_breakpoint_ctrl ctrl;
+    uint32_t _pad;
+  };
+
+  struct user_hwdebug_state {
+    uint32_t dbg_info;
+    uint32_t pad;
+    struct hw_bp dbg_regs[16];
+  };
+
   struct sigcontext {
     __u64 fault_addr;
     user_pt_regs regs;

--- a/src/test/watchpoint.c
+++ b/src/test/watchpoint.c
@@ -7,7 +7,7 @@ static void breakpoint(void) {
   (void)break_here;
 }
 
-static int var;
+static volatile int var;
 
 static void* thread(__attribute__((unused)) void* unused) {
   var = 1337;

--- a/src/test/watchpoint.py
+++ b/src/test/watchpoint.py
@@ -8,7 +8,7 @@ expect_gdb('Breakpoint 1')
 # Test write watchpoint
 
 send_gdb('p &var')
-expect_gdb(r'\$1 = \(int \*\) ')
+expect_gdb(r'\$1 = \(volatile int \*\) ')
 
 send_gdb('watch *$1')
 expect_gdb('Hardware[()/a-z ]+watchpoint 2')

--- a/src/util.h
+++ b/src/util.h
@@ -341,7 +341,7 @@ inline bool is_kernel_trap(int si_code) {
   /* XXX unable to find docs on which of these "should" be
    * right.  The SI_KERNEL code is seen in the int3 test, so we
    * at least need to handle that. */
-  return si_code == TRAP_TRACE || si_code == TRAP_BRKPT || si_code == SI_KERNEL;
+  return si_code == TRAP_TRACE || si_code == TRAP_BRKPT || si_code == TRAP_HWBKPT || si_code == SI_KERNEL;
 }
 
 enum ProbePort { DONT_PROBE = 0, PROBE_PORT };


### PR DESCRIPTION
There's a few notable differences (aarch64 watchpoints fire before applying instruction effects, you get the matched address, but not which one fired), but in general the capabilities provided are similar to x86, so the number of changes is reasonable.