### PR TITLE
Leave AddressSpace::verify if Task already exited.

### DIFF
--- a/src/AddressSpace.cc
+++ b/src/AddressSpace.cc
@@ -1552,6 +1552,10 @@ void AddressSpace::verify(Task* t) const {
 
   MemoryMap::const_iterator mem_it = mem.begin();
   KernelMapIterator kernel_it(t);
+  if (kernel_it.at_end()) {
+    LOG(debug) << "Task " << t->tid << " exited unexpectedly, ignoring";
+    return;
+  }
   while (!kernel_it.at_end() && mem_it != mem.end()) {
     KernelMapping km = kernel_it.current();
     ++kernel_it;


### PR DESCRIPTION
Thanks for the fast response.
Your proposed change fixed the test at my test system.
Fixes 2633.