### PR TITLE
Fix bugs when passing long filenames to open_memory_file()

### DIFF
--- a/src/EmuFs.cc
+++ b/src/EmuFs.cc
@@ -77,7 +77,10 @@ std::string make_temp_name(const string& orig_path, dev_t orig_device,
   stringstream name;
   name << "rr-emufs-" << getpid() << "-dev-" << orig_device
        << "-inode-" << orig_inode << "-" << orig_path;
-  return name.str().substr(0, 255);
+  // The linux man page for memfd_create says the length limit for the name
+  // argument is 249 bytes, evidently because it prepends "memfd:" to the
+  // parameter before using it.
+  return name.str().substr(0, 249);
 }
 
 /*static*/ EmuFile::shr_ptr EmuFile::create(EmuFs& owner,

--- a/src/util.cc
+++ b/src/util.cc
@@ -1551,14 +1551,14 @@ static void replace_char(string& s, char c, char replacement) {
 static ScopedFd create_tmpfs_file(const string &real_name) {
   std::string name = real_name;
   replace_char(name, '/', '\\');
-  name = tmp_dir() + real_name;
+  name = string(tmp_dir()) + '/' + name;
   name = name.substr(0, 255);
 
   ScopedFd fd =
       open(name.c_str(), O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0700);
   /* Remove the fs name so that we don't have to worry about
    * cleaning up this segment in error conditions. */
-  unlink(real_name.c_str());
+  unlink(name.c_str());
   return fd;
 }
 


### PR DESCRIPTION
I encountered a couple bugs when using rr on a deeply nested (i.e. long pathname) target. The failure I encountered was EmuFile::create() fatally exiting with the message "Failed to create shmem segment for _my long pathname_".

These changes fixed my issue, but I'm unsure how they could be effectively unit tested.
