### PR TITLE
Switch to linux spelling for NT_* regsets

### DIFF
--- a/src/Task.cc
+++ b/src/Task.cc
@@ -1,9 +1,9 @@
 /* -*- Mode: C++; tab-width: 8; c-basic-offset: 2; indent-tabs-mode: nil; -*- */
 
-#include <elf.h>
 #include <errno.h>
 #include <limits.h>
 #include <linux/capability.h>
+#include <linux/elf.h>
 #include <linux/ipc.h>
 #include <linux/net.h>
 #include <linux/perf_event.h>
@@ -686,7 +686,7 @@ void Task::on_syscall_exit_arch(int syscallno, const Registers& regs) {
               tracee->set_regs(r);
               break;
             }
-            case NT_FPREGSET: {
+            case NT_PRFPREG: {
               auto set = ptrace_get_regs_set<Arch>(
                   this, regs, user_fpregs_struct_size(tracee->arch()));
               ExtraRegisters r = tracee->extra_regs();
@@ -1063,7 +1063,7 @@ const ExtraRegisters* Task::extra_regs_fallible() {
     extra_registers.data_.resize(sizeof(ARM64Arch::user_fpregs_struct));
     struct iovec vec = { extra_registers.data_.data(),
                           extra_registers.data_.size() };
-    if (fallible_ptrace(PTRACE_GETREGSET, NT_FPREGSET, &vec)) {
+    if (fallible_ptrace(PTRACE_GETREGSET, NT_PRFPREG, &vec)) {
       return nullptr;
     }
     extra_registers.data_.resize(vec.iov_len);
@@ -1531,7 +1531,7 @@ void Task::set_extra_regs(const ExtraRegisters& regs) {
     case ExtraRegisters::NT_FPR: {
       struct iovec vec = { extra_registers.data_.data(),
                             extra_registers.data_.size() };
-      ptrace_if_alive(PTRACE_SETREGSET, NT_FPREGSET, &vec);
+      ptrace_if_alive(PTRACE_SETREGSET, NT_PRFPREG, &vec);
       break;
     }
     default:

--- a/src/record_syscall.cc
+++ b/src/record_syscall.cc
@@ -2,11 +2,12 @@
 
 #include <arpa/inet.h>
 #include <dirent.h>
-#include <elf.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <linux/auxvec.h>
 #include <linux/capability.h>
+#include <linux/elf.h>
 #include <linux/ethtool.h>
 #include <linux/fs.h>
 #include <linux/futex.h>
@@ -2600,7 +2601,7 @@ static Switchable prepare_ptrace(RecordTask* t,
           }
           break;
         }
-        case NT_FPREGSET: {
+        case NT_PRFPREG: {
           RecordTask* tracee = verify_ptrace_target(t, syscall_state, pid);
           if (tracee) {
             auto regs =
@@ -2681,7 +2682,7 @@ static Switchable prepare_ptrace(RecordTask* t,
           }
           break;
         }
-        case NT_FPREGSET: {
+        case NT_PRFPREG: {
           RecordTask* tracee = verify_ptrace_target(t, syscall_state, pid);
           if (tracee) {
             ptrace_verify_set_reg_set<Arch>(


### PR DESCRIPTION
Rather than the libc-specific spelling. This should have better
compatibility across libcs, as well as dealing with situations
where the kernel headers are recent, but the libc is not (which
is the case for our build environment). The opposite case (new
libc, old kernel headers), is significantly more rare, since the
glibc build generally pulls in the newest kernel headers and ships
them. I haven't yet seen such a configuration in practice. Also,
since we're emulating the Linux ABI, not the libc ABI, we using
the Linux spelling is probably correct in a technical sense (though
of course in practice, the values are identical).