### PR TITLE
Check for task event time monotonicity and update var `last_time` in loop

### DIFF
--- a/src/DumpCommand.cc
+++ b/src/DumpCommand.cc
@@ -176,13 +176,14 @@ static void dump_events_matching(TraceReader& trace, const DumpFlags& flags,
   while (true) {
     FrameTime time;
     TraceTaskEvent r = trace.read_task_event(&time);
-    if (time <= last_time) {
-      FATAL() << "TraceTaskEvent times non-increasing";
+    if (time < last_time) {
+      FATAL() << "TraceTaskEvent times non-monotonic";
     }
     if (r.type() == TraceTaskEvent::NONE) {
       break;
     }
     task_events.insert(make_pair(time, r));
+    last_time = time;
   }
 
   bool process_raw_data =


### PR DESCRIPTION
https://github.com/mozilla/rr/blob/a9024348faf0e1daff77640b03139cc6c4ed70e2/src/DumpCommand.cc#L174-L186

I am wondering about the use of variable `last_time` in the above code snippet. The variable itself is never updated (it always remains zero). 

Now a reasonable conclusion would be that we need to update its value at the end of the while loop. E.g. do

```c
last_time = time;
```

But this would not work for some traces. `time` can remain the same (and not increase) for some trace task events while going around this while loop (e.g. try `exec_from_other_thread` test dump). So if we make above change we will get a fatal error at line 180. 

What is the correct treatment here? Maybe use < instead of <= ?
```c
if (time < last_time) { 
     FATAL() << "TraceTaskEvent times non-monotonic"; 
} 
```