### PR TITLE
Preserve FdTables properly during a session fork.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1203,6 +1203,7 @@ set(TESTS_WITH_PROGRAM
   link
   madvise_dontfork
   main_thread_exit
+  mmap_fd_reuse_checkpoint
   mmap_replace_most_mappings
   mmap_shared_prot
   mmap_shared_write_exec_race

--- a/src/FdTable.h
+++ b/src/FdTable.h
@@ -34,11 +34,10 @@ public:
   void did_dup(int from, int to);
   void did_close(int fd);
 
-  shr_ptr clone(Task* t) {
-    shr_ptr fds(new FdTable(*this));
-    fds->insert_task(t);
-    return fds;
+  shr_ptr clone() const {
+    return shr_ptr(new FdTable(*this));
   }
+
   static shr_ptr create(Task* t) {
     shr_ptr fds(new FdTable());
     fds->insert_task(t);

--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -290,11 +290,13 @@ TraceWriter& RecordTask::trace_writer() const {
 Task* RecordTask::clone(CloneReason reason, int flags, remote_ptr<void> stack,
                         remote_ptr<void> tls, remote_ptr<int> cleartid_addr,
                         pid_t new_tid, pid_t new_rec_tid, uint32_t new_serial,
-                        Session* other_session, ThreadGroup::shr_ptr new_tg) {
+                        Session* other_session, FdTable::shr_ptr new_fds,
+                        ThreadGroup::shr_ptr new_tg) {
   ASSERT(this, reason == Task::TRACEE_CLONE);
   ASSERT(this, new_tg == nullptr);
   Task* t = Task::clone(reason, flags, stack, tls, cleartid_addr, new_tid,
-                        new_rec_tid, new_serial, other_session, new_tg);
+                        new_rec_tid, new_serial, other_session, new_fds,
+                        new_tg);
   if (t->session().is_recording()) {
     RecordTask* rt = static_cast<RecordTask*>(t);
     if (CLONE_CLEARTID & flags) {

--- a/src/RecordTask.h
+++ b/src/RecordTask.h
@@ -64,6 +64,7 @@ public:
               remote_ptr<void> tls, remote_ptr<int> cleartid_addr,
               pid_t new_tid, pid_t new_rec_tid, uint32_t new_serial,
               Session* other_session = nullptr,
+              FdTable::shr_ptr new_fds = nullptr,
               ThreadGroup::shr_ptr new_tg = nullptr) override;
   virtual void post_wait_clone(Task* cloned_from, int flags) override;
   virtual void on_syscall_exit(int syscallno, SupportedArch arch,

--- a/src/Session.cc
+++ b/src/Session.cc
@@ -38,6 +38,7 @@ struct Session::CloneCompletion {
     vector<pair<remote_ptr<void>, vector<uint8_t>>> captured_memory;
   };
   vector<AddressSpaceClone> address_spaces;
+  Task::ClonedFdTables cloned_fd_tables;
 };
 
 Session::Session()
@@ -369,7 +370,8 @@ void Session::finish_initializing() const {
             (self, nullptr, asmember.tguid.tid(), asmember.tguid.tid(), asmember.tguid.serial());
           self->on_create(tg.get());
         }
-        Task* t_clone = Task::os_clone_into(asmember, remote, tg);
+        Task* t_clone = Task::os_clone_into(
+            asmember, remote, clone_completion->cloned_fd_tables, tg);
         self->on_create(t_clone);
         t_clone->copy_state(asmember);
       }
@@ -607,11 +609,23 @@ static vector<uint8_t> capture_syscallbuf(const AddressSpace::Mapping& m,
   return clone_leader->read_mem(start, data_size);
 }
 
+static FdTable::shr_ptr& get_or_clone_fd_table(
+    Task::ClonedFdTables& existing_clones, Task* task_to_clone) {
+  auto original_fd_table = task_to_clone->fd_table();
+  FdTable::shr_ptr& existing_clone =
+      existing_clones[uintptr_t(original_fd_table.get())];
+  if (!existing_clone) {
+    existing_clone = original_fd_table->clone();
+  }
+  return existing_clone;
+}
+
 void Session::copy_state_to(Session& dest, EmuFs& emu_fs, EmuFs& dest_emu_fs) {
   assert_fully_initialized();
   DEBUG_ASSERT(!dest.clone_completion);
 
   auto completion = unique_ptr<CloneCompletion>(new CloneCompletion());
+  auto& cloned_fd_tables = completion->cloned_fd_tables;
 
   for (auto vm : vm_map) {
     // Pick an arbitrary task to be group leader. The actual group leader
@@ -623,7 +637,8 @@ void Session::copy_state_to(Session& dest, EmuFs& emu_fs, EmuFs& dest_emu_fs) {
     completion->address_spaces.push_back(CloneCompletion::AddressSpaceClone());
     auto& group = completion->address_spaces.back();
 
-    group.clone_leader = group_leader->os_fork_into(&dest);
+    group.clone_leader = group_leader->os_fork_into(
+        &dest, get_or_clone_fd_table(cloned_fd_tables, group_leader));
     dest.on_create(group.clone_leader);
     LOG(debug) << "  forked new group leader " << group.clone_leader->tid;
 
@@ -657,6 +672,7 @@ void Session::copy_state_to(Session& dest, EmuFs& emu_fs, EmuFs& dest_emu_fs) {
         }
         LOG(debug) << "    cloning " << t->rec_tid;
 
+        get_or_clone_fd_table(cloned_fd_tables, t);
         group.member_states.push_back(t->capture_state());
       }
     }

--- a/src/test/mmap_fd_reuse_checkpoint.c
+++ b/src/test/mmap_fd_reuse_checkpoint.c
@@ -1,0 +1,36 @@
+/* -*- Mode: C; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
+
+#include "util.h"
+
+static int fd;
+
+void do_checkpoint(void) {}
+
+static void* le_thread(__attribute__((unused)) void* p) {
+  do_checkpoint();
+  close(fd);
+  return NULL;
+}
+
+int main(void) {
+  size_t page_size = sysconf(_SC_PAGESIZE);
+  const char kFileName[] = "file";
+
+  fd = open(kFileName, O_CREAT | O_EXCL | O_RDWR, 0600);
+  assert(fd >= 0);
+
+  int old = fd;
+
+  char* wpage = mmap(NULL, page_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  assert(wpage != MAP_FAILED);
+
+  pthread_t thread;
+  pthread_create(&thread, NULL, le_thread, wpage);
+  pthread_join(thread, NULL);
+
+  fd = open(kFileName, O_EXCL | O_RDWR, 0600);
+  assert(fd == old && "test expects fd reuse");
+
+  munmap(wpage, 0);
+  unlink(kFileName);
+}

--- a/src/test/mmap_fd_reuse_checkpoint.py
+++ b/src/test/mmap_fd_reuse_checkpoint.py
@@ -1,0 +1,17 @@
+from util import *
+
+send_gdb('break do_checkpoint')
+expect_gdb('Breakpoint 1')
+send_gdb('c')
+expect_gdb('Breakpoint 1')
+send_gdb('checkpoint')
+expect_gdb('Checkpoint 1')
+send_gdb('c')
+expect_gdb('xited normally')
+send_gdb('restart 1')
+expect_gdb('stopped')
+send_gdb('c')
+expect_gdb('xited normally')
+send_gdb('c')
+
+ok()

--- a/src/test/mmap_fd_reuse_checkpoint.run
+++ b/src/test/mmap_fd_reuse_checkpoint.run
@@ -1,0 +1,3 @@
+source `dirname $0`/util.sh
+record mmap_fd_reuse_checkpoint$bitness
+debug mmap_fd_reuse_checkpoint


### PR DESCRIPTION
As I understand it, this is not only about the fdtable sharing
relationships. Complete FdTables may have gotten lost if two threads
shared address spaces but not an FdTable (which AIUI can happen with
some exotic system calls, or with unshare() maybe?).

That's why I opted into eagerly cloning all fd tables during the fork
process, I don't know how we'd be able to preserve them properly
otherwise.

Fixes #2592