### PR TITLE
Always call check_for_bugs

### DIFF
--- a/src/PerfCounters_aarch64.h
+++ b/src/PerfCounters_aarch64.h
@@ -43,7 +43,7 @@ static bool always_recreate_counters() {
   return false;
 }
 
-static void check_for_arch_bugs() {}
+static void check_for_arch_bugs(__attribute__((unused)) CpuMicroarch uarch) {}
 
 template <>
 void PerfCounters::reset_arch_extras<ARM64Arch>() {

--- a/src/PerfCounters_x86.h
+++ b/src/PerfCounters_x86.h
@@ -265,9 +265,11 @@ static void check_for_xen_pmi_bug() {
   }
 }
 
-static void check_for_arch_bugs() {
-  check_for_kvm_in_txcp_bug();
-  check_for_xen_pmi_bug();
+static void check_for_arch_bugs(CpuMicroarch uarch) {
+  if (uarch >= FirstIntel && uarch <= LastIntel) {
+    check_for_kvm_in_txcp_bug();
+    check_for_xen_pmi_bug();
+  }
 }
 
 static bool always_recreate_counters() {


### PR DESCRIPTION
PMU_SKIP_INTEL_BUG_CHECK would previously skip check_for_bugs entirely,
although it'd be desirable to at least run check_working_counters and
probably check_for_ioc_period_bug.

This change removes PMU_SKIP_INTEL_BUG_CHECK entirely, always runs
check_for_bugs, and passes down the CPU microarchitecture down to
check_for_arch_bugs to let it decide on its own which tests to skip
based on the microarchitecture.