### PR TITLE
Turn on LTO for release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if(LOWERCASE_CMAKE_BUILD_TYPE STREQUAL "debug")
   set(RR_FLAGS "${RR_FLAGS_DEBUG} -g3 -Werror")
 elseif(LOWERCASE_CMAKE_BUILD_TYPE STREQUAL "release")
   # CMake itself will add optimization flags
-  set(RR_FLAGS "${RR_FLAGS_RELEASE} -g3")
+  set(RR_FLAGS "${RR_FLAGS_RELEASE} -g3 -flto")
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")


### PR DESCRIPTION
This adds a fair amount of link time (about a minute), but also
improves runtime performance by about 3%. Most users will be
running rr in debug mode anyway, since that's default,
but if you need performance (as we do in our deployed version of rr),
the extra link time is a low price to pay.