### PR TITLE
Avoid extra ptrace call when registers aren't actually dirty

### DIFF
--- a/src/Registers.cc
+++ b/src/Registers.cc
@@ -659,32 +659,6 @@ void Registers::set_from_trace(SupportedArch a, const void* data,
   memcpy(&u.arm64regs, data, sizeof(u.arm64regs));
 }
 
-uintptr_t Registers::flags() const {
-  switch (arch()) {
-    case x86:
-      return u.x86regs.eflags;
-    case x86_64:
-      return u.x64regs.eflags;
-    default:
-      DEBUG_ASSERT(0 && "Unknown arch");
-      return false;
-  }
-}
-
-void Registers::set_flags(uintptr_t value) {
-  switch (arch()) {
-    case x86:
-      u.x86regs.eflags = value;
-      break;
-    case x86_64:
-      u.x64regs.eflags = value;
-      break;
-    default:
-      DEBUG_ASSERT(0 && "Unknown arch");
-      break;
-  }
-}
-
 bool Registers::aarch64_singlestep_flag() {
   switch (arch()) {
     case aarch64:
@@ -720,7 +694,8 @@ void Registers::clear_x86_singlestep_flag() {
   switch (arch()) {
     case x86:
     case x86_64:
-      return set_flags(flags() & ~X86_TF_FLAG);
+      set_flags(flags() & ~X86_TF_FLAG);
+      return;
     default:
       DEBUG_ASSERT(0 && "X86 only code path");
       break;

--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1457,8 +1457,11 @@ void Task::set_regs(const Registers& regs) {
   if (registers.original_syscallno() != regs.original_syscallno()) {
     orig_syscallno_dirty = true;
   }
-  registers = regs;
-  registers_dirty = true;
+  bool changed = registers != regs;
+  if (changed) {
+    registers_dirty = true;
+    registers = regs;
+  }
 }
 
 void Task::flush_regs() {
@@ -1908,10 +1911,10 @@ void Task::canonicalize_regs(SupportedArch syscall_arch) {
       // which, though possible, does not appear to actually be done by any
       // real application (contrary to int $0x80, which is accessible from 64bit
       // mode as well).
-      registers.set_r8(0x0);
-      registers.set_r9(0x0);
-      registers.set_r10(0x0);
-      registers.set_r11(0x0);
+      registers_dirty |= registers.set_r8(0x0);
+      registers_dirty |= registers.set_r9(0x0);
+      registers_dirty |= registers.set_r10(0x0);
+      registers_dirty |= registers.set_r11(0x0);
     } else {
       // x86-64 'syscall' instruction copies RFLAGS to R11 on syscall entry.
       // If we single-stepped into the syscall instruction, the TF flag will be
@@ -1926,7 +1929,7 @@ void Task::canonicalize_regs(SupportedArch syscall_arch) {
       // Ubuntu/Debian kernels.
       // Making this match the flags makes this operation idempotent, which is
       // helpful.
-      registers.set_r11(0x246);
+      registers_dirty |= registers.set_r11(0x246);
       // x86-64 'syscall' instruction copies return address to RCX on syscall
       // entry. rr-related kernel activity normally sets RCX to -1 at some point
       // during syscall execution, but apparently in some (unknown) situations
@@ -1937,7 +1940,7 @@ void Task::canonicalize_regs(SupportedArch syscall_arch) {
       // want to clobber that.
       // For untraced syscalls, the untraced-syscall entry point code (see
       // write_rr_page) does this itself.
-      registers.set_cx((intptr_t)-1);
+      registers_dirty |= registers.set_cx((intptr_t)-1);
     }
     // On kernel 3.13.0-68-generic #111-Ubuntu SMP we have observed a failed
     // execve() clearing all flags during recording. During replay we emulate
@@ -1945,7 +1948,7 @@ void Task::canonicalize_regs(SupportedArch syscall_arch) {
     // consistent.
     // 0x246 is ZF+PF+IF+reserved, the result clearing a register using
     // "xor reg, reg".
-    registers.set_flags(0x246);
+    registers_dirty |= registers.set_flags(0x246);
   } else if (registers.arch() == x86) {
     // The x86 SYSENTER handling in Linux modifies EBP and EFLAGS on entry.
     // EBP is the potential sixth syscall parameter, stored on the user stack.
@@ -1954,10 +1957,8 @@ void Task::canonicalize_regs(SupportedArch syscall_arch) {
     // In a VMWare guest, the modifications to EFLAGS appear to be
     // nondeterministic. Cover that up by setting EFLAGS to reasonable values
     // now.
-    registers.set_flags(0x246);
+    registers_dirty |= registers.set_flags(0x246);
   }
-
-  registers_dirty = true;
 }
 
 bool Task::read_aarch64_tls_register(uintptr_t *result) {


### PR DESCRIPTION
We were unconditionally setting the registers_dirty flag,
often resulting in unnecessary additional ptrace system calls
(e.g. we'd try to set the eflags on every syscall event, but
if the flags weren't touched that's usually a no-op). Track
whether modification actually happened and if so avoid marking
the registers as dirty, saving a system call. This is a backport
from our deployed branch of rr. I don't have the exact perf numbers
anymore, but I remember it being around a 15% end-to-end perf
improvement on one of our benchmarks.