### PR TITLE
zen_workaround: check for /dev/cpu/0/msr

### DIFF
--- a/scripts/zen_workaround.py
+++ b/scripts/zen_workaround.py
@@ -12,7 +12,7 @@ MSR = 0xc0011020
 # Disable SpecLockMap
 BIT = 1 << 54
 
-if not os.path.exists('/dev/cpu'):
+if not os.path.exists('/dev/cpu/0/msr'):
     ret = os.system('modprobe msr')
     if ret:
         sys.exit(ret)


### PR DESCRIPTION
/dev/cpu may exist without the msr module being loaded, so test for
/dev/cpu/0/msr instead.

Fixes #2673