### PR TITLE
Increase timeout on vsyscall_reverse_next

### DIFF
--- a/src/test/vsyscall_reverse_next.run
+++ b/src/test/vsyscall_reverse_next.run
@@ -1,2 +1,3 @@
 source `dirname $0`/util.sh
+TIMEOUT=300
 debug_test


### PR DESCRIPTION
For some reason, the 32-bits no-syscallbuf variant is slow.