### PR TITLE
let the user specify substitute source paths for libraries

### DIFF
--- a/src/SourcesCommand.cc
+++ b/src/SourcesCommand.cc
@@ -56,7 +56,8 @@ SourcesCommand SourcesCommand::singleton(
     " rr sources [<trace_dir>]\n"
     "  --substitute=LIBRARY=PATH  When searching for the source to LIBRARY,\n"
     "                             substitute PATH in place of the path stored\n"
-    "                             in the library's DWARF debug information.\n");
+    "                             in the library's DW_AT_comp_dir property\n"
+    "                             for all compilation units.\n");
 
 static void parent_dir(string& s) {
   size_t p = s.rfind('/');


### PR DESCRIPTION
Most binaries with debug info have a DW_AT_comp_dir which comes from
the build machine. If that directory doesn't exist, "rr sources" can't
list any of the source files for that library. This option allows the
user to manually specify the correct directory containing the source
code for the binary.

In my case there was no source package for a library used by a binary that I was recording. I had to clone the source repository and check out the correct tag to get the correct source files.