### PR TITLE
Mention man pages in the perf_event_paranoid error

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -2125,7 +2125,8 @@ static string lookup_by_path(const string& name) {
           fprintf(stderr,
                   "rr needs /proc/sys/kernel/perf_event_paranoid <= 1, but it is %d.\n"
                   "Change it to 1, or use 'rr record -n' (slow).\n"
-                  "Consider putting 'kernel.perf_event_paranoid = 1' in /etc/sysctl.conf\n",
+                  "Consider putting 'kernel.perf_event_paranoid = 1' in /etc/sysctl.conf.\n"
+                  "See 'man 8 sysctl', 'man 5 sysctl.d' and 'man 5 sysctl.conf' for more details.\n",
                   val);
           exit(1);
         }


### PR DESCRIPTION
Pointing users to relevant man pages here is IMHO good addition to just telling what to do (which might not work on all distributions, see #2638) and can help one understand what is actually needed for `rr` to run properly.