### PR TITLE
Avoid some useless refcount churn when passing new tg/fds.

### DIFF
--- a/src/RecordTask.cc
+++ b/src/RecordTask.cc
@@ -293,7 +293,8 @@ Task* RecordTask::clone(CloneReason reason, int flags, remote_ptr<void> stack,
                         Session* other_session, FdTable::shr_ptr new_fds,
                         ThreadGroup::shr_ptr new_tg) {
   ASSERT(this, reason == Task::TRACEE_CLONE);
-  ASSERT(this, new_tg == nullptr);
+  ASSERT(this, !new_fds);
+  ASSERT(this, !new_tg);
   Task* t = Task::clone(reason, flags, stack, tls, cleartid_addr, new_tid,
                         new_rec_tid, new_serial, other_session, new_fds,
                         new_tg);

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -2415,7 +2415,7 @@ Task* Task::os_clone_into(const CapturedState& state,
                   (CLONE_VM | CLONE_FS | CLONE_SIGHAND |
                    CLONE_SYSVSEM),
                   fdtable_entry->second,
-                  new_tg,
+                  move(new_tg),
                   state.top_of_stack);
 }
 
@@ -3059,7 +3059,8 @@ static long perform_remote_clone(AutoRemoteSyscalls& remote,
 
   Task* child = remote.task()->clone(
       reason, clone_flags_to_task_flags(base_flags), stack, tls, ctid,
-      remote.new_tid(), rec_child_tid, new_serial, session, new_fds, new_tg);
+      remote.new_tid(), rec_child_tid, new_serial, session, move(new_fds),
+      move(new_tg));
   return child;
 }
 


### PR DESCRIPTION
This is a minor cleanup that I thought was worth doing.

This also adds an assertion that should've been added in
685ffeae62ed588cc7eec36f1a61c9456d50d8b8.