### PR TITLE
Don't update latest-trace symlink when using  --output-trace-dir

### DIFF
--- a/src/RecordCommand.cc
+++ b/src/RecordCommand.cc
@@ -647,7 +647,8 @@ static WaitStatus record(const vector<string>& args, const RecordFlags& flags) {
   do {
     bool done_initial_exec = session->done_initial_exec();
     step_result = session->record_step();
-    if (!done_initial_exec && session->done_initial_exec()) {
+    // Only create latest-trace symlink if --output-trace-dir is not being used
+    if (!done_initial_exec && session->done_initial_exec() && flags.output_trace_dir.empty()) {
       session->trace_writer().make_latest_trace();
     }
   } while (step_result.status == RecordSession::STEP_CONTINUE && !term_requested);


### PR DESCRIPTION
On each recording run, the symlink in the default trace directory is updated with the latest trace. However, this can cause a crash if the default trace directory is not already created before `rr record --output-trace-dir <target-dir>` is run, because this flag disables the creation of the default trace directory in favor of creating `<target-dir>`.

This change adds a check to only attempt to update the symlink if the `--output-trace-dir` option is not being used.