### PR TITLE
Properly clear ReturnAddressList for aarch64

### DIFF
--- a/src/ReturnAddressList.cc
+++ b/src/ReturnAddressList.cc
@@ -63,7 +63,9 @@ template <> void return_addresses_arch<ARM64Arch>(ReturnAddressList* result, Tas
   // On aarch64, we track all taken branches, so tracking return addresses should
   // not be necessary.
   DEBUG_ASSERT(ReturnAddressList::AARCH64_COUNT == 0);
-  memset(result->addresses, 0, sizeof(result->addresses));
+  for (size_t i = 0; i < array_length(result->addresses); ++i) {
+    result->addresses[i] = nullptr;
+  }
 }
 
 static void compute_return_addresses(ReturnAddressList* result, Task* t) {

--- a/src/ReturnAddressList.h
+++ b/src/ReturnAddressList.h
@@ -28,7 +28,11 @@ struct ReturnAddressList {
    * will probably not be), but they will be a function of the task's current
    * state, so may be useful for distinguishing this state from other states.
    */
-  ReturnAddressList() { memset(addresses, 0, sizeof(addresses)); }
+  ReturnAddressList() {
+    for (size_t i = 0; i < MAX_COUNT; ++i) {
+      addresses[i] = nullptr;
+    }
+  }
   explicit ReturnAddressList(Task* t);
 
   bool operator==(const ReturnAddressList& other) const {


### PR DESCRIPTION
The memset from ff4802e (#2579) fails to build since remote_ptr is a non-trivial type:

```
In file included from /home/src/github.com/mozilla/rr/rr/src/ReplayTimeline.h:16,
                 from /home/src/github.com/mozilla/rr/rr/src/GdbConnection.h:17,
                 from /home/src/github.com/mozilla/rr/rr/src/GdbServer.h:11,
                 from /home/src/github.com/mozilla/rr/rr/src/CPUFeaturesCommand.cc:4:
/home/src/github.com/mozilla/rr/rr/src/ReturnAddressList.h: In constructor ‘rr::ReturnAddressList::ReturnAddressList()’:
/home/src/github.com/mozilla/rr/rr/src/ReturnAddressList.h:31:63: error: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘class rr::remote_ptr<void>’; use assignment or value-initialization instead [-Werror=class-memaccess]
   31 |   ReturnAddressList() { memset(addresses, 0, sizeof(addresses)); }
      |                                                               ^
In file included from /home/src/github.com/mozilla/rr/rr/src/preload/preload_interface.h:50,
                 from /home/src/github.com/mozilla/rr/rr/src/AddressSpace.h:18,
                 from /home/src/github.com/mozilla/rr/rr/src/Session.h:13,
                 from /home/src/github.com/mozilla/rr/rr/src/DiversionSession.h:7,
                 from /home/src/github.com/mozilla/rr/rr/src/GdbServer.h:10,
                 from /home/src/github.com/mozilla/rr/rr/src/CPUFeaturesCommand.cc:4:
/home/src/github.com/mozilla/rr/rr/src/preload/../remote_ptr.h:24:29: note: ‘class rr::remote_ptr<void>’ declared here
   24 | template <typename T> class remote_ptr {
      |                             ^~~~~~~~~~
```