### PR TITLE
Use GDB "hbreak+" extension

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -2085,6 +2085,11 @@ static int random_addr_bits(SupportedArch arch) {
     // and only the bottom half is usable by user space
     case x86_64:
       return 47;
+    // Aarch64 has 48 bit address space, with user and kernel each getting
+    // their own 48 bits worth of address space at opposite end of the full
+    // 64-bit address space.
+    case aarch64:
+      return 48;
   }
 }
 

--- a/src/GdbConnection.cc
+++ b/src/GdbConnection.cc
@@ -654,6 +654,8 @@ bool GdbConnection::query(char* payload) {
     LOG(debug) << "gdb supports " << args;
 
     multiprocess_supported_ = strstr(args, "multiprocess+") != nullptr;
+    hwbreak_supported_ = strstr(args, "hwbreak+") != nullptr;
+    swbreak_supported_ = strstr(args, "swbreak+") != nullptr;
 
     stringstream supported;
     // Encourage gdb to use very large packets since we support any packet size
@@ -665,6 +667,8 @@ bool GdbConnection::query(char* payload) {
                  ";qXfer:siginfo:read+"
                  ";qXfer:siginfo:write+"
                  ";multiprocess+"
+                 ";hwbreak+"
+                 ";swbreak+"
                  ";ConditionalBreakpoints+"
                  ";vContSupported+";
     if (features().reverse_execution) {
@@ -1446,30 +1450,24 @@ static int to_gdb_signum(int sig) {
 }
 
 void GdbConnection::send_stop_reply_packet(GdbThreadId thread, int sig,
-                                           uintptr_t watch_addr) {
+                                           const char *reason) {
   if (sig < 0) {
     write_packet("E01");
     return;
   }
-  char watch[1024];
-  if (watch_addr) {
-    snprintf(watch, sizeof(watch) - 1, "watch:%" PRIxPTR ";", watch_addr);
-  } else {
-    watch[0] = '\0';
-  }
   char buf[PATH_MAX];
   if (multiprocess_supported_) {
     snprintf(buf, sizeof(buf) - 1, "T%02xthread:p%02x.%02x;%s",
-           to_gdb_signum(sig), thread.pid, thread.tid, watch);
+           to_gdb_signum(sig), thread.pid, thread.tid, reason);
   } else {
     snprintf(buf, sizeof(buf) - 1, "T%02xthread:%02x;%s",
-           to_gdb_signum(sig), thread.tid, watch);
+           to_gdb_signum(sig), thread.tid, reason);
   }
   write_packet(buf);
 }
 
 void GdbConnection::notify_stop(GdbThreadId thread, int sig,
-                                uintptr_t watch_addr) {
+                                const char *reason) {
   DEBUG_ASSERT(req.is_resume_request() || req.type == DREQ_INTERRUPT);
 
   if (tgid != thread.pid) {
@@ -1479,7 +1477,11 @@ void GdbConnection::notify_stop(GdbThreadId thread, int sig,
     // the next stop we're willing to tell gdb about.
     return;
   }
-  send_stop_reply_packet(thread, sig, watch_addr);
+
+  if (!reason) {
+    reason = "";
+  }
+  send_stop_reply_packet(thread, sig, reason);
 
   // This isn't documented in the gdb remote protocol, but if we
   // don't do this, gdb will sometimes continue to send requests
@@ -1669,7 +1671,7 @@ void GdbConnection::reply_set_reg(bool ok) {
 void GdbConnection::reply_get_stop_reason(GdbThreadId which, int sig) {
   DEBUG_ASSERT(DREQ_GET_STOP_REASON == req.type);
 
-  send_stop_reply_packet(which, sig);
+  send_stop_reply_packet(which, sig, "");
 
   consume_request();
 }

--- a/src/GdbConnection.h
+++ b/src/GdbConnection.h
@@ -397,7 +397,7 @@ public:
    * target has stopped executing for some reason.  |sig| is the signal
    * that stopped execution, or 0 if execution stopped otherwise.
    */
-  void notify_stop(GdbThreadId which, int sig, uintptr_t watch_addr = 0);
+  void notify_stop(GdbThreadId which, int sig, const char *reason=nullptr);
 
   /** Notify the debugger that a restart request failed. */
   void notify_restart_failed();
@@ -599,6 +599,9 @@ public:
   */
   bool is_connection_alive();
 
+  bool hwbreak_supported() { return hwbreak_supported_; }
+  bool swbreak_supported() { return swbreak_supported_; }
+
 private:
   /**
    * read() incoming data exactly one time, successfully.  May block.
@@ -666,7 +669,7 @@ private:
   bool process_packet();
   void consume_request();
   void send_stop_reply_packet(GdbThreadId thread, int sig,
-                              uintptr_t watch_addr = 0);
+                              const char *reason);
   void send_file_error_reply(int system_errno);
 
   // Current request to be processed.
@@ -690,6 +693,8 @@ private:
   Features features_;
   bool connection_alive_;
   bool multiprocess_supported_; // client supports multiprocess extension
+  bool hwbreak_supported_; // client supports hwbreak extension
+  bool swbreak_supported_; // client supports swbreak extension
 };
 
 } // namespace rr

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -696,6 +696,17 @@ void Task::on_syscall_exit_arch(int syscallno, const Registers& regs) {
               tracee->set_regs(r);
               break;
             }
+            case NT_ARM_HW_WATCH:
+            case NT_ARM_HW_BREAK: {
+              auto set = ptrace_get_regs_set<Arch>(
+                  this, regs, offsetof(ARM64Arch::user_hwdebug_state, dbg_regs[0]));
+              ASSERT(this, set.size() >= sizeof(int));
+              tracee->set_aarch64_debug_regs((int)regs.arg3(),
+                (ARM64Arch::user_hwdebug_state*)set.data(),
+                (set.size() - offsetof(ARM64Arch::user_hwdebug_state, dbg_regs[0]))/
+                  2*sizeof(ARM64Arch::hw_bp));
+              break;
+            }
             case NT_X86_XSTATE: {
               switch (tracee->extra_regs().format()) {
                 case ExtraRegisters::XSAVE: {


### PR DESCRIPTION
This GDB protocol extension allows reporting hardware breakpoints
as a stop reason. Without it, we report hardware breakpoints as
watchpoints, but aarch64 GDB considers them separate (probably
because they're separate hardware registers on aarch64), so it
just ignores hardware breakpoints reported that way.

While we're at it, also add the appropriate ptrace emulation for
aarch64 hardware break/watchpoints.