### PR TITLE
[RFC] i386: Avoid IPC_64 in the semctl syscall with cmd IPC_STAT.

### DIFF
--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -97,22 +97,22 @@ union _semun {
  * linux/shm.h.
  */
 static int _shmctl(int shmid, int cmd, shmid64_ds* buf) {
-  if (sizeof(void*) == 4) {
-    cmd |= IPC_64;
-  }
 #ifdef SYS_shmctl
   return syscall(SYS_shmctl, shmid, cmd, buf);
 #else
+  if (sizeof(void*) == 4) {
+    cmd |= IPC_64;
+  }
   return syscall(SYS_ipc, SHMCTL, shmid, cmd, 0, buf);
 #endif
 }
 static int _semctl(int semid, int semnum, int cmd, _semun un_arg) {
-  if (sizeof(void*) == 4) {
-    cmd |= IPC_64;
-  }
 #ifdef SYS_semctl
   return syscall(SYS_semctl, semid, semnum, cmd, un_arg);
 #else
+  if (sizeof(void*) == 4) {
+    cmd |= IPC_64;
+  }
   return syscall(SYS_ipc, SEMCTL, semid, semnum, cmd, &un_arg);
 #endif
 }


### PR DESCRIPTION
The IPC_64 was added unconditionally on i386.
At least up until debian kernel 4.19.118 this was no issue or expected.

At least in newer i386 debian kernel 5.6.14
semctl with IPC_STAT|IPC_64 returns EINVAL.

This patch tries to call on i386 first with IPC_64. If this fails
call again without IPC_64.

Or is that a case of breaking userland and should be
reported to the kernel and handled there (additionally)?

[FATAL /home/benutzer/source/rr/git/rr/src/record_syscall.cc:1286:prepare_semctl() errno: EINVAL]
 (task 24867 (rec:24867) at time 230)
 -> Assertion `ret == 0' failed to hold.

Affected tests:
        sem
        sem-no-syscallbuf
        shm
        shm-no-syscallbuf
        shm_unmap
        shm_unmap-no-syscallbuf
        shm_checkpoint
        shm_checkpoint-no-syscallbuf

Maybe related:
https://sourceware.org/git/?p=glibc.git;a=commit;h=720e9541f5d919f3735925a4e6324ecdec171844
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/ipc/sem.c?id=275f22148e8720e84b180d9e0cdf8abfd69bac5b