### PR TITLE
Add new install option for Fedora.

### DIFF
--- a/index.html
+++ b/index.html
@@ -294,6 +294,8 @@ New value = 11220
       <pre>cd /tmp
 wget https://github.com/mozilla/rr/releases/download/<span class=ver>5.3.0</span>/rr-<span class=ver>5.3.0</span>-Linux-$(uname -m).rpm
 sudo dnf install rr-<span class=ver>5.3.0</span>-Linux-$(uname -m).rpm</pre>
+      <p>You can also install rr directly from the package manager.</p>
+      <pre>sudo dnf install rr</pre>
     </div>
 
     <div>


### PR DESCRIPTION
Users can now install rr straight from the `dnf` package manager on Fedora.