### PR TITLE
Help modern cmake versions deal with empty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -599,9 +599,9 @@ else()
   target_link_libraries(rr ${CAPNP_LDFLAGS})
 endif()
 
-set_target_properties(rr PROPERTIES LINK_FLAGS ${RR_MAIN_LINKER_FLAGS})
+set_target_properties(rr PROPERTIES LINK_FLAGS "${RR_MAIN_LINKER_FLAGS}")
 if(RR_BUILD_SHARED)
-  set_target_properties(rrbin PROPERTIES LINK_FLAGS ${RR_MAIN_LINKER_FLAGS})
+  set_target_properties(rrbin PROPERTIES LINK_FLAGS "${RR_MAIN_LINKER_FLAGS}")
 endif()
 
 target_link_libraries(rrpreload


### PR DESCRIPTION
Without this PR/patch, my OOB experience with `rr` is as follows:

```bash
cmake ../ -G Ninja -DCMAKE_BUILD_TYPE=Release
-- The C compiler identification is Clang 10.0.0
-- The CXX compiler identification is Clang 10.0.0
-- The ASM compiler identification is Clang
-- Found assembler: /usr/bin/clang
-- Check for working C compiler: /usr/bin/clang
-- Check for working C compiler: /usr/bin/clang -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/clang++
-- Check for working CXX compiler: /usr/bin/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test SUPPORTS_CXX14
-- Performing Test SUPPORTS_CXX14 - Success
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.1") 
-- Checking for module 'capnp'
--   Found capnp, version 0.7.0
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.8.5", minimum required is "3") 
CMake Error at CMakeLists.txt:602 (set_target_properties):
  set_target_properties called with incorrect number of arguments.


```

After this patch, cmake finishes running with no issues and the build works.

The culprit seems to be the handling of newer cmake with a call like:
```cmake
set_target_properties(rr PROPERTIES LINK_FLAGS ${RR_MAIN_LINKER_FLAGS})
```

when `RR_MAIN_LINKER_FLAGS` is empty.