### PR TITLE
Don't copy XSAVE data related to unsupported CPU features

### DIFF
--- a/src/Flags.h
+++ b/src/Flags.h
@@ -68,6 +68,10 @@ struct Flags {
   // User override for the path to page files and other resources.
   std::string resource_path;
 
+  // When set, ignore any XSAVE data which is incompatible with the available CPU
+  // features. This can improve trace portability, but is dangerous because it may lead to unexpected behavior and crashes.
+  bool dangerous_ignore_xsave_mismatch;
+
   Flags()
       : checksum(CHECKSUM_NONE),
         dump_on(DUMP_ON_NONE),
@@ -78,7 +82,8 @@ struct Flags {
         suppress_environment_warnings(false),
         fatal_errors_and_warnings(false),
         disable_cpuid_faulting(false),
-        disable_ptrace_exit_events(false) {}
+        disable_ptrace_exit_events(false),
+        dangerous_ignore_xsave_mismatch(false) {}
 
   static const Flags& get() { return singleton; }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -61,6 +61,13 @@ void print_global_options(FILE* out) {
       "should\n"
       "                             be located in PATH/bin, PATH/lib[64], and\n"
       "                             PATH/share as appropriate.\n"
+      "  --dangerous-ignore-xsave-mismatch\n"
+      "                             ignore any XSAVE data which is "
+      "incompatible\n"
+      "                             with the available CPU features. This is\n"
+      "                             dangerous and can lead to unexpected "
+      "behavior\n"
+      "                             and crashes.\n"
       "  -A, --microarch=<NAME>     force rr to assume it's running on a CPU\n"
       "                             with microarch NAME even if runtime "
       "detection\n"
@@ -136,6 +143,7 @@ bool parse_global_option(std::vector<std::string>& args) {
     { 0, "disable-cpuid-faulting", NO_PARAMETER },
     { 1, "disable-ptrace-exit-events", NO_PARAMETER },
     { 2, "resource-path", HAS_PARAMETER },
+    { 3, "dangerous-ignore-xsave-mismatch", NO_PARAMETER },
     { 'A', "microarch", HAS_PARAMETER },
     { 'C', "checksum", HAS_PARAMETER },
     { 'D', "dump-on", HAS_PARAMETER },
@@ -167,6 +175,9 @@ bool parse_global_option(std::vector<std::string>& args) {
       if (flags.resource_path.back() != '/') {
         flags.resource_path.append("/");
       }
+      break;
+    case 3:
+      flags.dangerous_ignore_xsave_mismatch = true;
       break;
     case 'A':
       flags.forced_uarch = opt.value;


### PR DESCRIPTION
Rather than causing ExtraRegisters::set_to_raw_data to fail when native CPU features != found CPU features, instead simply do not copy the XSAVE data associated with those features.

This should improve trace portability in situations where the replay CPU does not support some of the expected features, but those features (and the XSAVE data associated with them) are not having any noticeable impact on the execution path.