### PR TITLE
zen_workaround: skip non numbers in /dev/cpu

### DIFF
--- a/scripts/zen_workaround.py
+++ b/scripts/zen_workaround.py
@@ -18,6 +18,8 @@ if not os.path.exists('/dev/cpu'):
         sys.exit(ret)
 
 for cpu in os.listdir('/dev/cpu'):
+    if not cpu.isdigit():
+        continue
     msr = os.open('/dev/cpu/{}/msr'.format(cpu), os.O_RDONLY)
     os.lseek(msr, MSR, os.SEEK_SET)
     (val,) = struct.unpack('<q', os.read(msr, 8))


### PR DESCRIPTION
Fixes #2674